### PR TITLE
Implement CheckpointService and route player respawn logic

### DIFF
--- a/Assets/Scripts/Core/CheckpointService.cs
+++ b/Assets/Scripts/Core/CheckpointService.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 [DefaultExecutionOrder(-1000)]
@@ -5,7 +6,11 @@ public sealed class CheckpointService : MonoBehaviour
 {
     public static CheckpointService Instance { get; private set; }
 
+    public Vector3 StartingCheckpointPosition { get; private set; }
     public Vector3 LastCheckpointPosition { get; private set; }
+    public int RemainingLives { get; private set; }
+    public bool IsRespawnInProgress { get; private set; }
+    public bool IsGameOver { get; private set; }
 
     public static CheckpointService GetOrCreate()
     {
@@ -37,13 +42,64 @@ public sealed class CheckpointService : MonoBehaviour
         }
     }
 
-    public void SaveCheckpoint(Vector3 position)
+    public void RegisterCheckpoint(Vector3 position)
     {
         LastCheckpointPosition = position;
     }
 
+    public bool TryRespawn(Behaviour player)
+    {
+        if (player == null || IsRespawnInProgress || IsGameOver)
+        {
+            return false;
+        }
+
+        if (RemainingLives <= 0)
+        {
+            IsGameOver = true;
+            player.Lives = 0;
+            return false;
+        }
+
+        IsRespawnInProgress = true;
+        RemainingLives--;
+        player.Lives = RemainingLives;
+        player.CurrentHealth = player.MaxHealth;
+
+        if (player.HealthBar != null)
+        {
+            player.HealthBar.SetHealth(player.MaxHealth);
+        }
+
+        player.transform.position = LastCheckpointPosition;
+        StartCoroutine(ClearRespawnGuardNextFrame());
+        return true;
+    }
+
+    public void ResetForNewRun(Vector3 startPosition, int startingLives)
+    {
+        StartingCheckpointPosition = startPosition;
+        LastCheckpointPosition = startPosition;
+        RemainingLives = Mathf.Max(0, startingLives);
+        IsRespawnInProgress = false;
+        IsGameOver = RemainingLives <= 0;
+    }
+
+    [System.Obsolete("Use RegisterCheckpoint(Vector3).")]
+    public void SaveCheckpoint(Vector3 position)
+    {
+        RegisterCheckpoint(position);
+    }
+
+    [System.Obsolete("Use LastCheckpointPosition.")]
     public Vector3 RespawnPosition(Vector3 offset)
     {
         return LastCheckpointPosition + offset;
+    }
+
+    private IEnumerator ClearRespawnGuardNextFrame()
+    {
+        yield return null;
+        IsRespawnInProgress = false;
     }
 }

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -337,13 +337,11 @@ public class Behaviour : MonoBehaviour
         }
         if (OBJ.gameObject.CompareTag("Strike"))
         {
-            if (Lives > 0)
+            if (CheckpointService.GetOrCreate().TryRespawn(this))
             {
-                transform.position = CheckpointService.GetOrCreate().RespawnPosition(new Vector3(1, 1, 1));
                 Instantiate(PopUpEffect, transform.position, Quaternion.identity);
-                Lives--;
             }
-            if (Lives == 0)
+            else
             {
                 ActivateLooseMenu();
             }
@@ -742,16 +740,16 @@ public class Behaviour : MonoBehaviour
 
     public void RestartCheckpoint()
     {
-        HealthBar.SetHealth(MaxHealth);
-        CurrentHealth = MaxHealth;
-        transform.position = CheckpointService.GetOrCreate().LastCheckpointPosition;
-        Instantiate(PopUpEffect, transform.position, Quaternion.identity);
-        Lives--;
+        if (CheckpointService.GetOrCreate().TryRespawn(this))
+        {
+            Instantiate(PopUpEffect, transform.position, Quaternion.identity);
+        }
     }
+
     void SaveCheckpoint(Vector3 position)
     {
         State.checkpointPosition = position;
-        CheckpointService.GetOrCreate().SaveCheckpoint(position);
+        CheckpointService.GetOrCreate().RegisterCheckpoint(position);
     }
 
     public void RestartGame()
@@ -860,14 +858,13 @@ public class Behaviour : MonoBehaviour
             return;
         }
 
-        if (Lives > 0)
-        {
-            RestartCheckpoint();
-        }
-        if (Lives == 0)
+        if (!CheckpointService.GetOrCreate().TryRespawn(this))
         {
             ActivateLooseMenu();
+            return;
         }
+
+        Instantiate(PopUpEffect, transform.position, Quaternion.identity);
     }
 
     bool ValidateStartReferences()
@@ -928,7 +925,9 @@ public class Behaviour : MonoBehaviour
         CamForTraders.enabled = false;
         Instantiate(PopUpEffect, Root.position, Quaternion.identity);
         HideCursor();
-        SaveCheckpoint(transform.position);
+        CheckpointService.GetOrCreate().ResetForNewRun(transform.position, 3);
+        State.checkpointPosition = transform.position;
+        Lives = CheckpointService.GetOrCreate().RemainingLives;
         AimIcon.SetActive(false);
         MunitionDisplay.SetActive(false);
         //Enable/Disable Background music
@@ -973,7 +972,6 @@ public class Behaviour : MonoBehaviour
         HoneyOFF();
         GoldOFF();
         ElectricEffect.SetActive(false);
-        Lives = 3;
         StaminaClock = StaminaClockInitial;
         JumpLimit = JumpNum;
         GobletJumpLimit = JumpNum + 2;

--- a/Assets/Scripts/SceneScripts/GameMaster.cs
+++ b/Assets/Scripts/SceneScripts/GameMaster.cs
@@ -1,7 +1,15 @@
+using System;
 using UnityEngine;
 
+[Obsolete("Use CheckpointService directly.")]
 public class GameMaster : MonoBehaviour
 {
+    public Vector3 lastCheckPointPos
+    {
+        get { return CheckpointService.GetOrCreate().LastCheckpointPosition; }
+        set { CheckpointService.GetOrCreate().RegisterCheckpoint(value); }
+    }
+
     public Vector3 LastCheckpointPosition
     {
         get { return CheckpointService.GetOrCreate().LastCheckpointPosition; }
@@ -9,11 +17,11 @@ public class GameMaster : MonoBehaviour
 
     public void SaveCheckpoint(Vector3 position)
     {
-        CheckpointService.GetOrCreate().SaveCheckpoint(position);
+        CheckpointService.GetOrCreate().RegisterCheckpoint(position);
     }
 
     public Vector3 RespawnPosition(Vector3 offset)
     {
-        return CheckpointService.GetOrCreate().RespawnPosition(offset);
+        return CheckpointService.GetOrCreate().LastCheckpointPosition + offset;
     }
 }


### PR DESCRIPTION
### Motivation
- Centralize checkpoint state and respawn rules (checkpoint position, starting checkpoint, lives, respawn guard, game-over) into a single service for safer lifecycle and scene-reset handling.
- Replace ad-hoc direct writes (`Lives--`, direct `transform.position`/`GM.lastCheckPointPos`) with a clear API to prevent duplicate respawns and accidental persistence across fresh level loads.

### Description
- Added `CheckpointService` with `RegisterCheckpoint(Vector3)`, `TryRespawn(Behaviour)`, and `ResetForNewRun(Vector3,int)` plus properties `StartingCheckpointPosition`, `LastCheckpointPosition`, `RemainingLives`, `IsRespawnInProgress`, and `IsGameOver` in `Assets/Scripts/Core/CheckpointService.cs`.
- `TryRespawn` enforces a one-death respawn guard, decrements `RemainingLives`, restores health/UI, moves the player to the checkpoint, and returns success/failure.
- Updated `Behaviour` to call `CheckpointService.GetOrCreate().TryRespawn(this)` / `RegisterCheckpoint(...)` / `ResetForNewRun(...)` and removed direct `Lives--` / hard `Lives = 3` / direct checkpoint writes in `Assets/Scripts/Player/Behaviour.cs`.
- Kept `GameMaster` as an obsolete compatibility wrapper that forwards `LastCheckpointPosition`, `SaveCheckpoint`, and `RespawnPosition` to `CheckpointService` in `Assets/Scripts/SceneScripts/GameMaster.cs`.

### Testing
- Ran `git diff --check` and it passed with no whitespace or diff-check errors.
- Ran targeted `rg` checks to ensure direct `Lives--` and direct checkpoint assignment patterns were removed, and the searches returned expected replacements successfully.
- Changes were committed locally as "Implement checkpoint respawn service"; no compile/build step was executed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcec216978832aa0ccd885a88cd374)