### PR TITLE
Add player controller components to Player prefab

### DIFF
--- a/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
+++ b/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
@@ -29802,6 +29802,14 @@ GameObject:
   - component: {fileID: 4580562239172740852}
   - component: {fileID: 8605846543303424432}
   - component: {fileID: 6562972538239049110}
+  - component: {fileID: 9000000000000000001}
+  - component: {fileID: 9000000000000000002}
+  - component: {fileID: 9000000000000000003}
+  - component: {fileID: 9000000000000000004}
+  - component: {fileID: 9000000000000000005}
+  - component: {fileID: 9000000000000000006}
+  - component: {fileID: 9000000000000000007}
+  - component: {fileID: 9000000000000000008}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -30206,6 +30214,102 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.5, y: 1.227511, z: 0.5}
   m_Center: {x: 0, y: -0.62334055, z: 0}
+--- !u!114 &9000000000000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9df28112db774dffa98adda7788af9e2, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &9000000000000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d6b88b9371a84b7badcd912c05c0f23a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &9000000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b95fb80eea43429e8636de54a40675ab, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &9000000000000000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6de1d9ec319b4e1a82aea5a694dc530a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &9000000000000000005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 585eaac3f017461c97671cc0a2887782, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &9000000000000000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a25c2fdbe5a840d3b6e857c7da02f0ad, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &9000000000000000007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62911df537e24751970696a9c864b8b9, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &9000000000000000008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e86f9f84024458c88d73d7cdd4e90ea, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1 &4622290205047029495
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/CheckpointService.cs.meta
+++ b/Assets/Scripts/Core/CheckpointService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6b88b9371a84b7badcd912c05c0f23a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
### Motivation
- Ensure the `Player` GameObject that owns `Behaviour` has scene-scoped controller components instantiated at runtime so `Behaviour.Start()` can initialize them.  
- Provide stable script GUIDs so the prefab can reference `CheckpointService` without editor re-linking.  
- Avoid adding persistent services that should live across scenes to prevent player hierarchy surviving scene loads.

### Description
- Added component references for `GameFlowController`, `CheckpointService`, `GameInputReader`, `PlayerHealthController`, `PlayerInventory`, `PlayerInteractionController`, `PlayerCombatController`, and `PlayerMovementController` to `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` on the GameObject owning `Behaviour`.  
- Appended corresponding `MonoBehaviour` blocks for those eight controllers in the prefab file so Unity can serialize the component entries.  
- Added `Assets/Scripts/Core/CheckpointService.cs.meta` with the service GUID so the prefab can reference the `CheckpointService` script.  
- Deliberately did not add `SceneTransitionService` or `CursorStateService` to the prefab because they are persistent services.

### Testing
- Ran a Python validation script that verifies required controller script GUIDs are present in the prefab and that `SceneTransitionService`/`CursorStateService` GUIDs are absent, and it passed.  
- Ran `git diff --cached --check` style validation pre-commit checks and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf4b78018832a9df053a600d90c02)