### PR TITLE
Add centralized scene transition service

### DIFF
--- a/Assets/Scripts/Core/SceneNames.cs
+++ b/Assets/Scripts/Core/SceneNames.cs
@@ -1,0 +1,5 @@
+public static class SceneNames
+{
+    public const string Menu = "Menu";
+    public const string Level1 = "Level 1";
+}

--- a/Assets/Scripts/Core/SceneNames.cs.meta
+++ b/Assets/Scripts/Core/SceneNames.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f7f0aae92ca4d69b91980dd8377720f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/SceneTransitionService.cs
+++ b/Assets/Scripts/Core/SceneTransitionService.cs
@@ -1,0 +1,143 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+[DefaultExecutionOrder(-1000)]
+public class SceneTransitionService : MonoBehaviour
+{
+    public static SceneTransitionService Instance { get; private set; }
+
+    internal bool isLoading;
+
+    public static SceneTransitionService GetOrCreate()
+    {
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        Instance = FindObjectOfType<SceneTransitionService>();
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        var gameObject = new GameObject(nameof(SceneTransitionService));
+        return gameObject.AddComponent<SceneTransitionService>();
+    }
+
+    public static void LoadMenu()
+    {
+        GetOrCreate().LoadSceneInternal(SceneNames.Menu, true);
+    }
+
+    public static void LoadLevel1()
+    {
+        GetOrCreate().LoadSceneInternal(SceneNames.Level1, false);
+    }
+
+    public static void ReloadActiveScene()
+    {
+        var activeScene = SceneManager.GetActiveScene();
+        GetOrCreate().LoadSceneInternal(activeScene.name, activeScene.name == SceneNames.Menu);
+    }
+
+    public static void LoadScene(string sceneName)
+    {
+        GetOrCreate().LoadSceneInternal(sceneName, sceneName == SceneNames.Menu);
+    }
+
+    public static AsyncOperation LoadSceneAsync(string sceneName)
+    {
+        return GetOrCreate().LoadSceneAsyncInternal(sceneName, sceneName == SceneNames.Menu);
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        isLoading = false;
+    }
+
+    private void LoadSceneInternal(string sceneName, bool showCursor)
+    {
+        if (!PrepareLoad(showCursor))
+        {
+            return;
+        }
+
+        SceneManager.LoadScene(sceneName);
+    }
+
+    private AsyncOperation LoadSceneAsyncInternal(string sceneName, bool showCursor)
+    {
+        if (!PrepareLoad(showCursor))
+        {
+            return null;
+        }
+
+        return SceneManager.LoadSceneAsync(sceneName);
+    }
+
+    private bool PrepareLoad(bool showCursor)
+    {
+        if (isLoading)
+        {
+            return false;
+        }
+
+        isLoading = true;
+        GameFlowController.GetOrCreate().BeginSceneTransition();
+        Time.timeScale = 1f;
+
+        if (showCursor)
+        {
+            CursorStateService.GetOrCreate().ShowCursor();
+        }
+
+        DisablePlayerInput();
+        return true;
+    }
+
+    private void DisablePlayerInput()
+    {
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        if (playerObject == null)
+        {
+            return;
+        }
+
+        var player = playerObject.GetComponent<Behaviour>();
+        if (player != null)
+        {
+            player.enabled = false;
+        }
+    }
+}

--- a/Assets/Scripts/Core/SceneTransitionService.cs.meta
+++ b/Assets/Scripts/Core/SceneTransitionService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87e0fd8a3f054550817a833f8ea655b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Cinemachine;
 using Cinemachine.Utility;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class Behaviour : MonoBehaviour
 {
@@ -689,8 +688,7 @@ public class Behaviour : MonoBehaviour
     }
     public void RestartGame()
     {
-        GameFlowController.GetOrCreate().BeginSceneTransition();
-        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+        SceneTransitionService.ReloadActiveScene();
     }
     public void GobletON()
     {

--- a/Assets/Scripts/SceneScripts/LoadingScreenController.cs
+++ b/Assets/Scripts/SceneScripts/LoadingScreenController.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using UnityEngine.UI;
-using UnityEngine.SceneManagement;
 
 public class LoadingScreenController : MonoBehaviour
 {
@@ -32,7 +31,11 @@ public class LoadingScreenController : MonoBehaviour
     System.Collections.IEnumerator LoadSceneAsync(string sceneName)
     {
         // Create an operation to load the scene asynchronously
-        AsyncOperation operation = SceneManager.LoadSceneAsync(sceneName);
+        AsyncOperation operation = SceneTransitionService.LoadSceneAsync(sceneName);
+        if (operation == null)
+        {
+            yield break;
+        }
 
         // Reset the fill amount to zero at the start of loading
         if (loadingBar != null)

--- a/Assets/Scripts/SceneScripts/MainMenu.cs
+++ b/Assets/Scripts/SceneScripts/MainMenu.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class MainMenu : MonoBehaviour
 {
@@ -18,7 +17,7 @@ public class MainMenu : MonoBehaviour
     //}
     public void PlayGame()
     {
-        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex +1);
+        SceneTransitionService.LoadLevel1();
     }
     public void QuitGame()
     {

--- a/Assets/Scripts/SceneScripts/RestartGameLooseMenu.cs
+++ b/Assets/Scripts/SceneScripts/RestartGameLooseMenu.cs
@@ -1,12 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class RestartGameLooseMenu : MonoBehaviour
 {
     public void ResetartGame()
     {
-        SceneManager.LoadScene("Level 1");
+        SceneTransitionService.LoadLevel1();
     }
 }

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
-using UnityEngine.SceneManagement;
 
 public class UIMenu : MonoBehaviour
 {
@@ -96,8 +95,7 @@ public class UIMenu : MonoBehaviour
 
     public void MainMenu()
     {
-        GameFlowController.GetOrCreate().BeginSceneTransition();
-        SceneManager.LoadScene("Menu");
+        SceneTransitionService.LoadMenu();
     }
     public void Volume()
     {


### PR DESCRIPTION
### Motivation
- Consolidate scene load logic and enforce a single transition flow with consistent pre-load steps and guards.
- Expose named scene constants to avoid string duplication for existing scenes `Menu` and `Level 1`.

### Description
- Add `Assets/Scripts/Core/SceneNames.cs` with `public const string Menu = "Menu";` and `public const string Level1 = "Level 1"`.
- Add `Assets/Scripts/Core/SceneTransitionService.cs` implementing `LoadMenu()`, `LoadLevel1()`, `ReloadActiveScene()`, `LoadScene()` and `LoadSceneAsync()` with an internal `bool isLoading` guard and `PrepareLoad()` that sets game state to `Transitioning`, restores `Time.timeScale = 1f`, shows/unlocks cursor for menu loads, and disables player input.
- Update call sites to use the service instead of direct `SceneManager` calls in `Assets/Scripts/SceneScripts/MainMenu.cs`, `Assets/Scripts/SceneScripts/RestartGameLooseMenu.cs`, `Assets/Scripts/UI/UIMenu.cs`, `Assets/Scripts/Player/Behaviour.cs`, and `Assets/Scripts/SceneScripts/LoadingScreenController.cs` (sync and async paths).
- Preserve existing scene names and build settings; service uses existing names via `SceneNames` constants.

### Testing
- Ran `git diff --check` which produced no whitespace errors and completed successfully.
- Ran `rg` to locate `SceneManager.LoadScene` / `LoadSceneAsync` usages in the targeted files and verified they were replaced with `SceneTransitionService` calls.
- Attempted to detect a Unity editor binary in the environment (`command -v Unity`), none was available so runtime/editor integration tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce46b914c832abaa02e0c9afaa90d)