### PR TITLE
Add build-safe once diagnostics

### DIFF
--- a/Assets/Scripts/Core/BuildSafeLogger.cs
+++ b/Assets/Scripts/Core/BuildSafeLogger.cs
@@ -1,19 +1,105 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public static class BuildSafeLogger
 {
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
-    private static readonly HashSet<string> warnedKeys = new HashSet<string>();
+    private static readonly HashSet<string> infoKeys = new HashSet<string>();
+    private static readonly HashSet<string> warnKeys = new HashSet<string>();
+    private static readonly HashSet<string> errorKeys = new HashSet<string>();
 #endif
 
-    public static void WarnOnce(string key, string message, Object context)
+    public static void InfoOnce(string key, string message, Object owner = null, string missingField = null, string missingTag = null, string missingMethod = null)
     {
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
-        if (warnedKeys.Add(string.IsNullOrEmpty(key) ? message : key))
+        if (infoKeys.Add(ResolveKey(key, message, owner, missingField, missingTag, missingMethod)))
         {
-            Debug.LogWarning(message, context);
+            Debug.Log(Format(message, owner, missingField, missingTag, missingMethod), owner);
         }
 #endif
     }
+
+    public static void WarnOnce(string key, string message, Object owner = null, string missingField = null, string missingTag = null, string missingMethod = null)
+    {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        if (warnKeys.Add(ResolveKey(key, message, owner, missingField, missingTag, missingMethod)))
+        {
+            Debug.LogWarning(Format(message, owner, missingField, missingTag, missingMethod), owner);
+        }
+#endif
+    }
+
+    public static void ErrorOnce(string key, string message, Object owner = null, string missingField = null, string missingTag = null, string missingMethod = null)
+    {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        if (errorKeys.Add(ResolveKey(key, message, owner, missingField, missingTag, missingMethod)))
+        {
+            Debug.LogError(Format(message, owner, missingField, missingTag, missingMethod), owner);
+        }
+#endif
+    }
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    private static string ResolveKey(string key, string message, Object owner, string missingField, string missingTag, string missingMethod)
+    {
+        if (!string.IsNullOrEmpty(key))
+        {
+            return key;
+        }
+
+        return SceneManager.GetActiveScene().name + "|" + OwnerName(owner) + "|" + message + "|" + missingField + "|" + missingTag + "|" + missingMethod;
+    }
+
+    private static string Format(string message, Object owner, string missingField, string missingTag, string missingMethod)
+    {
+        var scene = SceneManager.GetActiveScene().name;
+        var formatted = "[" + (string.IsNullOrEmpty(scene) ? "<no scene>" : scene) + "] " + message + " Owner=" + OwnerName(owner);
+
+        if (!string.IsNullOrEmpty(missingField))
+        {
+            formatted += " MissingField=" + missingField;
+        }
+
+        if (!string.IsNullOrEmpty(missingTag))
+        {
+            formatted += " MissingTag=" + missingTag;
+        }
+
+        if (!string.IsNullOrEmpty(missingMethod))
+        {
+            formatted += " MissingMethod=" + missingMethod;
+        }
+
+        return formatted;
+    }
+
+    private static string OwnerName(Object owner)
+    {
+        var component = owner as Component;
+        if (component != null)
+        {
+            return component.GetType().Name + "(" + GameObjectPath(component.transform) + ")";
+        }
+
+        return owner != null ? owner.GetType().Name + "(" + owner.name + ")" : "<null>";
+    }
+
+    private static string GameObjectPath(Transform transform)
+    {
+        if (transform == null)
+        {
+            return "<null>";
+        }
+
+        var path = transform.name;
+        while (transform.parent != null)
+        {
+            transform = transform.parent;
+            path = transform.name + "/" + path;
+        }
+
+        return path;
+    }
+#endif
 }

--- a/Assets/Scripts/Core/CheckpointService.cs
+++ b/Assets/Scripts/Core/CheckpointService.cs
@@ -16,6 +16,11 @@ public sealed class CheckpointService : MonoBehaviour
     {
         if (Instance != null && Instance != this)
         {
+            BuildSafeLogger.WarnOnce(
+                nameof(CheckpointService) + ".DuplicateManager",
+                "Duplicate manager destroyed: " + nameof(CheckpointService) + ".",
+                this,
+                nameof(CheckpointService));
             Destroy(gameObject);
             return;
         }

--- a/Assets/Scripts/Core/CursorStateService.cs
+++ b/Assets/Scripts/Core/CursorStateService.cs
@@ -14,6 +14,11 @@ public class CursorStateService : MonoBehaviour
     {
         if (Instance != null && Instance != this)
         {
+            BuildSafeLogger.WarnOnce(
+                nameof(CursorStateService) + ".DuplicateManager",
+                "Duplicate manager destroyed: " + nameof(CursorStateService) + ".",
+                this,
+                nameof(CursorStateService));
             Destroy(gameObject);
             return;
         }

--- a/Assets/Scripts/Core/GameFlowController.cs
+++ b/Assets/Scripts/Core/GameFlowController.cs
@@ -16,6 +16,11 @@ public class GameFlowController : MonoBehaviour
     {
         if (Instance != null && Instance != this)
         {
+            BuildSafeLogger.WarnOnce(
+                nameof(GameFlowController) + ".DuplicateManager",
+                "Duplicate manager destroyed: " + nameof(GameFlowController) + ".",
+                this,
+                nameof(GameFlowController));
             Destroy(gameObject);
             return;
         }

--- a/Assets/Scripts/Core/RuntimeReferenceValidator.cs
+++ b/Assets/Scripts/Core/RuntimeReferenceValidator.cs
@@ -10,10 +10,15 @@ public static class RuntimeReferenceValidator
         }
 
         string ownerName = owner != null ? owner.GetType().Name : "<null owner>";
+        bool isTag = fieldName != null && fieldName.EndsWith(" tag");
+        string missingTag = isTag ? fieldName.Substring(0, fieldName.Length - 4) : null;
+        string missingField = isTag ? null : fieldName;
         BuildSafeLogger.WarnOnce(
             $"{ownerName}.{fieldName}",
             $"Missing required reference '{fieldName}' on {ownerName}.",
-            owner);
+            owner,
+            missingField,
+            missingTag);
 
         if (owner != null)
         {

--- a/Assets/Scripts/Core/RuntimeServices.cs
+++ b/Assets/Scripts/Core/RuntimeServices.cs
@@ -27,6 +27,7 @@ public static class RuntimeServices
 
     public static T GetOrCreate<T>(ServiceLifetime lifetime) where T : Component
     {
+        var serviceType = typeof(T);
         T service;
         if (TryGet(out service))
         {
@@ -40,7 +41,12 @@ public static class RuntimeServices
             return service;
         }
 
-        return new GameObject(typeof(T).Name).AddComponent<T>();
+        BuildSafeLogger.WarnOnce(
+            serviceType.FullName + ".MissingService",
+            "Missing runtime service; creating fallback " + serviceType.Name + ".",
+            null,
+            serviceType.Name);
+        return new GameObject(serviceType.Name).AddComponent<T>();
     }
 
     public static bool Register<T>(T service, ServiceLifetime lifetime) where T : UnityEngine.Object
@@ -54,6 +60,11 @@ public static class RuntimeServices
         Registration existing;
         if (Services.TryGetValue(serviceType, out existing) && existing.Service != null && existing.Service != service)
         {
+            BuildSafeLogger.WarnOnce(
+                serviceType.FullName + ".DuplicateManager",
+                "Duplicate manager/service rejected: " + serviceType.Name + ".",
+                service as UnityEngine.Object,
+                serviceType.Name);
             var component = service as Component;
             if (component != null)
             {

--- a/Assets/Scripts/Core/SceneTransitionService.cs
+++ b/Assets/Scripts/Core/SceneTransitionService.cs
@@ -43,6 +43,11 @@ public class SceneTransitionService : MonoBehaviour
     {
         if (Instance != null && Instance != this)
         {
+            BuildSafeLogger.WarnOnce(
+                nameof(SceneTransitionService) + ".DuplicateManager",
+                "Duplicate manager destroyed: " + nameof(SceneTransitionService) + ".",
+                this,
+                nameof(SceneTransitionService));
             Destroy(gameObject);
             return;
         }
@@ -113,6 +118,13 @@ public class SceneTransitionService : MonoBehaviour
     {
         if (isLoading)
         {
+            BuildSafeLogger.WarnOnce(
+                nameof(SceneTransitionService) + ".BlockedDuplicateSceneLoad",
+                "Blocked duplicate scene load request.",
+                this,
+                null,
+                null,
+                nameof(PrepareLoad));
             return false;
         }
 
@@ -134,6 +146,13 @@ public class SceneTransitionService : MonoBehaviour
         var playerObject = GameObject.FindGameObjectWithTag("Player");
         if (playerObject == null)
         {
+            BuildSafeLogger.WarnOnce(
+                nameof(SceneTransitionService) + ".MissingPlayer",
+                "Cannot disable player input because Player tag was not found.",
+                this,
+                null,
+                "Player",
+                nameof(DisablePlayerInput));
             return;
         }
 

--- a/Assets/Scripts/SceneScripts/MainMenu.cs
+++ b/Assets/Scripts/SceneScripts/MainMenu.cs
@@ -21,7 +21,7 @@ public class MainMenu : MonoBehaviour
     }
     public void QuitGame()
     {
-        Debug.Log("Quit");
+        BuildSafeLogger.InfoOnce("MainMenu.QuitGame", "Quit requested.", this, null, null, nameof(QuitGame));
         Application.Quit();
     }
 }

--- a/Assets/Scripts/UI/LoseMenuController.cs
+++ b/Assets/Scripts/UI/LoseMenuController.cs
@@ -39,6 +39,13 @@ public sealed class LoseMenuController : MonoBehaviour
         if (LosePanel != null)
         {
             LosePanel.SetActive(active);
+            return;
         }
+
+        BuildSafeLogger.WarnOnce(
+            nameof(LoseMenuController) + ".NullPanel." + nameof(LosePanel),
+            "UI panel is null; cannot set active=" + active + ".",
+            this,
+            nameof(LosePanel));
     }
 }

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -116,22 +116,22 @@ public class PauseMenuController : MonoBehaviour
 
     public void ShowPausePanel()
     {
-        SetPanel(PauseMenu, true);
+        SetPanel(PauseMenu, true, this, nameof(PauseMenu));
     }
 
     public void HidePausePanel()
     {
-        SetPanel(PauseMenu, false);
+        SetPanel(PauseMenu, false, this, nameof(PauseMenu));
     }
 
     public void ShowQuestionPanel()
     {
-        SetPanel(Question, true);
+        SetPanel(Question, true, this, nameof(Question));
     }
 
     public void HideQuestionPanel()
     {
-        SetPanel(Question, false);
+        SetPanel(Question, false, this, nameof(Question));
     }
 
     void SetPaused(bool paused)
@@ -156,11 +156,18 @@ public class PauseMenuController : MonoBehaviour
         inputReader.EnableGameplayInput();
     }
 
-    static void SetPanel(GameObject panel, bool active)
+    static void SetPanel(GameObject panel, bool active, PauseMenuController owner, string fieldName)
     {
         if (panel != null)
         {
             panel.SetActive(active);
+            return;
         }
+
+        BuildSafeLogger.WarnOnce(
+            nameof(PauseMenuController) + ".NullPanel." + fieldName,
+            "UI panel is null; cannot set active=" + active + ".",
+            owner,
+            fieldName);
     }
 }


### PR DESCRIPTION
### Motivation

- Reduce noisy logging in release builds by centralizing once-only diagnostics behind build-only gates. 
- Provide richer diagnostic context (scene, owner component, missing field/tag/method) for runtime issues like missing references and services. 
- Replace direct runtime logs (e.g. `MainMenu.QuitGame`) and add guarded warnings for duplicate managers, blocked scene loads, missing player/service, and null UI panels.

### Description

- Added `Assets/Scripts/Core/BuildSafeLogger.cs` implementing `InfoOnce`, `WarnOnce`, and `ErrorOnce` with `#if UNITY_EDITOR || DEVELOPMENT_BUILD` guards and contextual formatting that includes scene name, owner, and missing field/tag/method. 
- Updated `RuntimeReferenceValidator` to call `BuildSafeLogger.WarnOnce` with `missingField`/`missingTag` context and disable owner when references are missing. 
- Updated `RuntimeServices` to log missing service fallbacks via `WarnOnce` and to log/reject duplicate registrations via `WarnOnce`. 
- Instrumented `SceneTransitionService` to emit warnings for duplicate manager, blocked duplicate scene loads, and missing `Player` tag when disabling input. 
- Added duplicate-manager warnings in `CheckpointService`, `GameFlowController`, and `CursorStateService`. 
- Replaced direct `Debug.Log` in `MainMenu.QuitGame()` with `BuildSafeLogger.InfoOnce`. 
- Added null-panel diagnostics and adjusted `SetPanel` usage in `PauseMenuController` and `LoseMenuController` to call `BuildSafeLogger.WarnOnce` when UI panels are null.

### Testing

- Ran `git diff --check` which reported no whitespace or diff errors. 
- Ran an automated brace/balance script over modified files which returned balanced braces (sanity check passed). 
- Attempted to run `command -v unity-editor || command -v Unity || command -v /opt/unity/Editor/Unity` and the Unity editor was not available in the environment, so no Unity compilation/run was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcec7891a4832a97366afd8f9bfb9a)