### PR TITLE
Wire HudPresenter and LoseMenuController on PlayerCanvas prefab

### DIFF
--- a/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
+++ b/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
@@ -15786,6 +15786,7 @@ GameObject:
   - component: {fileID: 3664632416280873462}
   - component: {fileID: 2439549891900878302}
   - component: {fileID: 8281943336708320071}
+  - component: {fileID: 1234567890123456789}
   m_Layer: 5
   m_Name: PlayerCanvas
   m_TagString: Untagged
@@ -16011,6 +16012,30 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 66e3189e81ab2eb41ae0a551e8ad811e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Player: {fileID: 0}
+  PlayerObjective: {fileID: 0}
+  ObjectiveText: {fileID: 9220225752409644998}
+  DisplayText: {fileID: 3664632416460160701}
+  StaminaText: {fileID: 702658506274280216}
+  LogCountText: {fileID: 3664632415969327218}
+  HealingDisplay: {fileID: 3664632415368234109}
+  CurrencyCount: {fileID: 8281943336737566932}
+  SeedCount: {fileID: 509081396571889018}
+  GobletCount: {fileID: 8281943335477456013}
+  AppleCount: {fileID: 189672765652707343}
+  ArrowMunition: {fileID: 8722552630855434181}
+--- !u!114 &1234567890123456789
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6569126030801917456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 682910bd58514bda9729bbdce91c3045, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
   Player: {fileID: 0}
   PlayerObjective: {fileID: 0}
   ObjectiveText: {fileID: 9220225752409644998}
@@ -33769,6 +33794,7 @@ GameObject:
   - component: {fileID: 8281943336893237011}
   - component: {fileID: 8281943336893237229}
   - component: {fileID: 8281943336893237010}
+  - component: {fileID: 1234567890123456790}
   m_Layer: 5
   m_Name: Loose Menu Panel
   m_TagString: Untagged
@@ -33838,6 +33864,19 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1234567890123456790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8281943336893237008}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49f9d3a4cfc242368d981e9552bc141d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  LosePanel: {fileID: 8281943336893237008}
 --- !u!1 &8281943336922718402
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Motivation
- Ensure HUD rendering is provided at runtime by wiring `HudPresenter` on the `PlayerCanvas` prefab and reusing existing TMP fields already assigned to `DebugReference`.
- Provide a controller for the lose screen by adding `LoseMenuController` and linking its `LosePanel` to the existing loose panel GameObject.
- Preserve existing debug and menu components (`DebugReference`, `UIMenu`, `RestartGameLooseMenu`) and do not alter button `OnClick` targets.

### Description
- Added a `HudPresenter` component entry to `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab` and populated its TMP fields (`ObjectiveText`, `DisplayText`, `StaminaText`, `LogCountText`, `HealingDisplay`, `CurrencyCount`, `SeedCount`, `GobletCount`, `AppleCount`, `ArrowMunition`) using the existing `fileID` references already used by `DebugReference`.
- Added a `LoseMenuController` component entry to the `Loose Menu Panel` GameObject in `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab` and set its `LosePanel` field to the same panel GameObject `fileID`.
- Left `DebugReference`, `UIMenu`, and `RestartGameLooseMenu` components in place and made no changes to any button `OnClick` targets.

### Testing
- Ran `git diff --check` and fixed trailing whitespace issues; the check passed.
- Executed a Python prefab verification script that confirmed the added component lines and field `fileID` wiring are present, and the script returned `prefab wiring verified`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfe88b0a4832a80a8adc75f5109f1)