### PR TITLE
Add prefab runtime config hardening

### DIFF
--- a/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
+++ b/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
@@ -5906,11 +5906,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 319d2fe34a804e245819465c9505ea59, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
-  m_LockStageInInspector: 
+  m_LockStageInInspector:
   m_StreamingVersion: 20170927
   m_Priority: 10
   m_StandbyUpdate: 2
@@ -6126,8 +6126,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
   - Header
@@ -7321,8 +7321,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &6644894321090993483
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7333,8 +7333,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_BindingMode: 5
   m_FollowOffset: {x: 0, y: 3.21, z: -6}
   m_XDamping: 1
@@ -7361,7 +7361,7 @@ MonoBehaviour:
     m_MaxSpeed: 300
     m_AccelTime: 0.1
     m_DecelTime: 0.1
-    m_InputAxisName: 
+    m_InputAxisName:
     m_InputAxisValue: 0
     m_InvertInput: 1
     m_MinValue: -180
@@ -7387,8 +7387,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
@@ -7447,8 +7447,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
   - Header
@@ -17149,8 +17149,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
   - Header
@@ -17303,7 +17303,7 @@ Animator:
   m_ApplyRootMotion: 1
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
-  m_WarningMessage: 
+  m_WarningMessage:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
@@ -17413,8 +17413,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8cb792c87e0d29343bcc404e81e585a7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   audioClip:
   - {fileID: 8300000, guid: ea7b2bc81a0162e4ba69bbaf074d9c10, type: 3}
   - {fileID: 8300000, guid: fd52d21afda73ae449b1e2330d9053f2, type: 3}
@@ -17447,8 +17447,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b65e1e7c41f558a4fa67250bfa9647a2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   FireSwordTrail: {fileID: 2360655870356088562, guid: d3d7b71df83d717448b295e1b47dab38, type: 3}
   FireBreath: {fileID: 8764043878647920493, guid: 17fe0077dd5b09b40944529f740fb760, type: 3}
   Sword: {fileID: 474002384174812215}
@@ -17465,8 +17465,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3afa02cfd36805c4b950fda5ac1a5b9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   anim: {fileID: 8986530077644096813}
   DistanceToGround: 0.15
   PositionWeight: 0.45
@@ -17483,8 +17483,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86c51f188782f664f8f56a3949621100, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   Player: {fileID: 8986530077644096813}
   AttackPoint: {fileID: 4580562237567520680}
   Sphere: {fileID: 4580562237485494874}
@@ -17721,8 +17721,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &4606268706475194607
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -17733,8 +17733,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_BindingMode: 5
   m_FollowOffset: {x: 0, y: 3.21, z: -6}
   m_XDamping: 1
@@ -17761,7 +17761,7 @@ MonoBehaviour:
     m_MaxSpeed: 300
     m_AccelTime: 0.1
     m_DecelTime: 0.1
-    m_InputAxisName: 
+    m_InputAxisName:
     m_InputAxisValue: 0
     m_InvertInput: 1
     m_MinValue: -180
@@ -17787,8 +17787,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
@@ -17848,8 +17848,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &520611400682036544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -17860,8 +17860,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_BindingMode: 5
   m_FollowOffset: {x: 0, y: 3.21, z: -6}
   m_XDamping: 1
@@ -17888,7 +17888,7 @@ MonoBehaviour:
     m_MaxSpeed: 300
     m_AccelTime: 0.1
     m_DecelTime: 0.1
-    m_InputAxisName: 
+    m_InputAxisName:
     m_InputAxisValue: 0
     m_InvertInput: 1
     m_MinValue: -180
@@ -17914,8 +17914,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
@@ -23075,8 +23075,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9205bc1bbacc90040a998067b5643d16, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   clearBehavior: 2
   cameraShake:
     enabled: 0
@@ -23363,8 +23363,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 74b9972fb60494746ad448b0cb071bc4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   Distance: {x: 0, y: 0, z: 0}
 --- !u!114 &1195687265868391985
 MonoBehaviour:
@@ -23376,8 +23376,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 49556bef1f862e442bd170c8e79583a8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   Player: {fileID: 4580562239172740872}
   PlatetringText: {fileID: 1828672474135638312}
 --- !u!1 &3610943399608678154
@@ -24010,8 +24010,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &3723630138933244544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -24022,8 +24022,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_BindingMode: 5
   m_FollowOffset: {x: 0, y: 1.61, z: -2}
   m_XDamping: 1
@@ -24050,7 +24050,7 @@ MonoBehaviour:
     m_MaxSpeed: 300
     m_AccelTime: 0.1
     m_DecelTime: 0.1
-    m_InputAxisName: 
+    m_InputAxisName:
     m_InputAxisValue: 0
     m_InvertInput: 1
     m_MinValue: -180
@@ -24076,8 +24076,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
@@ -29541,8 +29541,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
   - Header
@@ -29810,6 +29810,8 @@ GameObject:
   - component: {fileID: 9000000000000000006}
   - component: {fileID: 9000000000000000007}
   - component: {fileID: 9000000000000000008}
+  - component: {fileID: 9003000000000000001}
+  - component: {fileID: 9003000000000000002}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -29874,8 +29876,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cebeb71f51b7ec54299a0c4215527197, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   fallDamageFactor: 0.202
   damageVelocity: 0
 --- !u!114 &3460990902718605333
@@ -29888,8 +29890,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9ce57594dbfd0414f8e2985186cde84e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   Mark: {fileID: 0}
   Locations:
   - {fileID: 0}
@@ -29925,8 +29927,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 11c575b9dcaa7e64cab36d8ee5f8295c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   Player: {fileID: 0}
   Objective:
   - Talk to the trader
@@ -29955,7 +29957,7 @@ MonoBehaviour:
   - Free your friend
   i: 0
   currentPoint: {fileID: 3460990902718605333}
-  Instruction: 
+  Instruction:
 --- !u!114 &4580562239172740872
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -29966,8 +29968,9 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8c489014c99e2174688db9b08f27a14e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
+  hazardDamageConfig: {fileID: 11400000, guid: 668f0735e880439992fa41bdc20572ce, type: 2}
   Player: {fileID: 4580562239172740854}
   grounded: 0
   Load: {fileID: 4580562239172740873}
@@ -30073,9 +30076,9 @@ MonoBehaviour:
   Honeypicked: 0
   GobletPicked: 0
   GobletClock: 0
-  GobletText: 
-  ArrowText: 
-  Plattering: 
+  GobletText:
+  ArrowText:
+  Plattering:
   seekMusic: 0
   Music: {fileID: 0}
   Sound: {fileID: 465923861175782815}
@@ -30097,17 +30100,17 @@ MonoBehaviour:
   moveSpeed: 5
   LooseScreen: {fileID: 0}
   isAtTrader: 0
-  LogCount: 
-  DebugText: 
-  StaminaText: 
-  HealingText: 
-  AppleText: 
+  LogCount:
+  DebugText:
+  StaminaText:
+  HealingText:
+  AppleText:
   GobletPickup: 3
   Apple: 0
   Currency: 0
   NutCount: 3
-  SeedText: 
-  Wallet: 
+  SeedText:
+  Wallet:
   GM: {fileID: 0}
   AimIcon: {fileID: 0}
   FreeLook: {fileID: 5012679269152501947}
@@ -30123,8 +30126,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9fe5bb27d1fd7004698c1c6c93060041, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   CarryPoint:
   - {fileID: 1422701224226453994}
   - {fileID: 1422701224735482151}
@@ -30158,8 +30161,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4edfb35d5c7f1954a8e1a1c395915808, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   HealthSlider: {fileID: 0}
   StaminaSlider: {fileID: 0}
 --- !u!114 &3318556070447194430
@@ -30172,8 +30175,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7a565b4e62b079c428781a90fe631c25, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   player: {fileID: 0}
   Boss: {fileID: 0}
   ChatCollider: {fileID: 0}
@@ -30356,11 +30359,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 319d2fe34a804e245819465c9505ea59, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
-  m_LockStageInInspector: 
+  m_LockStageInInspector:
   m_StreamingVersion: 20170927
   m_Priority: 10
   m_StandbyUpdate: 2
@@ -30460,12 +30463,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e501d18bb52cf8c40b1853ca4904654f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_CollideAgainst:
     serializedVersion: 2
     m_Bits: 1
-  m_IgnoreTag: 
+  m_IgnoreTag:
   m_TransparentLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -30826,8 +30829,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &4935695994066166169
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -30838,8 +30841,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_BindingMode: 5
   m_FollowOffset: {x: 0, y: 1.61, z: -2}
   m_XDamping: 1
@@ -30866,7 +30869,7 @@ MonoBehaviour:
     m_MaxSpeed: 300
     m_AccelTime: 0.1
     m_DecelTime: 0.1
-    m_InputAxisName: 
+    m_InputAxisName:
     m_InputAxisValue: 0
     m_InvertInput: 1
     m_MinValue: -180
@@ -30892,8 +30895,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
@@ -30953,8 +30956,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &5012679268527766832
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -30965,8 +30968,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_BindingMode: 0
   m_FollowOffset: {x: 0, y: 2.3, z: -6}
   m_XDamping: 2
@@ -30993,7 +30996,7 @@ MonoBehaviour:
     m_MaxSpeed: 300
     m_AccelTime: 0.1
     m_DecelTime: 0.1
-    m_InputAxisName: 
+    m_InputAxisName:
     m_InputAxisValue: 0
     m_InvertInput: 1
     m_MinValue: -180
@@ -31019,8 +31022,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
@@ -31110,8 +31113,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
   - Header
@@ -31399,8 +31402,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
   - Header
@@ -31481,8 +31484,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1b05706e1c4b358499459122f608ddd2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   zoomSpeed: 10
   minFOV: 10
   maxFOV: 80
@@ -31499,11 +31502,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 319d2fe34a804e245819465c9505ea59, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
-  m_LockStageInInspector: 
+  m_LockStageInInspector:
   m_StreamingVersion: 20170927
   m_Priority: 10
   m_StandbyUpdate: 2
@@ -31637,8 +31640,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &5012679269713821992
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31649,8 +31652,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_BindingMode: 0
   m_FollowOffset: {x: 0, y: 2.3, z: -6}
   m_XDamping: 2
@@ -31677,7 +31680,7 @@ MonoBehaviour:
     m_MaxSpeed: 300
     m_AccelTime: 0.1
     m_DecelTime: 0.1
-    m_InputAxisName: 
+    m_InputAxisName:
     m_InputAxisValue: 0
     m_InvertInput: 1
     m_MinValue: -180
@@ -31703,8 +31706,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
@@ -31764,8 +31767,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &5012679269788669586
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31776,8 +31779,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_BindingMode: 0
   m_FollowOffset: {x: 0, y: 2.3, z: -6}
   m_XDamping: 2
@@ -31804,7 +31807,7 @@ MonoBehaviour:
     m_MaxSpeed: 300
     m_AccelTime: 0.1
     m_DecelTime: 0.1
-    m_InputAxisName: 
+    m_InputAxisName:
     m_InputAxisValue: 0
     m_InvertInput: 1
     m_MinValue: -180
@@ -31830,8 +31833,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
@@ -32070,8 +32073,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
   - Header
@@ -32608,8 +32611,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_UiScaleMode: 0
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -32631,8 +32634,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -82863,8 +82866,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
   - Header
@@ -83184,8 +83187,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -83306,8 +83309,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ExcludedPropertiesInInspector:
   - m_Script
   - Header
@@ -83385,8 +83388,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &6200935561493948824
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -83397,8 +83400,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_BindingMode: 5
   m_FollowOffset: {x: 0, y: 1.61, z: -2}
   m_XDamping: 1
@@ -83425,7 +83428,7 @@ MonoBehaviour:
     m_MaxSpeed: 300
     m_AccelTime: 0.1
     m_DecelTime: 0.1
-    m_InputAxisName: 
+    m_InputAxisName:
     m_InputAxisValue: 0
     m_InvertInput: 1
     m_MinValue: -180
@@ -83451,8 +83454,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
@@ -83468,3 +83471,34 @@ MonoBehaviour:
   m_BiasX: 0
   m_BiasY: 0
   m_CenterOnActivate: 1
+--- !u!114 &9003000000000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca59dcc4f9f94a9cab31a566232f3837, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  debugConfig: {fileID: 11400000, guid: 3c4d0b1eb8254a47869c1dd912aca17b, type: 2}
+--- !u!114 &9003000000000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5279260caf244a48496eedb3918558b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  debugConfig: {fileID: 11400000, guid: 3c4d0b1eb8254a47869c1dd912aca17b, type: 2}
+  requiredComponents:
+  - {fileID: 4580562239172740872}
+  - {fileID: 4580562239172740854}
+  - {fileID: 4580562239172740878}
+  requiredObjects: []

--- a/Assets/Prefabs/Scorpion/ScorpionBoss.prefab
+++ b/Assets/Prefabs/Scorpion/ScorpionBoss.prefab
@@ -29082,8 +29082,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.12518108, b: 0, a: 1}
   m_RaycastTarget: 1
@@ -29173,8 +29173,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_UiScaleMode: 0
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -29196,8 +29196,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -29252,8 +29252,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -37426,8 +37426,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 74b9972fb60494746ad448b0cb071bc4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   Distance: {x: 0, y: 0, z: 0}
 --- !u!1 &4775430634472590800
 GameObject:
@@ -43700,8 +43700,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9205bc1bbacc90040a998067b5643d16, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   clearBehavior: 1
   cameraShake:
     enabled: 1
@@ -43844,8 +43844,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 42da10f13d86cee4d8b1a69500376617, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   time: 0.5
 --- !u!82 &4297084379228316669
 AudioSource:
@@ -51326,6 +51326,7 @@ GameObject:
   - component: {fileID: 6107630362012945904}
   - component: {fileID: 6107630362012945911}
   - component: {fileID: 3561575782887557094}
+  - component: {fileID: 9002000000000000001}
   m_Layer: 10
   m_Name: ScorpionBoss
   m_TagString: Scorpion
@@ -51363,8 +51364,9 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3d3162e48494bc64ab26370e7a299cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
+  bossConfig: {fileID: 11400000, guid: 2065d023a8674677922a16390512cd86, type: 2}
   Scorpion: {fileID: 407642689355950290}
   BossHealth: {fileID: 6107630362012945904}
   CurrentHealth: 150000
@@ -51402,8 +51404,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 31ea55b4c87a18340bd56bcc0c07b233, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   NPCslider: {fileID: 0}
 --- !u!54 &6107630362012945911
 Rigidbody:
@@ -52075,7 +52077,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
-  m_WarningMessage: 
+  m_WarningMessage:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
@@ -52185,8 +52187,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f705a3743fe57ce4396e714e1f63ef8d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   audioClip:
   - {fileID: 8300000, guid: 26006051b5c98c644964fe770338f09d, type: 3}
   - {fileID: 8300000, guid: 928c1cf43af53e14db147a0440148587, type: 3}
@@ -61832,8 +61834,8 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cb320059d2209204aac1872dd9ba6cea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   Clock: 3
   effect: {fileID: 5257925790666190459}
   saveAfterKill: 0
@@ -65500,3 +65502,22 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: 2506323010638760798, guid: 71d184d9fbae1f445a496f7f9163aedd, type: 3}
+--- !u!114 &9002000000000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6107630362012945909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5279260caf244a48496eedb3918558b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  debugConfig: {fileID: 11400000, guid: 3c4d0b1eb8254a47869c1dd912aca17b, type: 2}
+  requiredComponents:
+  - {fileID: 6107630362012945905}
+  - {fileID: 6107630362012945911}
+  requiredObjects:
+  - {fileID: 3050568388787473839}
+  - {fileID: 8211043342563841022}

--- a/Assets/Prefabs/Wasp/LVL1 Wasp.prefab
+++ b/Assets/Prefabs/Wasp/LVL1 Wasp.prefab
@@ -5031,8 +5031,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 74b9972fb60494746ad448b0cb071bc4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   Distance: {x: 0, y: 0, z: 0}
 --- !u!1 &630764799270797316
 GameObject:
@@ -15353,6 +15353,7 @@ GameObject:
   - component: {fileID: 7731927592017154948}
   - component: {fileID: 4992882469211511398}
   - component: {fileID: 8675218551507148661}
+  - component: {fileID: 9001000000000000001}
   m_Layer: 10
   m_Name: LVL1 Wasp
   m_TagString: NPC
@@ -15398,7 +15399,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
-  m_WarningMessage: 
+  m_WarningMessage:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
@@ -15428,8 +15429,9 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 04917a49b5936164d999be346f447d22, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
+  aiConfig: {fileID: 11400000, guid: 45f991efa30b476493801f9c8b94c778, type: 2}
   NPC: {fileID: 2735624339671731891}
   Wasp: {fileID: 8402721289759985096}
   Distance: {x: 0, y: 0, z: 0}
@@ -15468,8 +15470,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 31ea55b4c87a18340bd56bcc0c07b233, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   NPCslider: {fileID: 9053961203221591993}
 --- !u!114 &7731927592017154948
 MonoBehaviour:
@@ -15481,8 +15483,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f705a3743fe57ce4396e714e1f63ef8d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   audioClip:
   - {fileID: 8300000, guid: 26006051b5c98c644964fe770338f09d, type: 3}
   - {fileID: 8300000, guid: d902e14d51277a24d9a1de8ca3765e72, type: 3}
@@ -37060,8 +37062,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 03c8102322ad0d04fa6ae3f17887e967, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   isDynamic: 0
   text: SLASH!
   size: 1
@@ -37262,8 +37264,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -37359,8 +37361,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.38431373}
   m_RaycastTarget: 1
@@ -37450,8 +37452,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_UiScaleMode: 0
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -37473,8 +37475,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -37536,8 +37538,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0.90128887, g: 1, b: 0, a: 1}
   m_RaycastTarget: 1
@@ -37685,7 +37687,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3400547379593215131, guid: 29caf87e6282fd044adbb00bd35e129a, type: 3}
       propertyPath: LightsModule.light
-      value: 
+      value:
       objectReference: {fileID: 0}
     - target: {fileID: 3400547379593215131, guid: 29caf87e6282fd044adbb00bd35e129a, type: 3}
       propertyPath: LightsModule.ratio
@@ -37755,3 +37757,22 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 3400547379593215125, guid: 29caf87e6282fd044adbb00bd35e129a, type: 3}
   m_PrefabInstance: {fileID: 5639969712290697209}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &9001000000000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2969994238874094856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5279260caf244a48496eedb3918558b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  debugConfig: {fileID: 11400000, guid: 3c4d0b1eb8254a47869c1dd912aca17b, type: 2}
+  requiredComponents:
+  - {fileID: 2735624339671731888}
+  - {fileID: 2735624339671731891}
+  requiredObjects:
+  - {fileID: 7022265487677813612}
+  - {fileID: 3110248994183801233}

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7dd7d797eab344fcb9d9734626f6a09b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/RuntimeConfig.meta
+++ b/Assets/Resources/RuntimeConfig.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8c9c0f635ae240ffa4e0cb73e9b24a85
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/RuntimeConfig/LoggingConfig.asset
+++ b/Assets/Resources/RuntimeConfig/LoggingConfig.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d86e5a7da0b45d0a634e78212a8289f, type: 3}
+  m_Name: LoggingConfig
+  m_EditorClassIdentifier:
+  logInfo: 1
+  logWarnings: 1
+  logErrors: 1
+  includeSceneName: 1
+  includeOwnerPath: 1

--- a/Assets/Resources/RuntimeConfig/LoggingConfig.asset.meta
+++ b/Assets/Resources/RuntimeConfig/LoggingConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3cf8260baf8041b8b7eee3d3c14d039e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects.meta
+++ b/Assets/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f1954018dae44eeb99380e358843b2f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/RuntimeConfig.meta
+++ b/Assets/ScriptableObjects/RuntimeConfig.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 96d4e6e4748c446a99263d966b937006
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/RuntimeConfig/DefaultBossConfig.asset
+++ b/Assets/ScriptableObjects/RuntimeConfig/DefaultBossConfig.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75867718cb9a4c718118c9e353697af3, type: 3}
+  m_Name: DefaultBossConfig
+  m_EditorClassIdentifier:
+  maxHealth: 150000
+  comboLimit: 20
+  stunSeconds: 7
+  chargeSpeed: 15
+  chargeClock: 5
+  lookDistance: 40
+  chargeDistance: 30
+  attackDistance: 4

--- a/Assets/ScriptableObjects/RuntimeConfig/DefaultBossConfig.asset.meta
+++ b/Assets/ScriptableObjects/RuntimeConfig/DefaultBossConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2065d023a8674677922a16390512cd86
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/RuntimeConfig/DefaultDebugQAConfig.asset
+++ b/Assets/ScriptableObjects/RuntimeConfig/DefaultDebugQAConfig.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90b490181f194c50ac017c264d12fcab, type: 3}
+  m_Name: DefaultDebugQAConfig
+  m_EditorClassIdentifier:
+  enableRuntimeReferenceValidation: 1
+  logPrefabConfigApplication: 0
+  disableCombatDamage: 0

--- a/Assets/ScriptableObjects/RuntimeConfig/DefaultDebugQAConfig.asset.meta
+++ b/Assets/ScriptableObjects/RuntimeConfig/DefaultDebugQAConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c4d0b1eb8254a47869c1dd912aca17b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/RuntimeConfig/DefaultEnemyAIConfig.asset
+++ b/Assets/ScriptableObjects/RuntimeConfig/DefaultEnemyAIConfig.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf3873e22e674cd99495c86fb4ab9de9, type: 3}
+  m_Name: DefaultEnemyAIConfig
+  m_EditorClassIdentifier:
+  maxHealth: 1000
+  hitToStun: 10
+  damageToPlayer: 15
+  attackSpeed: 50
+  recoverySeconds: 10
+  aggroDistance: 50
+  leashDistance: 30

--- a/Assets/ScriptableObjects/RuntimeConfig/DefaultEnemyAIConfig.asset.meta
+++ b/Assets/ScriptableObjects/RuntimeConfig/DefaultEnemyAIConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 45f991efa30b476493801f9c8b94c778
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/RuntimeConfig/DefaultHazardDamageConfig.asset
+++ b/Assets/ScriptableObjects/RuntimeConfig/DefaultHazardDamageConfig.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4bf8a6584e740e492663c58309ad677, type: 3}
+  m_Name: DefaultHazardDamageConfig
+  m_EditorClassIdentifier:
+  scorpionJawClampDamage: 15
+  scorpionStingDamage: 30
+  scorpionParryChipDamage: 6
+  scorpionParryCounterDamage: 10

--- a/Assets/ScriptableObjects/RuntimeConfig/DefaultHazardDamageConfig.asset.meta
+++ b/Assets/ScriptableObjects/RuntimeConfig/DefaultHazardDamageConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 668f0735e880439992fa41bdc20572ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config.meta
+++ b/Assets/Scripts/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc5535f2b986487d8b1b6fd8fd4e0745
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config/BossConfig.cs
+++ b/Assets/Scripts/Config/BossConfig.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "BossConfig", menuName = "BeaverMania/Config/Boss Config")]
+public class BossConfig : ScriptableObject
+{
+    [Min(1)] public int maxHealth = 2000;
+    [Min(1)] public int comboLimit = 10;
+    [Min(0f)] public float stunSeconds = 10f;
+    [Min(0f)] public float chargeSpeed = 7f;
+    [Min(0f)] public float chargeClock = 1f;
+    [Min(0f)] public float lookDistance = 40f;
+    [Min(0f)] public float chargeDistance = 30f;
+    [Min(0f)] public float attackDistance = 10f;
+}

--- a/Assets/Scripts/Config/BossConfig.cs.meta
+++ b/Assets/Scripts/Config/BossConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75867718cb9a4c718118c9e353697af3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config/DebugQAConfig.cs
+++ b/Assets/Scripts/Config/DebugQAConfig.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "DebugQAConfig", menuName = "BeaverMania/Config/Debug QA Config")]
+public class DebugQAConfig : ScriptableObject
+{
+    public bool enableRuntimeReferenceValidation = true;
+    public bool logPrefabConfigApplication;
+    public bool disableCombatDamage;
+}

--- a/Assets/Scripts/Config/DebugQAConfig.cs.meta
+++ b/Assets/Scripts/Config/DebugQAConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90b490181f194c50ac017c264d12fcab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config/EnemyAIConfig.cs
+++ b/Assets/Scripts/Config/EnemyAIConfig.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "EnemyAIConfig", menuName = "BeaverMania/Config/Enemy AI Config")]
+public class EnemyAIConfig : ScriptableObject
+{
+    [Header("Wasp")]
+    [Min(0)] public int maxHealth = 2000;
+    [Min(0)] public int hitToStun = 3;
+    [Min(0)] public int damageToPlayer = 1;
+    [Min(0f)] public float attackSpeed = 7f;
+    [Min(0f)] public float recoverySeconds = 10f;
+    [Min(0f)] public float aggroDistance = 50f;
+    [Min(0f)] public float leashDistance = 30f;
+}

--- a/Assets/Scripts/Config/EnemyAIConfig.cs.meta
+++ b/Assets/Scripts/Config/EnemyAIConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf3873e22e674cd99495c86fb4ab9de9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config/HazardDamageConfig.cs
+++ b/Assets/Scripts/Config/HazardDamageConfig.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "HazardDamageConfig", menuName = "BeaverMania/Config/Hazard Damage Config")]
+public class HazardDamageConfig : ScriptableObject
+{
+    [Min(0f)] public float scorpionJawClampDamage = 15f;
+    [Min(0f)] public float scorpionStingDamage = 30f;
+    [Min(0f)] public float scorpionParryChipDamage = 6f;
+    [Min(0)] public int scorpionParryCounterDamage = 10;
+}

--- a/Assets/Scripts/Config/HazardDamageConfig.cs.meta
+++ b/Assets/Scripts/Config/HazardDamageConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4bf8a6584e740e492663c58309ad677
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config/LoggingConfig.cs
+++ b/Assets/Scripts/Config/LoggingConfig.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "LoggingConfig", menuName = "BeaverMania/Config/Logging Config")]
+public class LoggingConfig : ScriptableObject
+{
+    public bool logInfo = true;
+    public bool logWarnings = true;
+    public bool logErrors = true;
+    public bool includeSceneName = true;
+    public bool includeOwnerPath = true;
+}

--- a/Assets/Scripts/Config/LoggingConfig.cs.meta
+++ b/Assets/Scripts/Config/LoggingConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d86e5a7da0b45d0a634e78212a8289f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/BuildSafeLogger.cs
+++ b/Assets/Scripts/Core/BuildSafeLogger.cs
@@ -5,6 +5,8 @@ using UnityEngine.SceneManagement;
 public static class BuildSafeLogger
 {
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
+    const string LoggingConfigResourcePath = "RuntimeConfig/LoggingConfig";
+    static LoggingConfig loggingConfig;
     private static readonly HashSet<string> infoKeys = new HashSet<string>();
     private static readonly HashSet<string> warnKeys = new HashSet<string>();
     private static readonly HashSet<string> errorKeys = new HashSet<string>();
@@ -13,7 +15,7 @@ public static class BuildSafeLogger
     public static void InfoOnce(string key, string message, Object owner = null, string missingField = null, string missingTag = null, string missingMethod = null)
     {
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
-        if (infoKeys.Add(ResolveKey(key, message, owner, missingField, missingTag, missingMethod)))
+        if (Config.logInfo && infoKeys.Add(ResolveKey(key, message, owner, missingField, missingTag, missingMethod)))
         {
             Debug.Log(Format(message, owner, missingField, missingTag, missingMethod), owner);
         }
@@ -23,7 +25,7 @@ public static class BuildSafeLogger
     public static void WarnOnce(string key, string message, Object owner = null, string missingField = null, string missingTag = null, string missingMethod = null)
     {
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
-        if (warnKeys.Add(ResolveKey(key, message, owner, missingField, missingTag, missingMethod)))
+        if (Config.logWarnings && warnKeys.Add(ResolveKey(key, message, owner, missingField, missingTag, missingMethod)))
         {
             Debug.LogWarning(Format(message, owner, missingField, missingTag, missingMethod), owner);
         }
@@ -33,7 +35,7 @@ public static class BuildSafeLogger
     public static void ErrorOnce(string key, string message, Object owner = null, string missingField = null, string missingTag = null, string missingMethod = null)
     {
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
-        if (errorKeys.Add(ResolveKey(key, message, owner, missingField, missingTag, missingMethod)))
+        if (Config.logErrors && errorKeys.Add(ResolveKey(key, message, owner, missingField, missingTag, missingMethod)))
         {
             Debug.LogError(Format(message, owner, missingField, missingTag, missingMethod), owner);
         }
@@ -41,6 +43,8 @@ public static class BuildSafeLogger
     }
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
+    static LoggingConfig Config => loggingConfig != null ? loggingConfig : (loggingConfig = Resources.Load<LoggingConfig>(LoggingConfigResourcePath)) ?? ScriptableObject.CreateInstance<LoggingConfig>();
+
     private static string ResolveKey(string key, string message, Object owner, string missingField, string missingTag, string missingMethod)
     {
         if (!string.IsNullOrEmpty(key))
@@ -54,7 +58,11 @@ public static class BuildSafeLogger
     private static string Format(string message, Object owner, string missingField, string missingTag, string missingMethod)
     {
         var scene = SceneManager.GetActiveScene().name;
-        var formatted = "[" + (string.IsNullOrEmpty(scene) ? "<no scene>" : scene) + "] " + message + " Owner=" + OwnerName(owner);
+        var formatted = Config.includeSceneName ? "[" + (string.IsNullOrEmpty(scene) ? "<no scene>" : scene) + "] " + message : message;
+        if (Config.includeOwnerPath)
+        {
+            formatted += " Owner=" + OwnerName(owner);
+        }
 
         if (!string.IsNullOrEmpty(missingField))
         {

--- a/Assets/Scripts/NPC/Scorpion/ScorpionDamage.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionDamage.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class ScorpionDamage : MonoBehaviour
 {
+    [SerializeField] HazardDamageConfig damageConfig;
     public float JawClamp;
     public float Sting;
     public Behaviour Player;
@@ -12,9 +13,25 @@ public class ScorpionDamage : MonoBehaviour
 
     private void Awake()
     {
+        ApplyConfig();
         BossAudio = GameObject.FindGameObjectWithTag("Boss").GetComponent<NPC_Audio>();
         Player = transform.GetComponent<Behaviour>();
     }
+    float ParryChipDamage => damageConfig != null ? damageConfig.scorpionParryChipDamage : 6f;
+    int ParryCounterDamage => damageConfig != null ? damageConfig.scorpionParryCounterDamage : 10;
+
+    void ApplyConfig()
+    {
+        if (damageConfig == null)
+        {
+            BuildSafeLogger.WarnOnce(nameof(ScorpionDamage) + ".MissingConfig", "Missing hazard damage config; using prefab values.", this, nameof(damageConfig));
+            return;
+        }
+
+        JawClamp = damageConfig.scorpionJawClampDamage;
+        Sting = damageConfig.scorpionStingDamage;
+    }
+
     public void OnTriggerEnter(Collider OBJ)
     {
         if (OBJ.gameObject.CompareTag("Arena"))
@@ -27,13 +44,16 @@ public class ScorpionDamage : MonoBehaviour
             {
                 if (Player.isParried == false)
                 {
-                    Player.TakeDamage(JawClamp);
+                    if (CombatDebugGate.AllowsDamage(Player.gameObject))
+                    {
+                        Player.TakeDamage(JawClamp);
+                    }
                     BossAudio.Sting();
                 }
                 if (Player.isParried == true)
                 {
-                    Player.TakeDamage(6);
-                    Scorpion.TakeDamage(10);
+                    Player.TakeDamage(ParryChipDamage);
+                    Scorpion.TakeDamage(ParryCounterDamage);
                     Scorpion.combo++;
                 }
             }
@@ -45,13 +65,16 @@ public class ScorpionDamage : MonoBehaviour
             {
                 if (Player.isParried == false)
                 {
-                    Player.TakeDamage(Sting);
+                    if (CombatDebugGate.AllowsDamage(Player.gameObject))
+                    {
+                        Player.TakeDamage(Sting);
+                    }
                     BossAudio.Sting();
                 }
                 if (Player.isParried == true)
                 {
-                    Player.TakeDamage(6f);
-                    Scorpion.TakeDamage(10);
+                    Player.TakeDamage(ParryChipDamage);
+                    Scorpion.TakeDamage(ParryCounterDamage);
                     Scorpion.combo++;
                 }
             }

--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 public class ScorpionScript : MonoBehaviour
 {
+    [Header("Config")]
+    [SerializeField] BossConfig bossConfig;
+
     [Header("General Stats")]
     Rigidbody RBScorpion;
     [SerializeField] Animator Scorpion;
@@ -49,6 +52,7 @@ public class ScorpionScript : MonoBehaviour
 
     private void Start()
     {
+        ApplyConfig();
         RBScorpion = gameObject.GetComponent<Rigidbody>();
         Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
         //AnotherScorpion = GameObject.FindGameObjectWithTag("Scorpion");
@@ -61,6 +65,24 @@ public class ScorpionScript : MonoBehaviour
         resetCharge = chargeClock;
         initialStun = StunnedClock;
         combo = 0;
+    }
+
+    void ApplyConfig()
+    {
+        if (bossConfig == null)
+        {
+            BuildSafeLogger.WarnOnce(nameof(ScorpionScript) + ".MissingConfig", "Missing boss config; using prefab values.", this, nameof(bossConfig));
+            return;
+        }
+
+        MaxHealth = bossConfig.maxHealth;
+        comboLimit = bossConfig.comboLimit;
+        StunnedClock = bossConfig.stunSeconds;
+        chargeSpeed = bossConfig.chargeSpeed;
+        chargeClock = bossConfig.chargeClock;
+        lookDistance = bossConfig.lookDistance;
+        chargeDistance = bossConfig.chargeDistance;
+        attackDistance = bossConfig.attackDistance;
     }
 
     public void FixedUpdate()

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 
 public class NPC_Basic : MonoBehaviour
 {
+    [Header("Config")]
+    [SerializeField] EnemyAIConfig aiConfig;
+
     [Header("Body and animation")]
     public Rigidbody NPC;
     [SerializeField] Animator Wasp;
@@ -54,6 +57,7 @@ public class NPC_Basic : MonoBehaviour
     // Start is called before the first frame update    
     public void Start()
     {
+        ApplyConfig();
         SpawnPos = transform.position;
         Wasp = GetComponent<Animator>();
         CurrentHealth = MaxHealth;
@@ -84,7 +88,7 @@ public class NPC_Basic : MonoBehaviour
             {
                 rotGoal = Quaternion.LookRotation(NPC.velocity);
                 transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
-                if (Distance.magnitude >= 50)
+                if (Distance.magnitude >= AggroDistance)
                 {
                     if (ChangeNav <= 0)
                     {
@@ -98,14 +102,14 @@ public class NPC_Basic : MonoBehaviour
                     }
                 }
 
-                if (PlayerDistance < 50)
+                if (PlayerDistance < AggroDistance)
                 {
                     if (Contact == false)
                     {
                         BuzzSource.SetActive(true);
                         ChargeClock = 0.7f;
                         Physics.IgnoreCollision(AnotherWasp.GetComponent<Collider>(), transform.GetComponent<Collider>());
-                        NPC.velocity = (Distance.normalized * 50f);
+                        NPC.velocity = (Distance.normalized * AttackSpeed);
                         Wasp.SetBool("Sting", true);
                         ChangeNav = 0;
                     }
@@ -208,7 +212,7 @@ public class NPC_Basic : MonoBehaviour
     {
         BuzzSource.SetActive(true);
         Wasp.SetBool("Sting", false);
-        if ((transform.position - SpawnPos).magnitude > 30)
+        if ((transform.position - SpawnPos).magnitude > LeashDistance)
         {
             NPC.velocity = (SpawnPos - transform.position).normalized * 10;
         }
@@ -251,7 +255,7 @@ public class NPC_Basic : MonoBehaviour
         BuzzSource.SetActive(true);
         floating = false;
         Wasp.SetBool("Stunned", false);
-        Recovery = 10f;
+        Recovery = RecoverySeconds;
         NPC.constraints = RigidbodyConstraints.FreezeRotation;
         NPC.useGravity = false;
     }
@@ -262,7 +266,10 @@ public class NPC_Basic : MonoBehaviour
         if (PlayerHealth.isParried == false && PlayerHealth.Rolling == false)
         {
             Sound.Sting();
-            PlayerHealth.TakeDamage(Damage2Player);
+            if (CombatDebugGate.AllowsDamage(PlayerHealth.gameObject))
+            {
+                PlayerHealth.TakeDamage(Damage2Player);
+            }
         }
         Wasp.SetBool("Sting", false);
         if (PlayerHealth.isParried == true)
@@ -274,10 +281,29 @@ public class NPC_Basic : MonoBehaviour
 
     }
 
+    float AggroDistance => aiConfig != null ? aiConfig.aggroDistance : 50f;
+    float LeashDistance => aiConfig != null ? aiConfig.leashDistance : 30f;
+    float RecoverySeconds => aiConfig != null ? aiConfig.recoverySeconds : 10f;
+
+    void ApplyConfig()
+    {
+        if (aiConfig == null)
+        {
+            BuildSafeLogger.WarnOnce(nameof(NPC_Basic) + ".MissingConfig", "Missing enemy AI config; using prefab values.", this, nameof(aiConfig));
+            return;
+        }
+
+        MaxHealth = aiConfig.maxHealth;
+        hit2stun = aiConfig.hitToStun;
+        Damage2Player = aiConfig.damageToPlayer;
+        AttackSpeed = aiConfig.attackSpeed;
+        Recovery = aiConfig.recoverySeconds;
+    }
+
     public void RandoMovement()
     {
         BuzzSource.SetActive(true);
-        if ((SpawnPos - transform.position).magnitude < 20)
+        if ((SpawnPos - transform.position).magnitude < LeashDistance)
         {
             Recovered();
             a = Random.Range(-1, 1);

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -7,6 +7,9 @@ using UnityEngine;
 
 public class Behaviour : MonoBehaviour
 {
+    [Header("Config")]
+    [SerializeField] HazardDamageConfig hazardDamageConfig;
+
     [Header("Movement and animation")]
     public Rigidbody Player;
     public bool grounded;
@@ -462,6 +465,9 @@ public class Behaviour : MonoBehaviour
             TouchShroom = false;
         }
     }
+    float ScorpionJawDamage => hazardDamageConfig != null ? hazardDamageConfig.scorpionJawClampDamage : 15f;
+    float ScorpionStingDamage => hazardDamageConfig != null ? hazardDamageConfig.scorpionStingDamage : 30f;
+
     public void OnTriggerEnter(Collider OBJ)
     {
         if (OBJ.gameObject.CompareTag("SwitchMusic"))
@@ -496,7 +502,10 @@ public class Behaviour : MonoBehaviour
             {
                 if (scorpAttack == true)
                 {
-                    TakeDamage(15);
+                    if (CombatDebugGate.AllowsDamage(gameObject))
+                    {
+                        TakeDamage(ScorpionJawDamage);
+                    }
                 }
             }
             else
@@ -508,7 +517,10 @@ public class Behaviour : MonoBehaviour
         {
             if (scorpAttack == true && isParried==false)
             {
-                TakeDamage(30);
+                if (CombatDebugGate.AllowsDamage(gameObject))
+                {
+                    TakeDamage(ScorpionStingDamage);
+                }
             }
         }
     }

--- a/Assets/Scripts/RuntimeHardening.meta
+++ b/Assets/Scripts/RuntimeHardening.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 84ea93da04aa43ca94d1706522244e54
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/RuntimeHardening/CombatDebugGate.cs
+++ b/Assets/Scripts/RuntimeHardening/CombatDebugGate.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class CombatDebugGate : MonoBehaviour
+{
+    [SerializeField] DebugQAConfig debugConfig;
+
+    public bool DamageEnabled => debugConfig == null || !debugConfig.disableCombatDamage;
+
+    public static bool AllowsDamage(GameObject target)
+    {
+        var gate = target != null ? target.GetComponentInParent<CombatDebugGate>() : null;
+        return gate == null || gate.DamageEnabled;
+    }
+}

--- a/Assets/Scripts/RuntimeHardening/CombatDebugGate.cs.meta
+++ b/Assets/Scripts/RuntimeHardening/CombatDebugGate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca59dcc4f9f94a9cab31a566232f3837
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/RuntimeHardening/PrefabRuntimeHardening.cs
+++ b/Assets/Scripts/RuntimeHardening/PrefabRuntimeHardening.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class PrefabRuntimeHardening : MonoBehaviour
+{
+    [SerializeField] DebugQAConfig debugConfig;
+    [SerializeField] Component[] requiredComponents;
+    [SerializeField] GameObject[] requiredObjects;
+
+    void Awake()
+    {
+        if (debugConfig != null && !debugConfig.enableRuntimeReferenceValidation)
+        {
+            return;
+        }
+
+        for (int i = 0; i < requiredComponents.Length; i++)
+        {
+            RuntimeReferenceValidator.Require(requiredComponents[i], this, nameof(requiredComponents) + "[" + i + "]");
+        }
+
+        for (int i = 0; i < requiredObjects.Length; i++)
+        {
+            RuntimeReferenceValidator.Require(requiredObjects[i], this, nameof(requiredObjects) + "[" + i + "]");
+        }
+    }
+}

--- a/Assets/Scripts/RuntimeHardening/PrefabRuntimeHardening.cs.meta
+++ b/Assets/Scripts/RuntimeHardening/PrefabRuntimeHardening.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5279260caf244a48496eedb3918558b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
### Motivation
- Provide runtime-configurable tuning for enemies/bosses/hazards and centralized logging while adding prefab-level runtime reference validation and combat debug gating without editing scene instances.

### Description
- Add ScriptableObject types for tuning and QA: `EnemyAIConfig`, `BossConfig`, `HazardDamageConfig`, `DebugQAConfig`, and `LoggingConfig` under `Assets/Scripts/Config` and default assets under `Assets/ScriptableObjects/RuntimeConfig` and `Assets/Resources/RuntimeConfig`.
- Add runtime hardening components `PrefabRuntimeHardening` and `CombatDebugGate` under `Assets/Scripts/RuntimeHardening` and attach them to prefabs (wasp, scorpion boss, player) with serialized references wired in prefab YAML.
- Wire configs into systems and gating: `NPC_Basic`, `ScorpionScript`, `ScorpionDamage`, and `Behaviour` now accept and apply configs at startup and use `CombatDebugGate` to enable/disable damage, and `BuildSafeLogger` now loads `LoggingConfig` from resources to control log output.
- Create/format asset/meta files and prefab edits only (no edits to `Assets/Scenes/Level 1.unity` or `Assets/Scenes/Menu.unity`) and add default runtime assets for immediate use.

### Testing
- Ran `git diff --cached --check` to validate staged changes and fix whitespace issues, which succeeded.
- Verified no scene YAML changes with `git diff --cached --exit-code -- Assets/Scenes/Level\ 1.unity Assets/Scenes/Menu.unity`, which returned success.
- Confirmed staged changes do not include `Assets/Scenes/Level 1.unity` or `Assets/Scenes/Menu.unity` via name-checking, which succeeded.
- Performed repository checks (`git status --short` and targeted `rg` queries) to ensure prefabs were wired and scripts reference configs, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd11872880832a98e983c5812467f2)