### PR TITLE
Add runtime reference validator and build-safe logger; update scripts to use validation

### DIFF
--- a/Assets/Scripts/Core.meta
+++ b/Assets/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0961c4ddcb9d4c8989053390218dd17b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/BuildSafeLogger.cs
+++ b/Assets/Scripts/Core/BuildSafeLogger.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class BuildSafeLogger
+{
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    private static readonly HashSet<string> warnedKeys = new HashSet<string>();
+#endif
+
+    public static void WarnOnce(string key, string message, Object context)
+    {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        if (warnedKeys.Add(string.IsNullOrEmpty(key) ? message : key))
+        {
+            Debug.LogWarning(message, context);
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Core/BuildSafeLogger.cs.meta
+++ b/Assets/Scripts/Core/BuildSafeLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01ee41f3cc6c4f359ad70b27a79db2b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/RuntimeReferenceValidator.cs
+++ b/Assets/Scripts/Core/RuntimeReferenceValidator.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+public static class RuntimeReferenceValidator
+{
+    public static bool Require(Object value, MonoBehaviour owner, string fieldName)
+    {
+        if (value != null)
+        {
+            return true;
+        }
+
+        string ownerName = owner != null ? owner.GetType().Name : "<null owner>";
+        BuildSafeLogger.WarnOnce(
+            $"{ownerName}.{fieldName}",
+            $"Missing required reference '{fieldName}' on {ownerName}.",
+            owner);
+
+        if (owner != null)
+        {
+            owner.enabled = false;
+        }
+
+        return false;
+    }
+}

--- a/Assets/Scripts/Core/RuntimeReferenceValidator.cs.meta
+++ b/Assets/Scripts/Core/RuntimeReferenceValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da047cfaaeb34d6f82a8505de3f71bb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -772,8 +772,66 @@ public class Behaviour : MonoBehaviour
         GoldBrick.SetActive(false);
         Physics.IgnoreLayerCollision(gameObject.layer, 7, false);
     }
+    bool ValidateStartReferences()
+    {
+        Player = GetComponent<Rigidbody>();
+
+        var gmObject = GameObject.FindGameObjectWithTag("GM");
+        if (!RuntimeReferenceValidator.Require(gmObject, this, "GM tag"))
+        {
+            return false;
+        }
+
+        GM = gmObject.GetComponent<GameMaster>();
+
+        bool valid = RuntimeReferenceValidator.Require(Player, this, nameof(Player)) &
+            RuntimeReferenceValidator.Require(Load, this, nameof(Load)) &
+            RuntimeReferenceValidator.Require(Root, this, nameof(Root)) &
+            RuntimeReferenceValidator.Require(Otter, this, nameof(Otter)) &
+            RuntimeReferenceValidator.Require(otterAction, this, nameof(otterAction)) &
+            RuntimeReferenceValidator.Require(arrowModel, this, nameof(arrowModel)) &
+            RuntimeReferenceValidator.Require(HealthBar, this, nameof(HealthBar)) &
+            RuntimeReferenceValidator.Require(HoneyJar, this, nameof(HoneyJar)) &
+            RuntimeReferenceValidator.Require(GoldBrick, this, nameof(GoldBrick)) &
+            RuntimeReferenceValidator.Require(PopUpEffect, this, nameof(PopUpEffect)) &
+            RuntimeReferenceValidator.Require(HealEffect, this, nameof(HealEffect)) &
+            RuntimeReferenceValidator.Require(ElectricEffect, this, nameof(ElectricEffect)) &
+            RuntimeReferenceValidator.Require(MunitionDisplay, this, nameof(MunitionDisplay)) &
+            RuntimeReferenceValidator.Require(LooseScreen, this, nameof(LooseScreen)) &
+            RuntimeReferenceValidator.Require(GM, this, nameof(GM)) &
+            RuntimeReferenceValidator.Require(AimIcon, this, nameof(AimIcon)) &
+            RuntimeReferenceValidator.Require(FreeLook, this, nameof(FreeLook)) &
+            RuntimeReferenceValidator.Require(CamForTraders, this, nameof(CamForTraders)) &
+            RuntimeReferenceValidator.Require(HologramedBridge, this, nameof(HologramedBridge)) &
+            RuntimeReferenceValidator.Require(appleOBJ, this, nameof(appleOBJ)) &
+            RuntimeReferenceValidator.Require(gobletOBJ, this, nameof(gobletOBJ));
+
+        if (ArmorSet != null)
+        {
+            for (int i = 0; i < ArmorSet.Length; i++)
+            {
+                valid &= RuntimeReferenceValidator.Require(ArmorSet[i], this, $"{nameof(ArmorSet)}[{i}]");
+            }
+        }
+
+        if (Bow != null)
+        {
+            for (int i = 0; i < Bow.Length; i++)
+            {
+                valid &= RuntimeReferenceValidator.Require(Bow[i], this, $"{nameof(Bow)}[{i}]");
+            }
+        }
+
+        return valid;
+    }
+
     public void Start()
     {
+        if (!ValidateStartReferences())
+        {
+            return;
+        }
+
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
         CamForTraders.enabled = false;
@@ -781,12 +839,21 @@ public class Behaviour : MonoBehaviour
         HideCursor();
         AimIcon.SetActive(false);
         MunitionDisplay.SetActive(false);
-        Player = GetComponent<Rigidbody>();
-        GM = GameObject.FindGameObjectWithTag("GM").GetComponent<GameMaster>();
         //Enable/Disable Background music
         if (seekMusic == true)
         {
-            Music = GameObject.Find("GameMusic").GetComponent<MusicPlaylist>();
+            var musicObject = GameObject.Find("GameMusic");
+            if (!RuntimeReferenceValidator.Require(musicObject, this, "GameMusic"))
+            {
+                return;
+            }
+
+            Music = musicObject.GetComponent<MusicPlaylist>();
+            if (!RuntimeReferenceValidator.Require(Music, this, nameof(Music)))
+            {
+                return;
+            }
+
             Music.transform.parent = Player.transform;
             Music.transform.position = new Vector3(0, 0, 0);
             var MusicSwitches = GameObject.FindGameObjectsWithTag("SwitchMusic");

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -20,8 +20,29 @@ public class DebugReference : MonoBehaviour
     public TextMeshProUGUI ArrowMunition;
     private void Start()
     {
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
-        PlayerObjective = GameObject.FindGameObjectWithTag("Player").GetComponent<ObjectiveUI>();
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        if (!RuntimeReferenceValidator.Require(playerObject, this, "Player tag"))
+        {
+            return;
+        }
+
+        Player = playerObject.GetComponent<Behaviour>();
+        PlayerObjective = playerObject.GetComponent<ObjectiveUI>();
+        if (!RuntimeReferenceValidator.Require(Player, this, nameof(Player)) ||
+            !RuntimeReferenceValidator.Require(PlayerObjective, this, nameof(PlayerObjective)) ||
+            !RuntimeReferenceValidator.Require(ObjectiveText, this, nameof(ObjectiveText)) ||
+            !RuntimeReferenceValidator.Require(DisplayText, this, nameof(DisplayText)) ||
+            !RuntimeReferenceValidator.Require(StaminaText, this, nameof(StaminaText)) ||
+            !RuntimeReferenceValidator.Require(LogCountText, this, nameof(LogCountText)) ||
+            !RuntimeReferenceValidator.Require(HealingDisplay, this, nameof(HealingDisplay)) ||
+            !RuntimeReferenceValidator.Require(CurrencyCount, this, nameof(CurrencyCount)) ||
+            !RuntimeReferenceValidator.Require(SeedCount, this, nameof(SeedCount)) ||
+            !RuntimeReferenceValidator.Require(GobletCount, this, nameof(GobletCount)) ||
+            !RuntimeReferenceValidator.Require(AppleCount, this, nameof(AppleCount)) ||
+            !RuntimeReferenceValidator.Require(ArrowMunition, this, nameof(ArrowMunition)))
+        {
+            return;
+        }
     }
 
     void Update()

--- a/Assets/Scripts/UI/Dialogue.cs
+++ b/Assets/Scripts/UI/Dialogue.cs
@@ -19,10 +19,33 @@ public class Dialogue : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        if (!RuntimeReferenceValidator.Require(playerObject, this, "Player tag"))
+        {
+            return;
+        }
+
+        Player = playerObject.GetComponent<Behaviour>();
         //Boss = GameObject.FindGameObjectWithTag("Boss").GetComponent<BossScript>();
-        PlayerObjective = GameObject.FindGameObjectWithTag("Player").GetComponent<ObjectiveUI>();
-        panel = gameObject.transform.parent.GetComponent<Transform>();
+        PlayerObjective = playerObject.GetComponent<ObjectiveUI>();
+        panel = transform.parent;
+
+        bool valid = RuntimeReferenceValidator.Require(Player, this, nameof(Player)) &
+            RuntimeReferenceValidator.Require(PlayerObjective, this, nameof(PlayerObjective)) &
+            RuntimeReferenceValidator.Require(panel, this, nameof(panel)) &
+            RuntimeReferenceValidator.Require(textComponent, this, nameof(textComponent)) &
+            RuntimeReferenceValidator.Require(SkipButton, this, nameof(SkipButton));
+
+        if (!isBoss)
+        {
+            valid &= RuntimeReferenceValidator.Require(Merchant, this, nameof(Merchant));
+        }
+
+        if (!valid)
+        {
+            return;
+        }
+
         SkipButton.SetActive(true);
         textComponent.text = string.Empty;
         StartDialogue();

--- a/Assets/Scripts/UI/Shop.cs
+++ b/Assets/Scripts/UI/Shop.cs
@@ -8,7 +8,14 @@ public class Shop : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        if (!RuntimeReferenceValidator.Require(playerObject, this, "Player tag"))
+        {
+            return;
+        }
+
+        Player = playerObject.GetComponent<Behaviour>();
+        RuntimeReferenceValidator.Require(Player, this, nameof(Player));
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -16,10 +16,33 @@ public class UIMenu : MonoBehaviour
     // Start is called before the first frame update
     private void Start()
     {
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        if (!RuntimeReferenceValidator.Require(playerObject, this, "Player tag"))
+        {
+            return;
+        }
+
+        Player = playerObject.GetComponent<Behaviour>();
+        if (!RuntimeReferenceValidator.Require(Player, this, nameof(Player)) ||
+            !RuntimeReferenceValidator.Require(PauseMenu, this, nameof(PauseMenu)) ||
+            !RuntimeReferenceValidator.Require(Question, this, nameof(Question)))
+        {
+            return;
+        }
+
         if (Player.seekMusic==true)
         {
-            Music = GameObject.FindGameObjectWithTag("Music").GetComponent<AudioSource>();
+            var musicObject = GameObject.FindGameObjectWithTag("Music");
+            if (!RuntimeReferenceValidator.Require(musicObject, this, "Music tag"))
+            {
+                return;
+            }
+
+            Music = musicObject.GetComponent<AudioSource>();
+            if (!RuntimeReferenceValidator.Require(Music, this, nameof(Music)))
+            {
+                return;
+            }
         }
         Player.HideCursor();
         PauseMenu.SetActive(false);


### PR DESCRIPTION
### Motivation
- Prevent noisy repeated warnings and catch missing Unity references at runtime by centralizing reference checks and failing fast when required objects are absent.
- Make game components more robust by disabling misconfigured `MonoBehaviour` instances and logging a single warning per missing reference to ease debugging in Editor/Dev builds.

### Description
- Add `BuildSafeLogger` with `WarnOnce(string key, string message, Object context)` that logs warnings only in `UNITY_EDITOR` or `DEVELOPMENT_BUILD` and deduplicates by key.
- Add `RuntimeReferenceValidator` with `Require(Object value, MonoBehaviour owner, string fieldName)` which logs a single warning via `BuildSafeLogger`, disables the `owner` when a required reference is missing, and returns the validation result.
- Introduce `ValidateStartReferences()` in `Behaviour` and refactor `Start()` to use `RuntimeReferenceValidator.Require` for many serialized references and dynamically found objects, and add defensive checks around `GameMusic` setup.
- Update UI scripts `DebugReference`, `Dialogue`, `Shop`, and `UIMenu` to obtain the `Player` object via `GameObject.FindGameObjectWithTag(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdea3badc832a82b095d6e3fc198f)