### PR TITLE
Add runtime reference validation to gameplay components

### DIFF
--- a/Assets/Prefabs/ProjectEffects/Dummy.prefab
+++ b/Assets/Prefabs/ProjectEffects/Dummy.prefab
@@ -130,7 +130,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Ball: {fileID: 5096351683646873467}
   isArrow: 0
-  RockSound: {fileID: 8047231019028153804}
+  Sound: {fileID: 8047231019028153804}
   clock: 3
   forwardVel: 70
   upwardVel: 10

--- a/Assets/Scripts/NPC/Scorpion/ScorpionDamage.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionDamage.cs
@@ -14,8 +14,22 @@ public class ScorpionDamage : MonoBehaviour
     private void Awake()
     {
         ApplyConfig();
-        BossAudio = GameObject.FindGameObjectWithTag("Boss").GetComponent<NPC_Audio>();
+        var bossObject = GameObject.FindGameObjectWithTag("Boss");
+        BossAudio = bossObject != null ? bossObject.GetComponent<NPC_Audio>() : null;
+        Scorpion = bossObject != null ? bossObject.GetComponent<ScorpionScript>() : null;
         Player = transform.GetComponent<Behaviour>();
+
+        if (!ValidateReferences())
+        {
+            return;
+        }
+    }
+
+    bool ValidateReferences()
+    {
+        return RuntimeReferenceValidator.Require(Player, this, nameof(Player)) &
+            RuntimeReferenceValidator.Require(BossAudio, this, nameof(BossAudio)) &
+            RuntimeReferenceValidator.Require(Scorpion, this, nameof(Scorpion));
     }
     float ParryChipDamage => damageConfig != null ? damageConfig.scorpionParryChipDamage : 6f;
     int ParryCounterDamage => damageConfig != null ? damageConfig.scorpionParryCounterDamage : 10;

--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -54,7 +54,14 @@ public class ScorpionScript : MonoBehaviour
     {
         ApplyConfig();
         RBScorpion = gameObject.GetComponent<Rigidbody>();
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        Player = playerObject != null ? playerObject.GetComponent<Behaviour>() : null;
+
+        if (!ValidateReferences())
+        {
+            return;
+        }
+
         //AnotherScorpion = GameObject.FindGameObjectWithTag("Scorpion");
         Physics.IgnoreLayerCollision(10, 10);
 
@@ -65,6 +72,33 @@ public class ScorpionScript : MonoBehaviour
         resetCharge = chargeClock;
         initialStun = StunnedClock;
         combo = 0;
+    }
+
+    bool ValidateReferences()
+    {
+        bool valid = RuntimeReferenceValidator.Require(RBScorpion, this, nameof(RBScorpion)) &
+            RuntimeReferenceValidator.Require(Scorpion, this, nameof(Scorpion)) &
+            RuntimeReferenceValidator.Require(BossHealth, this, nameof(BossHealth)) &
+            RuntimeReferenceValidator.Require(Player, this, nameof(Player)) &
+            RuntimeReferenceValidator.Require(Jaw1A, this, nameof(Jaw1A)) &
+            RuntimeReferenceValidator.Require(Jaw1B, this, nameof(Jaw1B)) &
+            RuntimeReferenceValidator.Require(Jaw2A, this, nameof(Jaw2A)) &
+            RuntimeReferenceValidator.Require(Jaw2B, this, nameof(Jaw2B)) &
+            RuntimeReferenceValidator.Require(Sting, this, nameof(Sting)) &
+            RuntimeReferenceValidator.Require(HitEffect, this, nameof(HitEffect)) &
+            RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion)) &
+            RuntimeReferenceValidator.Require(StunEffect, this, nameof(StunEffect)) &
+            RuntimeReferenceValidator.Require(Sound, this, nameof(Sound));
+
+        if (drops != null)
+        {
+            for (int i = 0; i < drops.Length; i++)
+            {
+                valid &= RuntimeReferenceValidator.Require(drops[i], this, $"{nameof(drops)}[{i}]");
+            }
+        }
+
+        return valid;
     }
 
     void ApplyConfig()

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -62,11 +62,38 @@ public class NPC_Basic : MonoBehaviour
         Wasp = GetComponent<Animator>();
         CurrentHealth = MaxHealth;
         PlayerTarget = GameObject.FindGameObjectWithTag("Player");
-        PlayerHealth = PlayerTarget.GetComponent<Behaviour>();
+        PlayerHealth = PlayerTarget != null ? PlayerTarget.GetComponent<Behaviour>() : null;
+
+        if (!ValidateReferences())
+        {
+            return;
+        }
+
         HitEffect.SetActive(false);
         RandoMovement();
         NPC.velocity = Vector3.forward;
         BuzzSource.SetActive(true);
+    }
+
+    bool ValidateReferences()
+    {
+        bool valid = RuntimeReferenceValidator.Require(NPC, this, nameof(NPC)) &
+            RuntimeReferenceValidator.Require(Wasp, this, nameof(Wasp)) &
+            RuntimeReferenceValidator.Require(PlayerTarget, this, "Player tag") &
+            RuntimeReferenceValidator.Require(PlayerHealth, this, nameof(PlayerHealth)) &
+            RuntimeReferenceValidator.Require(NPCHealthBar, this, nameof(NPCHealthBar)) &
+            RuntimeReferenceValidator.Require(HitEffect, this, nameof(HitEffect)) &
+            RuntimeReferenceValidator.Require(SlashEffect, this, nameof(SlashEffect)) &
+            RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion)) &
+            RuntimeReferenceValidator.Require(Sound, this, nameof(Sound)) &
+            RuntimeReferenceValidator.Require(BuzzSource, this, nameof(BuzzSource)) &
+            RuntimeReferenceValidator.Require(Body, this, nameof(Body)) &
+            RuntimeReferenceValidator.Require(Head, this, nameof(Head)) &
+            RuntimeReferenceValidator.Require(Wing, this, nameof(Wing)) &
+            RuntimeReferenceValidator.Require(Leg, this, nameof(Leg)) &
+            RuntimeReferenceValidator.Require(Reward, this, nameof(Reward));
+
+        return valid;
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/Objects/Hive/Static_Hive.cs
+++ b/Assets/Scripts/Objects/Hive/Static_Hive.cs
@@ -24,8 +24,33 @@ public class Static_Hive : MonoBehaviour
     //Start is called before the first frame update
     public void Start()
     {
+        if (!ValidateReferences())
+        {
+            return;
+        }
+
         CurrentHealth = MaxHealth;
         Explosion.SetActive(false);
+    }
+
+    bool ValidateReferences()
+    {
+        bool valid = RuntimeReferenceValidator.Require(HiveBar, this, nameof(HiveBar)) &
+            RuntimeReferenceValidator.Require(Hive, this, nameof(Hive)) &
+            RuntimeReferenceValidator.Require(Wasp, this, nameof(Wasp)) &
+            RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion)) &
+            RuntimeReferenceValidator.Require(Sound, this, nameof(Sound)) &
+            RuntimeReferenceValidator.Require(HitEffect, this, nameof(HitEffect));
+
+        if (SpawnedObjects != null)
+        {
+            for (int i = 0; i < SpawnedObjects.Length; i++)
+            {
+                valid &= RuntimeReferenceValidator.Require(SpawnedObjects[i], this, $"{nameof(SpawnedObjects)}[{i}]");
+            }
+        }
+
+        return valid;
     }
     private void LateUpdate()
     {

--- a/Assets/Scripts/Objects/Hive/WaspSpawner.cs
+++ b/Assets/Scripts/Objects/Hive/WaspSpawner.cs
@@ -18,7 +18,20 @@ public class WaspSpawner : MonoBehaviour
     { 
         Counter=WaspCounter;
         RealClock = SpawnClock;
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        Player = playerObject != null ? playerObject.GetComponent<Behaviour>() : null;
+
+        if (!ValidateReferences())
+        {
+            return;
+        }
+    }
+
+    bool ValidateReferences()
+    {
+        return RuntimeReferenceValidator.Require(Wasp, this, nameof(Wasp)) &
+            RuntimeReferenceValidator.Require(Hive, this, nameof(Hive)) &
+            RuntimeReferenceValidator.Require(Player, this, nameof(Player));
     }
 
 

--- a/Assets/Scripts/Player/BossHandler.cs
+++ b/Assets/Scripts/Player/BossHandler.cs
@@ -18,9 +18,25 @@ public class BossHandler : MonoBehaviour
     void Start()
     {
         player = gameObject.GetComponent<Behaviour>();
-        Boss = GameObject.Find("ScorpionBoss").GetComponent<ScorpionScript>();
+        var bossObject = GameObject.Find("ScorpionBoss");
+        Boss = bossObject != null ? bossObject.GetComponent<ScorpionScript>() : null;
+
+        if (!ValidateReferences())
+        {
+            return;
+        }
+
         //bossSound = Boss.GetComponent<NPC_Audio>();
         BossBar.SetActive(false);
+    }
+
+    bool ValidateReferences()
+    {
+        return RuntimeReferenceValidator.Require(player, this, nameof(player)) &
+            RuntimeReferenceValidator.Require(Boss, this, nameof(Boss)) &
+            RuntimeReferenceValidator.Require(ChatCollider, this, nameof(ChatCollider)) &
+            RuntimeReferenceValidator.Require(BossBar, this, nameof(BossBar)) &
+            RuntimeReferenceValidator.Require(BossPanel, this, nameof(BossPanel));
     }
 
 

--- a/Assets/Scripts/Player/FallDamage.cs
+++ b/Assets/Scripts/Player/FallDamage.cs
@@ -16,7 +16,19 @@ public class FallDamage : MonoBehaviour
     {
         Player = gameObject.GetComponent<Behaviour>();
         RB_Player = gameObject.GetComponent<Rigidbody>();
+
+        if (!ValidateReferences())
+        {
+            return;
+        }
+
         fallReader = 0;
+    }
+
+    bool ValidateReferences()
+    {
+        return RuntimeReferenceValidator.Require(Player, this, nameof(Player)) &
+            RuntimeReferenceValidator.Require(RB_Player, this, nameof(RB_Player));
     }
 
     private void FixedUpdate()

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -18,10 +18,42 @@ public class Projectile : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        Vector3 launchDirection = Camera.main.transform.TransformDirection(Vector3.forward);
+        var mainCamera = Camera.main;
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        Player = playerObject != null ? playerObject.GetComponent<Behaviour>() : null;
+
+        if (!ValidateReferences(mainCamera))
+        {
+            return;
+        }
+
+        Vector3 launchDirection = mainCamera.transform.TransformDirection(Vector3.forward);
         Physics.IgnoreLayerCollision(1, 3);
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
         Ball.velocity = launchDirection * forwardVel + Vector3.up * upwardVel;
+    }
+
+    bool ValidateReferences(Camera mainCamera)
+    {
+        bool valid = RuntimeReferenceValidator.Require(mainCamera, this, nameof(mainCamera)) &
+            RuntimeReferenceValidator.Require(Player, this, nameof(Player)) &
+            RuntimeReferenceValidator.Require(Ball, this, nameof(Ball));
+
+        if (isFireBall)
+        {
+            valid &= RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion));
+        }
+
+        if (isArrow)
+        {
+            valid &= RuntimeReferenceValidator.Require(arrowPickup, this, nameof(arrowPickup));
+        }
+
+        if (!isFireBall)
+        {
+            valid &= RuntimeReferenceValidator.Require(Sound, this, nameof(Sound));
+        }
+
+        return valid;
     }
     private void Update()
     {


### PR DESCRIPTION
### Motivation
- Prevent null-reference crashes by validating critical serialized and resolved references early in affected components. 
- Ensure missing refs are logged once and only the broken component is disabled, not whole prefabs or scenes. 

### Description
- Added `ValidateReferences()` (calls to `RuntimeReferenceValidator.Require(...)`) and early exit guards to `NPC_Basic`, `ScorpionScript`, `ScorpionDamage`, `Static_Hive`, `WaspSpawner`, `BossHandler`, `FallDamage`, and `Projectile` in `Awake`/`Start` as appropriate. 
- Made tag/component lookups null-safe (resolve `GameObject.Find...` to local var, `GetComponent` only when object exists) before validation to avoid derefs. 
- `RuntimeReferenceValidator.Require` usage follows existing pattern (logs once via `BuildSafeLogger.WarnOnce` and disables only the owner component on failure). 
- Updated `Assets/Prefabs/ProjectEffects/Dummy.prefab` to wire the prefab audio field to the serialized `Sound` property (replaced legacy `RockSound` key). 

### Testing
- Ran `git diff --check` to validate no whitespace/errors (passed). 
- Ran automated presence checks (Python/rg) that assert each modified script contains `ValidateReferences()` and `RuntimeReferenceValidator.Require()` (passed). 
- Verified prefab field rename in `Assets/Prefabs/ProjectEffects/Dummy.prefab` via `rg`/file inspection to ensure `Sound` serialized field exists (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd13c0703c832a96871795284dd02e)