### PR TITLE
Add centralized game input reader

### DIFF
--- a/Assets/Scripts/Input.meta
+++ b/Assets/Scripts/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b6229edc9c74d2f8309c0f6b93d962b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Input/GameInputReader.cs
+++ b/Assets/Scripts/Input/GameInputReader.cs
@@ -1,0 +1,156 @@
+using System;
+using UnityEngine;
+
+[DefaultExecutionOrder(-1100)]
+public class GameInputReader : MonoBehaviour
+{
+    public static GameInputReader Instance { get; private set; }
+
+    public InputMode Mode { get; private set; } = InputMode.Gameplay;
+    public bool IsGameplayInputEnabled { get { return Mode == InputMode.Gameplay; } }
+    public bool IsUiInputEnabled { get { return Mode == InputMode.Ui; } }
+
+    public bool PausePressed { get; private set; }
+    public bool PrimaryHeld { get; private set; }
+    public bool PrimaryPressed { get; private set; }
+    public bool PrimaryReleased { get; private set; }
+    public bool SecondaryHeld { get; private set; }
+    public bool SecondaryPressed { get; private set; }
+    public bool SecondaryReleased { get; private set; }
+    public bool InteractPressed { get; private set; }
+    public Vector2 MovementVector { get; private set; }
+    public Vector2 ScrollDelta { get; private set; }
+
+    public event Action PausePressedEvent;
+    public event Action PrimaryPressedEvent;
+    public event Action PrimaryReleasedEvent;
+    public event Action SecondaryPressedEvent;
+    public event Action SecondaryReleasedEvent;
+    public event Action InteractPressedEvent;
+
+    public static GameInputReader GetOrCreate()
+    {
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        Instance = FindObjectOfType<GameInputReader>();
+        if (Instance != null)
+        {
+            return Instance;
+        }
+
+        var gameObject = new GameObject(nameof(GameInputReader));
+        return gameObject.AddComponent<GameInputReader>();
+    }
+
+    public void EnableGameplayInput()
+    {
+        Mode = InputMode.Gameplay;
+    }
+
+    public void DisableGameplayInput()
+    {
+        Mode = InputMode.Disabled;
+        ClearGameplayInput();
+    }
+
+    public void EnableUiInput()
+    {
+        Mode = InputMode.Ui;
+        ClearGameplayInput();
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+    }
+
+    private void Update()
+    {
+        PollLegacyInput();
+        DispatchEvents();
+    }
+
+    private void PollLegacyInput()
+    {
+        PausePressed = Mode != InputMode.Disabled && UnityEngine.Input.GetKeyDown(KeyCode.Escape);
+
+        if (Mode != InputMode.Gameplay)
+        {
+            ClearGameplayInput();
+            return;
+        }
+
+        PrimaryHeld = UnityEngine.Input.GetKey(KeyCode.Mouse0);
+        PrimaryPressed = UnityEngine.Input.GetKeyDown(KeyCode.Mouse0);
+        PrimaryReleased = UnityEngine.Input.GetKeyUp(KeyCode.Mouse0);
+        SecondaryHeld = UnityEngine.Input.GetKey(KeyCode.Mouse1);
+        SecondaryPressed = UnityEngine.Input.GetKeyDown(KeyCode.Mouse1);
+        SecondaryReleased = UnityEngine.Input.GetKeyUp(KeyCode.Mouse1);
+        InteractPressed = UnityEngine.Input.GetKeyDown(KeyCode.F);
+        MovementVector = new Vector2(UnityEngine.Input.GetAxisRaw("Horizontal"), UnityEngine.Input.GetAxisRaw("Vertical"));
+        ScrollDelta = UnityEngine.Input.mouseScrollDelta;
+    }
+
+    private void ClearGameplayInput()
+    {
+        PrimaryHeld = false;
+        PrimaryPressed = false;
+        PrimaryReleased = false;
+        SecondaryHeld = false;
+        SecondaryPressed = false;
+        SecondaryReleased = false;
+        InteractPressed = false;
+        MovementVector = Vector2.zero;
+        ScrollDelta = Vector2.zero;
+    }
+
+    private void DispatchEvents()
+    {
+        if (PausePressed && PausePressedEvent != null)
+        {
+            PausePressedEvent();
+        }
+
+        if (PrimaryPressed && PrimaryPressedEvent != null)
+        {
+            PrimaryPressedEvent();
+        }
+
+        if (PrimaryReleased && PrimaryReleasedEvent != null)
+        {
+            PrimaryReleasedEvent();
+        }
+
+        if (SecondaryPressed && SecondaryPressedEvent != null)
+        {
+            SecondaryPressedEvent();
+        }
+
+        if (SecondaryReleased && SecondaryReleasedEvent != null)
+        {
+            SecondaryReleasedEvent();
+        }
+
+        if (InteractPressed && InteractPressedEvent != null)
+        {
+            InteractPressedEvent();
+        }
+    }
+}

--- a/Assets/Scripts/Input/GameInputReader.cs.meta
+++ b/Assets/Scripts/Input/GameInputReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b95fb80eea43429e8636de54a40675ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Input/InputMode.cs
+++ b/Assets/Scripts/Input/InputMode.cs
@@ -1,0 +1,6 @@
+public enum InputMode
+{
+    Disabled,
+    Gameplay,
+    Ui
+}

--- a/Assets/Scripts/Input/InputMode.cs.meta
+++ b/Assets/Scripts/Input/InputMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f0d68fd11a14290a5c3f8ee832a4c9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -171,6 +171,7 @@ public class Behaviour : MonoBehaviour
     public CinemachineFreeLook FreeLook;
     public CinemachineFreeLook CamForTraders;
     public float ChangeSpeech = 1F;
+    GameInputReader inputReader;
 
     public void OnCollisionEnter(Collision OBJ)
     {
@@ -449,6 +450,7 @@ public class Behaviour : MonoBehaviour
             {
                 ShowCursor();
                 isAtTrader = true;
+                GetInputReader().EnableUiInput();
                 FreeLook.enabled = false;
                 CamForTraders.enabled = true;
                 CamForTraders.m_LookAt = OBJ.transform;
@@ -456,6 +458,7 @@ public class Behaviour : MonoBehaviour
             if (skip ==true)
             {
                 isAtTrader = false;
+                GetInputReader().EnableGameplayInput();
                 CamForTraders.enabled = false;
                 CamForTraders.m_LookAt = null;
                 FreeLook.enabled = true;
@@ -493,6 +496,7 @@ public class Behaviour : MonoBehaviour
         if (OBJ.gameObject.CompareTag("Trader"))
         {
             isAtTrader = false;
+            GetInputReader().EnableGameplayInput();
             CamForTraders.enabled = false;
             CamForTraders.m_LookAt = null;
             FreeLook.enabled = true;
@@ -669,12 +673,18 @@ public class Behaviour : MonoBehaviour
     {
         //show mouse icon
         CursorStateService.GetOrCreate().ShowCursor();
+        GetInputReader().EnableUiInput();
     }
     public void HideCursor()
     {
         //Lock and hide mouse icon
         FreeLook.m_LookAt = Root;
         CursorStateService.GetOrCreate().HideCursor();
+        var gameFlow = GameFlowController.Instance;
+        if (gameFlow == null || gameFlow.State == GameFlowState.Playing)
+        {
+            GetInputReader().EnableGameplayInput();
+        }
     }
     public void ActivateLooseMenu()
     {
@@ -682,12 +692,14 @@ public class Behaviour : MonoBehaviour
         GameFlowController.GetOrCreate().SetGameOver();
         ShowCursor();
         LooseScreen.SetActive(true);
+        GetInputReader().DisableGameplayInput();
     }
     public void HideLooseMenu()
     {
         //MusicOP.ResumeMusic();
         GameFlowController.GetOrCreate().SetPlaying();
         HideCursor();
+        GetInputReader().EnableGameplayInput();
         LooseScreen.SetActive(false);
     }
     public void RestartCheckpoint()
@@ -787,6 +799,39 @@ public class Behaviour : MonoBehaviour
         GoldBrick.SetActive(false);
         Physics.IgnoreLayerCollision(gameObject.layer, 7, false);
     }
+    GameInputReader GetInputReader()
+    {
+        if (inputReader == null)
+        {
+            inputReader = GameInputReader.GetOrCreate();
+        }
+
+        return inputReader;
+    }
+
+    bool IsGameplayInputBlocked()
+    {
+        var reader = GetInputReader();
+        return reader != null && !reader.IsGameplayInputEnabled;
+    }
+
+    void HandleDeathState()
+    {
+        if (CurrentHealth > 0)
+        {
+            return;
+        }
+
+        if (Lives > 0)
+        {
+            RestartCheckpoint();
+        }
+        if (Lives == 0)
+        {
+            ActivateLooseMenu();
+        }
+    }
+
     bool ValidateStartReferences()
     {
         Player = GetComponent<Rigidbody>();
@@ -838,6 +883,8 @@ public class Behaviour : MonoBehaviour
             return;
         }
 
+        inputReader = GameInputReader.GetOrCreate();
+        inputReader.EnableGameplayInput();
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
         CamForTraders.enabled = false;
@@ -914,6 +961,12 @@ public class Behaviour : MonoBehaviour
     [System.Obsolete]
     public void Update()
     {
+        HandleDeathState();
+        if (IsGameplayInputBlocked())
+        {
+            return;
+        }
+
         //Parry animations
         if (Defend == true)
         {
@@ -1037,17 +1090,7 @@ public class Behaviour : MonoBehaviour
                 JumpNum = JumpNumPreserve;
         }
         //Load Loose screen on death
-        if (CurrentHealth <= 0)
-        {
-            if (Lives > 0)
-            {
-                RestartCheckpoint();
-            }
-            if (Lives == 0)
-            {
-                ActivateLooseMenu();
-            }
-        }
+        HandleDeathState();
         //Limit Stamina decrease down to 0 only
         if (CurrentStamina <= 0)
         {
@@ -1416,6 +1459,11 @@ public class Behaviour : MonoBehaviour
     [Obsolete]
     public void LateUpdate()
     {
+        if (IsGameplayInputBlocked())
+        {
+            return;
+        }
+
         if (Input.GetKey(KeyCode.Mouse1))
         {
             RotateForward();
@@ -1433,6 +1481,11 @@ public class Behaviour : MonoBehaviour
     [System.Obsolete]
     public void FixedUpdate()
     {
+        if (IsGameplayInputBlocked())
+        {
+            return;
+        }
+
         //Camera vectors setup
         Vector3 cameraRelativeForward = Camera.main.transform.TransformDirection(Vector3.forward);
         Vector3 cameraRelativeBack = Camera.main.transform.TransformDirection(Vector3.back);

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -10,6 +10,7 @@ public class UIMenu : MonoBehaviour
     public Behaviour Player;
     public bool ActivePause = false;
     GameFlowController gameFlow;
+    GameInputReader inputReader;
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
 
@@ -23,6 +24,8 @@ public class UIMenu : MonoBehaviour
         }
 
         gameFlow = GameFlowController.GetOrCreate();
+        inputReader = GameInputReader.GetOrCreate();
+        inputReader.EnableGameplayInput();
         gameFlow.SetPlaying();
         Player = playerObject.GetComponent<Behaviour>();
         if (!RuntimeReferenceValidator.Require(Player, this, nameof(Player)) ||
@@ -52,7 +55,7 @@ public class UIMenu : MonoBehaviour
     }
     public void Pause()
     {
-        if (Input.GetKeyDown(KeyCode.Escape))
+        if (inputReader != null && inputReader.PausePressed)
         {
             ChangeBolean();
         }
@@ -81,6 +84,22 @@ public class UIMenu : MonoBehaviour
             gameFlow = GameFlowController.GetOrCreate();
         }
         gameFlow.SetPaused(ActivePause);
+        if (inputReader == null)
+        {
+            inputReader = GameInputReader.GetOrCreate();
+        }
+        if (ActivePause)
+        {
+            inputReader.EnableUiInput();
+        }
+        else if (Player != null && Player.isAtTrader)
+        {
+            inputReader.EnableUiInput();
+        }
+        else
+        {
+            inputReader.EnableGameplayInput();
+        }
     }
 
     public void RestartCheckpointFromMenu()


### PR DESCRIPTION
### Motivation
- Centralize legacy `UnityEngine.Input` polling to provide frame-safe cached input for gameplay and UI code paths.
- Provide a minimal migration path so pause/UI/death gating can be enforced immediately while movement/combat migration remains incremental.
- Expose events and properties so other systems can subscribe or poll without touching `Input` directly.

### Description
- Added `Assets/Scripts/Input/GameInputReader.cs` (singleton) which keeps legacy `UnityEngine.Input` internally, polls once in `Update()`, caches values, and exposes frame-safe properties and events for `PausePressed`, `PrimaryHeld`, `PrimaryPressed`, `PrimaryReleased`, `SecondaryHeld`, `SecondaryPressed`, `SecondaryReleased`, `InteractPressed`, `MovementVector`, and `ScrollDelta`.
- Added `Assets/Scripts/Input/InputMode.cs` enum with `Disabled`, `Gameplay`, and `Ui` modes, plus `EnableGameplayInput()`, `DisableGameplayInput()`, and `EnableUiInput()` methods on the reader to switch input gating.
- Updated `Assets/Scripts/UI/UIMenu.cs` to use `GameInputReader.PausePressed` instead of polling `Input.GetKeyDown(KeyCode.Escape)` and to toggle input mode when pausing/unpausing (keeps UI mode when at trader UI).
- Updated `Assets/Scripts/Player/Behaviour.cs` to use `GameInputReader` for UI/trader show/hide cursor flows, to disable gameplay input during pause/game-over, and to run an incremental gating strategy (pause/death/UI first; movement/combat left using legacy polling until migrated).

### Testing
- Ran `git diff --check` and it returned no whitespace/merge errors (passed).
- Ran a brace-balance Python check on changed C# files which completed successfully (passed).
- Verified `UIMenu` no longer polls `Input.GetKeyDown(KeyCode.Escape)` via a targeted `rg` check (passed).
- Attempted to run Unity headless validation (`unity-editor -batchmode`) but the editor binary was not available in this environment (unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce7146968832a80a04fc3ec80d86f)