### PR TITLE
Add runtime service lifetimes and type-keyed service registry

### DIFF
--- a/Assets/Scripts/Core/CheckpointService.cs
+++ b/Assets/Scripts/Core/CheckpointService.cs
@@ -9,19 +9,7 @@ public sealed class CheckpointService : MonoBehaviour
 
     public static CheckpointService GetOrCreate()
     {
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        Instance = FindObjectOfType<CheckpointService>();
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        var gameObject = new GameObject(nameof(CheckpointService));
-        return gameObject.AddComponent<CheckpointService>();
+        return RuntimeServices.GetOrCreate<CheckpointService>(ServiceLifetime.Scene);
     }
 
     private void Awake()
@@ -32,8 +20,12 @@ public sealed class CheckpointService : MonoBehaviour
             return;
         }
 
+        if (!RuntimeServices.Register(this, ServiceLifetime.Scene))
+        {
+            return;
+        }
+
         Instance = this;
-        DontDestroyOnLoad(gameObject);
     }
 
     private void OnDestroy()
@@ -41,6 +33,7 @@ public sealed class CheckpointService : MonoBehaviour
         if (Instance == this)
         {
             Instance = null;
+            RuntimeServices.Unregister(this);
         }
     }
 

--- a/Assets/Scripts/Core/CursorStateService.cs
+++ b/Assets/Scripts/Core/CursorStateService.cs
@@ -7,19 +7,7 @@ public class CursorStateService : MonoBehaviour
 
     public static CursorStateService GetOrCreate()
     {
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        Instance = FindObjectOfType<CursorStateService>();
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        var gameObject = new GameObject(nameof(CursorStateService));
-        return gameObject.AddComponent<CursorStateService>();
+        return RuntimeServices.GetOrCreate<CursorStateService>(ServiceLifetime.Persistent);
     }
 
     private void Awake()
@@ -27,6 +15,11 @@ public class CursorStateService : MonoBehaviour
         if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
+        }
+
+        if (!RuntimeServices.Register(this, ServiceLifetime.Persistent))
+        {
             return;
         }
 
@@ -38,6 +31,7 @@ public class CursorStateService : MonoBehaviour
         if (Instance == this)
         {
             Instance = null;
+            RuntimeServices.Unregister(this);
         }
     }
 

--- a/Assets/Scripts/Core/GameFlowController.cs
+++ b/Assets/Scripts/Core/GameFlowController.cs
@@ -9,19 +9,7 @@ public class GameFlowController : MonoBehaviour
 
     public static GameFlowController GetOrCreate()
     {
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        Instance = FindObjectOfType<GameFlowController>();
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        var gameObject = new GameObject(nameof(GameFlowController));
-        return gameObject.AddComponent<GameFlowController>();
+        return RuntimeServices.GetOrCreate<GameFlowController>(ServiceLifetime.Scene);
     }
 
     private void Awake()
@@ -29,6 +17,11 @@ public class GameFlowController : MonoBehaviour
         if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
+        }
+
+        if (!RuntimeServices.Register(this, ServiceLifetime.Scene))
+        {
             return;
         }
 
@@ -40,6 +33,7 @@ public class GameFlowController : MonoBehaviour
         if (Instance == this)
         {
             Instance = null;
+            RuntimeServices.Unregister(this);
         }
     }
 

--- a/Assets/Scripts/Core/RuntimeServices.cs
+++ b/Assets/Scripts/Core/RuntimeServices.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class RuntimeServices
+{
+    private sealed class Registration
+    {
+        public UnityEngine.Object Service;
+        public ServiceLifetime Lifetime;
+    }
+
+    private static readonly Dictionary<Type, Registration> Services = new Dictionary<Type, Registration>();
+
+    public static bool TryGet<T>(out T service) where T : UnityEngine.Object
+    {
+        Registration registration;
+        if (Services.TryGetValue(typeof(T), out registration) && registration.Service != null)
+        {
+            service = (T)registration.Service;
+            return true;
+        }
+
+        service = null;
+        return false;
+    }
+
+    public static T GetOrCreate<T>(ServiceLifetime lifetime) where T : Component
+    {
+        T service;
+        if (TryGet(out service))
+        {
+            return service;
+        }
+
+        service = UnityEngine.Object.FindObjectOfType<T>();
+        if (service != null)
+        {
+            Register(service, lifetime);
+            return service;
+        }
+
+        return new GameObject(typeof(T).Name).AddComponent<T>();
+    }
+
+    public static bool Register<T>(T service, ServiceLifetime lifetime) where T : UnityEngine.Object
+    {
+        if (service == null)
+        {
+            return false;
+        }
+
+        var serviceType = typeof(T);
+        Registration existing;
+        if (Services.TryGetValue(serviceType, out existing) && existing.Service != null && existing.Service != service)
+        {
+            var component = service as Component;
+            if (component != null)
+            {
+                UnityEngine.Object.Destroy(component.gameObject);
+            }
+            else
+            {
+                UnityEngine.Object.Destroy(service);
+            }
+
+            return false;
+        }
+
+        Services[serviceType] = new Registration
+        {
+            Service = service,
+            Lifetime = lifetime
+        };
+
+        var serviceComponent = service as Component;
+        if (lifetime == ServiceLifetime.Persistent && serviceComponent != null)
+        {
+            UnityEngine.Object.DontDestroyOnLoad(serviceComponent.gameObject);
+        }
+
+        return true;
+    }
+
+    public static void Unregister<T>(T service) where T : UnityEngine.Object
+    {
+        if (service == null)
+        {
+            return;
+        }
+
+        Registration registration;
+        if (Services.TryGetValue(typeof(T), out registration) && registration.Service == service)
+        {
+            Services.Remove(typeof(T));
+        }
+    }
+
+    public static void ResetSceneServices()
+    {
+        var sceneServiceTypes = new List<Type>();
+
+        foreach (var service in Services)
+        {
+            if (service.Value.Lifetime == ServiceLifetime.Scene)
+            {
+                sceneServiceTypes.Add(service.Key);
+            }
+        }
+
+        foreach (var serviceType in sceneServiceTypes)
+        {
+            var registration = Services[serviceType];
+            Services.Remove(serviceType);
+
+            if (registration.Service == null)
+            {
+                continue;
+            }
+
+            var component = registration.Service as Component;
+            if (component != null)
+            {
+                UnityEngine.Object.Destroy(component.gameObject);
+            }
+            else
+            {
+                UnityEngine.Object.Destroy(registration.Service);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/RuntimeServices.cs.meta
+++ b/Assets/Scripts/Core/RuntimeServices.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a3cc292723b4bf1846da04f9106bfaa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/SceneTransitionService.cs
+++ b/Assets/Scripts/Core/SceneTransitionService.cs
@@ -10,19 +10,7 @@ public class SceneTransitionService : MonoBehaviour
 
     public static SceneTransitionService GetOrCreate()
     {
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        Instance = FindObjectOfType<SceneTransitionService>();
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        var gameObject = new GameObject(nameof(SceneTransitionService));
-        return gameObject.AddComponent<SceneTransitionService>();
+        return RuntimeServices.GetOrCreate<SceneTransitionService>(ServiceLifetime.Persistent);
     }
 
     public static void LoadMenu()
@@ -32,7 +20,7 @@ public class SceneTransitionService : MonoBehaviour
 
     public static void LoadLevel1()
     {
-        GetOrCreate().LoadSceneInternal(SceneNames.Level1, false);
+        GetOrCreate().LoadSceneInternal(SceneNames.Level1, false, true);
     }
 
     public static void ReloadActiveScene()
@@ -59,8 +47,12 @@ public class SceneTransitionService : MonoBehaviour
             return;
         }
 
+        if (!RuntimeServices.Register(this, ServiceLifetime.Persistent))
+        {
+            return;
+        }
+
         Instance = this;
-        DontDestroyOnLoad(gameObject);
     }
 
     private void OnEnable()
@@ -78,6 +70,7 @@ public class SceneTransitionService : MonoBehaviour
         if (Instance == this)
         {
             Instance = null;
+            RuntimeServices.Unregister(this);
         }
     }
 
@@ -88,9 +81,19 @@ public class SceneTransitionService : MonoBehaviour
 
     private void LoadSceneInternal(string sceneName, bool showCursor)
     {
+        LoadSceneInternal(sceneName, showCursor, false);
+    }
+
+    private void LoadSceneInternal(string sceneName, bool showCursor, bool resetSceneServices)
+    {
         if (!PrepareLoad(showCursor))
         {
             return;
+        }
+
+        if (resetSceneServices)
+        {
+            RuntimeServices.ResetSceneServices();
         }
 
         SceneManager.LoadScene(sceneName);

--- a/Assets/Scripts/Core/ServiceLifetime.cs
+++ b/Assets/Scripts/Core/ServiceLifetime.cs
@@ -1,0 +1,8 @@
+public enum ServiceLifetime
+{
+    // Survives scene transitions; use for app-level settings/services.
+    Persistent,
+
+    // Bound to gameplay scenes; use for checkpoint, HUD, and player state.
+    Scene
+}

--- a/Assets/Scripts/Core/ServiceLifetime.cs.meta
+++ b/Assets/Scripts/Core/ServiceLifetime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db76afabc2024917b29aadc0947cd7ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Input/GameInputReader.cs
+++ b/Assets/Scripts/Input/GameInputReader.cs
@@ -30,19 +30,7 @@ public class GameInputReader : MonoBehaviour
 
     public static GameInputReader GetOrCreate()
     {
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        Instance = FindObjectOfType<GameInputReader>();
-        if (Instance != null)
-        {
-            return Instance;
-        }
-
-        var gameObject = new GameObject(nameof(GameInputReader));
-        return gameObject.AddComponent<GameInputReader>();
+        return RuntimeServices.GetOrCreate<GameInputReader>(ServiceLifetime.Scene);
     }
 
     public void EnableGameplayInput()
@@ -70,6 +58,11 @@ public class GameInputReader : MonoBehaviour
             return;
         }
 
+        if (!RuntimeServices.Register(this, ServiceLifetime.Scene))
+        {
+            return;
+        }
+
         Instance = this;
     }
 
@@ -78,6 +71,7 @@ public class GameInputReader : MonoBehaviour
         if (Instance == this)
         {
             Instance = null;
+            RuntimeServices.Unregister(this);
         }
     }
 

--- a/Assets/Scripts/SceneScripts/DoNotDestroy.cs
+++ b/Assets/Scripts/SceneScripts/DoNotDestroy.cs
@@ -1,16 +1,33 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class DoNotDestroy : MonoBehaviour
 {
+    private static readonly System.Collections.Generic.HashSet<System.Type> PersistentTypes =
+        new System.Collections.Generic.HashSet<System.Type>();
+
+    private bool registered;
+
     private void Awake()
     {
-        GameObject[] musicObj = GameObject.FindGameObjectsWithTag("Music");
-        if (musicObj.Length>1)
+        var serviceType = GetType();
+        if (PersistentTypes.Contains(serviceType))
         {
-            Destroy(this.gameObject);
+            Destroy(gameObject);
+            return;
         }
-        DontDestroyOnLoad(this.gameObject);
+
+        PersistentTypes.Add(serviceType);
+        registered = true;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    private void OnDestroy()
+    {
+        if (!registered || !Application.isPlaying)
+        {
+            return;
+        }
+
+        PersistentTypes.Remove(GetType());
     }
 }

--- a/Assets/Scripts/SceneScripts/GameMaster.cs
+++ b/Assets/Scripts/SceneScripts/GameMaster.cs
@@ -2,18 +2,18 @@ using UnityEngine;
 
 public class GameMaster : MonoBehaviour
 {
-    private static GameMaster instance;
-
-    private void Awake()
+    public Vector3 LastCheckpointPosition
     {
-        if (instance == null)
-        {
-            instance = this;
-            DontDestroyOnLoad(instance);
-        }
-        else
-        {
-            Destroy(gameObject);
-        }
+        get { return CheckpointService.GetOrCreate().LastCheckpointPosition; }
+    }
+
+    public void SaveCheckpoint(Vector3 position)
+    {
+        CheckpointService.GetOrCreate().SaveCheckpoint(position);
+    }
+
+    public Vector3 RespawnPosition(Vector3 offset)
+    {
+        return CheckpointService.GetOrCreate().RespawnPosition(offset);
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce a small runtime registry to manage core services by type and lifetime to avoid fragile tag/count-based persistence and accidental duplicates.
- Provide two lifetimes for clear intent: `Persistent` for app-level services and `Scene` for gameplay-scoped services (checkpoint/HUD/player state).
- Ensure starting a new game from the menu resets gameplay-scoped services and keep `GameMaster` as a compatibility wrapper over `CheckpointService`.

### Description
- Add `ServiceLifetime` enum and `RuntimeServices` static registry with type-keyed `Register`, `GetOrCreate`, `TryGet`, `Unregister` and `ResetSceneServices` (applies `DontDestroyOnLoad` for `Persistent`).
- Replace singletons' manual `GetOrCreate` logic and manual `DontDestroyOnLoad` with `RuntimeServices` usage and call `RuntimeServices.Register(this, ServiceLifetime.<...>)` in `Awake` for core services.
- Set lifetimes: `SceneTransitionService` and `CursorStateService` as `Persistent`, and `CheckpointService`, `GameFlowController`, and `GameInputReader` as `Scene` scoped; `RuntimeServices.Register` destroys duplicate instances by service type.
- Invoke `RuntimeServices.ResetSceneServices()` when loading Level 1 from the main menu to tear down scene-lifetime services; refactor `GameMaster` to forward to `CheckpointService`; replace `DoNotDestroy` tag-count logic with a type-based uniqueness guard.

### Testing
- Ran `git diff --check` with no whitespace errors and verified modified files compile-ready for review.
- Attempted to locate Unity/editor and C# compiler in the environment but they were not available so no in-editor or compile-time validation was executed.
- No automated unit tests exist in the repo and none were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fceab7db60832a8d73e349108880b3)