### PR TITLE
Add GameFlowController and CursorStateService; centralize timeScale and cursor control

### DIFF
--- a/Assets/Scripts/Core/CursorStateService.cs
+++ b/Assets/Scripts/Core/CursorStateService.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+
+[DefaultExecutionOrder(-1000)]
+public class CursorStateService : MonoBehaviour
+{
+    public static CursorStateService Instance { get; private set; }
+
+    public static CursorStateService GetOrCreate()
+    {
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        Instance = FindObjectOfType<CursorStateService>();
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        var gameObject = new GameObject(nameof(CursorStateService));
+        return gameObject.AddComponent<CursorStateService>();
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+    }
+
+    public void ShowCursor()
+    {
+        Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
+    }
+
+    public void HideCursor()
+    {
+        Cursor.lockState = CursorLockMode.Locked;
+        Cursor.visible = false;
+    }
+}

--- a/Assets/Scripts/Core/CursorStateService.cs.meta
+++ b/Assets/Scripts/Core/CursorStateService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ceed2cbf5f3d470f81d4370ba7bdfa0a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameFlowController.cs
+++ b/Assets/Scripts/Core/GameFlowController.cs
@@ -1,0 +1,69 @@
+using UnityEngine;
+
+[DefaultExecutionOrder(-1000)]
+public class GameFlowController : MonoBehaviour
+{
+    public static GameFlowController Instance { get; private set; }
+
+    public GameFlowState State { get; private set; } = GameFlowState.Boot;
+
+    public static GameFlowController GetOrCreate()
+    {
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        Instance = FindObjectOfType<GameFlowController>();
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        var gameObject = new GameObject(nameof(GameFlowController));
+        return gameObject.AddComponent<GameFlowController>();
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+    }
+
+    public void SetPlaying()
+    {
+        State = GameFlowState.Playing;
+        Time.timeScale = 1f;
+    }
+
+    public void SetPaused(bool paused)
+    {
+        State = paused ? GameFlowState.Paused : GameFlowState.Playing;
+        Time.timeScale = paused ? 0f : 1f;
+    }
+
+    public void SetGameOver()
+    {
+        State = GameFlowState.GameOver;
+        Time.timeScale = 0f;
+    }
+
+    public void BeginSceneTransition()
+    {
+        State = GameFlowState.Transitioning;
+        Time.timeScale = 1f;
+    }
+}

--- a/Assets/Scripts/Core/GameFlowController.cs.meta
+++ b/Assets/Scripts/Core/GameFlowController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9df28112db774dffa98adda7788af9e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameFlowState.cs
+++ b/Assets/Scripts/Core/GameFlowState.cs
@@ -1,0 +1,11 @@
+public enum GameFlowState
+{
+    Boot,
+    MainMenu,
+    Playing,
+    Paused,
+    GameOver,
+    Transitioning,
+    Dialogue,
+    Shop
+}

--- a/Assets/Scripts/Core/GameFlowState.cs.meta
+++ b/Assets/Scripts/Core/GameFlowState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2343b3307d73446480b33d56f3f7f885
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -657,27 +657,25 @@ public class Behaviour : MonoBehaviour
     public void ShowCursor()
     {
         //show mouse icon
-        Cursor.lockState = CursorLockMode.None;
-        Cursor.visible = true;
+        CursorStateService.GetOrCreate().ShowCursor();
     }
     public void HideCursor()
     {
         //Lock and hide mouse icon
         FreeLook.m_LookAt = Root;
-        Cursor.lockState = CursorLockMode.Locked;
-        Cursor.visible = false;
+        CursorStateService.GetOrCreate().HideCursor();
     }
     public void ActivateLooseMenu()
     {
         //MusicOP.StopMusic();
-        Time.timeScale = 0;
+        GameFlowController.GetOrCreate().SetGameOver();
         ShowCursor();
         LooseScreen.SetActive(true);
     }
     public void HideLooseMenu()
     {
         //MusicOP.ResumeMusic();
-        Time.timeScale = 1;
+        GameFlowController.GetOrCreate().SetPlaying();
         HideCursor();
         LooseScreen.SetActive(false);
     }
@@ -691,6 +689,7 @@ public class Behaviour : MonoBehaviour
     }
     public void RestartGame()
     {
+        GameFlowController.GetOrCreate().BeginSceneTransition();
         SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
     }
     public void GobletON()

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -10,6 +10,7 @@ public class UIMenu : MonoBehaviour
     public GameObject Question;
     public Behaviour Player;
     public bool ActivePause = false;
+    GameFlowController gameFlow;
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
 
@@ -22,6 +23,8 @@ public class UIMenu : MonoBehaviour
             return;
         }
 
+        gameFlow = GameFlowController.GetOrCreate();
+        gameFlow.SetPlaying();
         Player = playerObject.GetComponent<Behaviour>();
         if (!RuntimeReferenceValidator.Require(Player, this, nameof(Player)) ||
             !RuntimeReferenceValidator.Require(PauseMenu, this, nameof(PauseMenu)) ||
@@ -58,7 +61,6 @@ public class UIMenu : MonoBehaviour
         if (ActivePause == true)
         {
             PauseMenu.SetActive(true);
-            Time.timeScale = 0;
             Player.ShowCursor();
         }
 
@@ -66,7 +68,6 @@ public class UIMenu : MonoBehaviour
         if (ActivePause == false)
         {
             PauseMenu.SetActive(false);
-            Time.timeScale = 1f;
             Question.SetActive(false);
             if (Player.isAtTrader == false)
                 Player.HideCursor();
@@ -76,6 +77,11 @@ public class UIMenu : MonoBehaviour
     public void ChangeBolean()
     {
         ActivePause = !ActivePause;
+        if (gameFlow == null)
+        {
+            gameFlow = GameFlowController.GetOrCreate();
+        }
+        gameFlow.SetPaused(ActivePause);
     }
 
     public void RestartCheckpointFromMenu()
@@ -90,6 +96,7 @@ public class UIMenu : MonoBehaviour
 
     public void MainMenu()
     {
+        GameFlowController.GetOrCreate().BeginSceneTransition();
         SceneManager.LoadScene("Menu");
     }
     public void Volume()


### PR DESCRIPTION
### Motivation
- Centralize game flow state and ensure a single writer for `Time.timeScale` to avoid conflicting pause/transition logic.
- Centralize cursor lock/visibility so only one service updates `Cursor.lockState`/`Cursor.visible`.
- Ensure scene transitions always restore `Time.timeScale = 1` to avoid stuck slow/paused scenes.

### Description
- Added `Assets/Scripts/Core/GameFlowState.cs` with enum values `Boot`, `MainMenu`, `Playing`, `Paused`, `GameOver`, `Transitioning`, `Dialogue`, `Shop`.
- Added scene-local `Assets/Scripts/Core/GameFlowController.cs` with `GetOrCreate()` and public API `SetPlaying()`, `SetPaused(bool)`, `SetGameOver()`, and `BeginSceneTransition()` where `BeginSceneTransition()` sets `Time.timeScale = 1f`.
- Added `Assets/Scripts/Core/CursorStateService.cs` with `GetOrCreate()`, `ShowCursor()` and `HideCursor()` as the single writers of `Cursor.lockState` and `Cursor.visible`.
- Replaced direct `Time.timeScale` and `Cursor.*` writes in `Assets/Scripts/UI/UIMenu.cs` and `Assets/Scripts/Player/Behaviour.cs` to call the new services while preserving existing UI panel activation logic.

### Testing
- Ran `git diff --check` which returned clean results.
- Ran `rg -n "Time\.timeScale|Cursor\.(lockState|visible)" Assets/Scripts -S` and verified the only remaining writers in `Assets/Scripts` are the new `GameFlowController` and `CursorStateService` implementations.
- Unity editor/runtime not available in this environment, so no PlayMode or runtime integration tests were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce0efba4c832ab256689cf91eac3b)