### PR TITLE
Extract player state and checkpoint services

### DIFF
--- a/Assets/Scripts/Core/CheckpointService.cs
+++ b/Assets/Scripts/Core/CheckpointService.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+
+[DefaultExecutionOrder(-1000)]
+public sealed class CheckpointService : MonoBehaviour
+{
+    public static CheckpointService Instance { get; private set; }
+
+    public Vector3 LastCheckpointPosition { get; private set; }
+
+    public static CheckpointService GetOrCreate()
+    {
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        Instance = FindObjectOfType<CheckpointService>();
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        var gameObject = new GameObject(nameof(CheckpointService));
+        return gameObject.AddComponent<CheckpointService>();
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+    }
+
+    public void SaveCheckpoint(Vector3 position)
+    {
+        LastCheckpointPosition = position;
+    }
+
+    public Vector3 RespawnPosition(Vector3 offset)
+    {
+        return LastCheckpointPosition + offset;
+    }
+}

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -42,10 +42,23 @@ public class Behaviour : MonoBehaviour
     [Header("Health")]
     float StopHurt = 0;
     [SerializeField] Rigidbody rb;
-    public float MaxHealth = 1000;
-    public float CurrentHealth;
-    public float MaxStamina = 100;
-    public float CurrentStamina;
+    [SerializeField] PlayerState state = new PlayerState();
+    public PlayerState State
+    {
+        get
+        {
+            if (state == null)
+            {
+                state = new PlayerState();
+            }
+
+            return state;
+        }
+    }
+    public float MaxHealth { get => State.maxHealth; set => State.maxHealth = value; }
+    public float CurrentHealth { get => State.currentHealth; set => State.currentHealth = value; }
+    public float MaxStamina { get => State.maxStamina; set => State.maxStamina = value; }
+    public float CurrentStamina { get => State.currentStamina; set => State.currentStamina = value; }
     readonly float StaminaClockInitial = 0.5f;
     float StaminaClock;
     public Health_Bar_Script HealthBar;
@@ -55,7 +68,7 @@ public class Behaviour : MonoBehaviour
     public bool Rolling;
     double HealthPercent;
     double StaminaPercent;
-    public int Lives;
+    public int Lives { get => State.lives; set => State.lives = value; }
     public GameObject ICON_1;
     public GameObject ICON_2;
     public GameObject ICON_3;
@@ -148,13 +161,12 @@ public class Behaviour : MonoBehaviour
     public string StaminaText;
     public string HealingText;
     public string AppleText;
-    public int GobletPickup = 0;
-    public int Apple;
-    public int Currency = 0;
-    public int NutCount;
+    public int GobletPickup { get => State.gobletPickup; set => State.gobletPickup = value; }
+    public int Apple { get => State.apple; set => State.apple = value; }
+    public int Currency { get => State.currency; set => State.currency = value; }
+    public int NutCount { get => State.nutCount; set => State.nutCount = value; }
     public string SeedText;
     public string Wallet;
-    public GameMaster GM;
     public GameObject AimIcon;
     public CinemachineFreeLook FreeLook;
     public CinemachineFreeLook CamForTraders;
@@ -327,7 +339,7 @@ public class Behaviour : MonoBehaviour
         {
             if (Lives > 0)
             {
-                transform.position = GM.lastCheckPointPos + new Vector3(1, 1, 1);
+                transform.position = CheckpointService.GetOrCreate().RespawnPosition(new Vector3(1, 1, 1));
                 Instantiate(PopUpEffect, transform.position, Quaternion.identity);
                 Lives--;
             }
@@ -419,7 +431,7 @@ public class Behaviour : MonoBehaviour
         }
         if (OBJ.gameObject.CompareTag("Life"))
         {
-            GM.lastCheckPointPos = OBJ.transform.position;
+            SaveCheckpoint(OBJ.transform.position);
             Plattering = ("Shroom!");
             ChangeSpeech = 1;
             if (CurrentHealth < MaxHealth)
@@ -682,10 +694,16 @@ public class Behaviour : MonoBehaviour
     {
         HealthBar.SetHealth(MaxHealth);
         CurrentHealth = MaxHealth;
-        transform.position = GM.lastCheckPointPos;
+        transform.position = CheckpointService.GetOrCreate().LastCheckpointPosition;
         Instantiate(PopUpEffect, transform.position, Quaternion.identity);
         Lives--;
     }
+    void SaveCheckpoint(Vector3 position)
+    {
+        State.checkpointPosition = position;
+        CheckpointService.GetOrCreate().SaveCheckpoint(position);
+    }
+
     public void RestartGame()
     {
         SceneTransitionService.ReloadActiveScene();
@@ -773,14 +791,6 @@ public class Behaviour : MonoBehaviour
     {
         Player = GetComponent<Rigidbody>();
 
-        var gmObject = GameObject.FindGameObjectWithTag("GM");
-        if (!RuntimeReferenceValidator.Require(gmObject, this, "GM tag"))
-        {
-            return false;
-        }
-
-        GM = gmObject.GetComponent<GameMaster>();
-
         bool valid = RuntimeReferenceValidator.Require(Player, this, nameof(Player)) &
             RuntimeReferenceValidator.Require(Load, this, nameof(Load)) &
             RuntimeReferenceValidator.Require(Root, this, nameof(Root)) &
@@ -795,7 +805,6 @@ public class Behaviour : MonoBehaviour
             RuntimeReferenceValidator.Require(ElectricEffect, this, nameof(ElectricEffect)) &
             RuntimeReferenceValidator.Require(MunitionDisplay, this, nameof(MunitionDisplay)) &
             RuntimeReferenceValidator.Require(LooseScreen, this, nameof(LooseScreen)) &
-            RuntimeReferenceValidator.Require(GM, this, nameof(GM)) &
             RuntimeReferenceValidator.Require(AimIcon, this, nameof(AimIcon)) &
             RuntimeReferenceValidator.Require(FreeLook, this, nameof(FreeLook)) &
             RuntimeReferenceValidator.Require(CamForTraders, this, nameof(CamForTraders)) &
@@ -834,6 +843,7 @@ public class Behaviour : MonoBehaviour
         CamForTraders.enabled = false;
         Instantiate(PopUpEffect, Root.position, Quaternion.identity);
         HideCursor();
+        SaveCheckpoint(transform.position);
         AimIcon.SetActive(false);
         MunitionDisplay.SetActive(false);
         //Enable/Disable Background music

--- a/Assets/Scripts/Player/PlayerState.cs
+++ b/Assets/Scripts/Player/PlayerState.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+[System.Serializable]
+public sealed class PlayerState
+{
+    [Header("Vitals")]
+    public float maxHealth = 1000f;
+    public float currentHealth;
+    public float maxStamina = 100f;
+    public float currentStamina;
+    public int lives;
+
+    [Header("Checkpoint")]
+    public Vector3 checkpointPosition;
+
+    [Header("Inventory")]
+    public int currency;
+    public int nutCount;
+    public int apple;
+    public int gobletPickup;
+}

--- a/Assets/Scripts/SceneScripts/GameMaster.cs
+++ b/Assets/Scripts/SceneScripts/GameMaster.cs
@@ -1,11 +1,9 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class GameMaster : MonoBehaviour
 {
     private static GameMaster instance;
-    public Vector3 lastCheckPointPos;
+
     private void Awake()
     {
         if (instance == null)

--- a/Assets/Scripts/UI/HudPresenter.cs
+++ b/Assets/Scripts/UI/HudPresenter.cs
@@ -1,0 +1,60 @@
+using TMPro;
+using UnityEngine;
+
+public sealed class HudPresenter : MonoBehaviour
+{
+    public Behaviour Player;
+    public ObjectiveUI PlayerObjective;
+
+    public TextMeshProUGUI ObjectiveText;
+    public TextMeshProUGUI DisplayText;
+    public TextMeshProUGUI StaminaText;
+    public TextMeshProUGUI LogCountText;
+    public TextMeshProUGUI HealingDisplay;
+    public TextMeshProUGUI CurrencyCount;
+    public TextMeshProUGUI SeedCount;
+    public TextMeshProUGUI GobletCount;
+    public TextMeshProUGUI AppleCount;
+    public TextMeshProUGUI ArrowMunition;
+
+    private void Start()
+    {
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        if (!RuntimeReferenceValidator.Require(playerObject, this, "Player tag"))
+        {
+            return;
+        }
+
+        Player = playerObject.GetComponent<Behaviour>();
+        PlayerObjective = playerObject.GetComponent<ObjectiveUI>();
+        if (!RuntimeReferenceValidator.Require(Player, this, nameof(Player)) ||
+            !RuntimeReferenceValidator.Require(PlayerObjective, this, nameof(PlayerObjective)) ||
+            !RuntimeReferenceValidator.Require(ObjectiveText, this, nameof(ObjectiveText)) ||
+            !RuntimeReferenceValidator.Require(DisplayText, this, nameof(DisplayText)) ||
+            !RuntimeReferenceValidator.Require(StaminaText, this, nameof(StaminaText)) ||
+            !RuntimeReferenceValidator.Require(LogCountText, this, nameof(LogCountText)) ||
+            !RuntimeReferenceValidator.Require(HealingDisplay, this, nameof(HealingDisplay)) ||
+            !RuntimeReferenceValidator.Require(CurrencyCount, this, nameof(CurrencyCount)) ||
+            !RuntimeReferenceValidator.Require(SeedCount, this, nameof(SeedCount)) ||
+            !RuntimeReferenceValidator.Require(GobletCount, this, nameof(GobletCount)) ||
+            !RuntimeReferenceValidator.Require(AppleCount, this, nameof(AppleCount)) ||
+            !RuntimeReferenceValidator.Require(ArrowMunition, this, nameof(ArrowMunition)))
+        {
+            return;
+        }
+    }
+
+    private void Update()
+    {
+        ObjectiveText.text = PlayerObjective.Instruction;
+        DisplayText.text = Player.DebugText;
+        StaminaText.text = Player.StaminaText;
+        LogCountText.text = Player.LogCount;
+        CurrencyCount.text = Player.Wallet;
+        HealingDisplay.text = Player.HealingText;
+        SeedCount.text = Player.SeedText;
+        GobletCount.text = Player.GobletText;
+        AppleCount.text = Player.AppleText;
+        ArrowMunition.text = Player.ArrowText;
+    }
+}


### PR DESCRIPTION
### Motivation
- Isolate pure player state (health, stamina, lives, checkpoint position, inventory) from `Behaviour` so state can be evolved/tested independently.
- Preserve `Behaviour` as the gameplay component and provide adapter properties so existing callers remain source-compatible.
- Centralize checkpoint persistence/respawn into a dedicated service to remove scene-tied fields and simplify checkpoint logic.

### Description
- Added `Assets/Scripts/Player/PlayerState.cs` to hold vitals, checkpoint position, and inventory counts as a serializable POCO (`PlayerState`).
- Added `Assets/Scripts/Core/CheckpointService.cs` singleton exposing `SaveCheckpoint`, `LastCheckpointPosition`, and `RespawnPosition` for checkpoint management.
- Added `Assets/Scripts/UI/HudPresenter.cs` as a HUD binder using the existing `Behaviour` properties (mirrors previous UI wiring).
- Modified `Assets/Scripts/Player/Behaviour.cs` to embed a `PlayerState` instance and expose adapter properties (`MaxHealth`, `CurrentHealth`, `MaxStamina`, `CurrentStamina`, `Lives`, `Currency`, `NutCount`, `Apple`, `GobletPickup`), moved checkpoint save/restore to `CheckpointService` and added `SaveCheckpoint` helper, and removed reliance on `GameMaster.lastCheckPointPos`.
- Simplified `Assets/Scripts/SceneScripts/GameMaster.cs` by removing the `lastCheckPointPos` field.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it completed with no errors.
- Changes were committed (commit message: "Extract player state and checkpoint services").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce5a55874832a9852fa8d98c86857)