### PR TITLE
Add centralized player failure handling

### DIFF
--- a/Assets/Prefabs/OtterPlayer/OtterAnimations/OtterPlayer.prefab
+++ b/Assets/Prefabs/OtterPlayer/OtterAnimations/OtterPlayer.prefab
@@ -18073,6 +18073,7 @@ GameObject:
   - component: {fileID: 7080714720866271190}
   - component: {fileID: 7080714720866270766}
   - component: {fileID: 7080714720866270764}
+  - component: {fileID: 3495515188903705103}
   m_Layer: 0
   m_Name: OtterPlayer
   m_TagString: Player
@@ -18172,6 +18173,19 @@ MonoBehaviour:
   Wallet: 
   GM: {fileID: 0}
   AimIcon: {fileID: 0}
+--- !u!114 &3495515188903705103
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7080714720866271186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4aa3be0aba8d4d7aa554c8a5d6996fc6, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  owner: {fileID: 7080714720866271184}
 --- !u!114 &7080714720866271185
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
+++ b/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
@@ -29812,6 +29812,7 @@ GameObject:
   - component: {fileID: 9000000000000000008}
   - component: {fileID: 9003000000000000001}
   - component: {fileID: 9003000000000000002}
+  - component: {fileID: 9003000000000000003}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -83502,3 +83503,16 @@ MonoBehaviour:
   - {fileID: 4580562239172740854}
   - {fileID: 4580562239172740878}
   requiredObjects: []
+--- !u!114 &9003000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4580562239172740874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4aa3be0aba8d4d7aa554c8a5d6996fc6, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  owner: {fileID: 4580562239172740872}

--- a/Assets/Prefabs/OtterPlayer/Player Updated.prefab
+++ b/Assets/Prefabs/OtterPlayer/Player Updated.prefab
@@ -66569,6 +66569,7 @@ GameObject:
   - component: {fileID: 8668838197977538418}
   - component: {fileID: 7624992565179513018}
   - component: {fileID: 7624992565179513016}
+  - component: {fileID: 157913311816747088}
   m_Layer: 3
   m_Name: Player Updated
   m_TagString: Player
@@ -66838,6 +66839,19 @@ MonoBehaviour:
   FreeLook: {fileID: 1427810939599441655}
   CamForTraders: {fileID: 3156488547051756512}
   ChangeSpeech: 1
+--- !u!114 &157913311816747088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7624992565179513158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4aa3be0aba8d4d7aa554c8a5d6996fc6, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  owner: {fileID: 7624992565179513156}
 --- !u!114 &7624992565179513157
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NPC/Scorpion/ScorpionDamage.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionDamage.cs
@@ -61,12 +61,20 @@ public class ScorpionDamage : MonoBehaviour
                     if (CombatDebugGate.AllowsDamage(Player.gameObject))
                     {
                         Player.TakeDamage(JawClamp);
+                        if (Player.CurrentHealth <= 0)
+                        {
+                            Player.HandleFailure(PlayerFailureReason.BossDamage);
+                        }
                     }
                     BossAudio.Sting();
                 }
                 if (Player.isParried == true)
                 {
                     Player.TakeDamage(ParryChipDamage);
+                    if (Player.CurrentHealth <= 0)
+                    {
+                        Player.HandleFailure(PlayerFailureReason.BossDamage);
+                    }
                     Scorpion.TakeDamage(ParryCounterDamage);
                     Scorpion.combo++;
                 }
@@ -82,12 +90,20 @@ public class ScorpionDamage : MonoBehaviour
                     if (CombatDebugGate.AllowsDamage(Player.gameObject))
                     {
                         Player.TakeDamage(Sting);
+                        if (Player.CurrentHealth <= 0)
+                        {
+                            Player.HandleFailure(PlayerFailureReason.BossDamage);
+                        }
                     }
                     BossAudio.Sting();
                 }
                 if (Player.isParried == true)
                 {
                     Player.TakeDamage(ParryChipDamage);
+                    if (Player.CurrentHealth <= 0)
+                    {
+                        Player.HandleFailure(PlayerFailureReason.BossDamage);
+                    }
                     Scorpion.TakeDamage(ParryCounterDamage);
                     Scorpion.combo++;
                 }

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -179,6 +179,7 @@ public class Behaviour : MonoBehaviour
     PlayerInteractionController interactionController;
     PlayerCombatController combatController;
     PlayerMovementController movementController;
+    PlayerFailureController failureController;
 
 
     PlayerHealthController Health
@@ -267,6 +268,24 @@ public class Behaviour : MonoBehaviour
             }
 
             return movementController;
+        }
+    }
+
+    PlayerFailureController Failure
+    {
+        get
+        {
+            if (failureController == null)
+            {
+                failureController = GetComponent<PlayerFailureController>();
+                if (failureController == null)
+                {
+                    failureController = gameObject.AddComponent<PlayerFailureController>();
+                }
+                failureController.Initialize(this);
+            }
+
+            return failureController;
         }
     }
 
@@ -438,16 +457,7 @@ public class Behaviour : MonoBehaviour
         }
         if (OBJ.gameObject.CompareTag("Strike"))
         {
-            if (Lives > 0)
-            {
-                transform.position = CheckpointService.GetOrCreate().RespawnPosition(new Vector3(1, 1, 1));
-                Instantiate(PopUpEffect, transform.position, Quaternion.identity);
-                Lives--;
-            }
-            if (Lives == 0)
-            {
-                ActivateLooseMenu();
-            }
+            HandleFailure(PlayerFailureReason.Strike);
         }
     }
     public void OnCollisionExit(Collision OBJ)
@@ -505,6 +515,10 @@ public class Behaviour : MonoBehaviour
                     if (CombatDebugGate.AllowsDamage(gameObject))
                     {
                         TakeDamage(ScorpionJawDamage);
+                        if (CurrentHealth <= 0)
+                        {
+                            HandleFailure(PlayerFailureReason.BossDamage);
+                        }
                     }
                 }
             }
@@ -520,6 +534,10 @@ public class Behaviour : MonoBehaviour
                 if (CombatDebugGate.AllowsDamage(gameObject))
                 {
                     TakeDamage(ScorpionStingDamage);
+                    if (CurrentHealth <= 0)
+                    {
+                        HandleFailure(PlayerFailureReason.BossDamage);
+                    }
                 }
             }
         }
@@ -609,6 +627,7 @@ public class Behaviour : MonoBehaviour
         }
     }
     public void TakeDamage(float Damage) => Health.TakeDamage(Damage);
+    public void HandleFailure(PlayerFailureReason reason) => Failure.HandleFailure(reason);
     public void PlayerMove(Vector3 Direction)
     {
         movementInvoked = true;
@@ -795,13 +814,18 @@ public class Behaviour : MonoBehaviour
         }
     }
 
-    public void RestartCheckpoint()
+    public void RestartCheckpoint() => HandleFailure(PlayerFailureReason.CompatibilityRestart);
+
+    public void RestoreHealth()
     {
-        HealthBar.SetHealth(MaxHealth);
         CurrentHealth = MaxHealth;
+        HealthBar.SetHealth(CurrentHealth);
+    }
+
+    public void MoveToCheckpoint()
+    {
         transform.position = CheckpointService.GetOrCreate().LastCheckpointPosition;
         Instantiate(PopUpEffect, transform.position, Quaternion.identity);
-        Lives--;
     }
     void SaveCheckpoint(Vector3 position)
     {
@@ -967,6 +991,7 @@ public class Behaviour : MonoBehaviour
         Interaction.Initialize(this, inputReader);
         Combat.Initialize(this);
         Movement.Initialize(this);
+        Failure.Initialize(this);
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
         CamForTraders.enabled = false;

--- a/Assets/Scripts/Player/BossHandler.cs
+++ b/Assets/Scripts/Player/BossHandler.cs
@@ -83,11 +83,19 @@ public class BossHandler : MonoBehaviour
             if (OBJ.gameObject.CompareTag("ScorpionDamage"))
             {
                 player.TakeDamage(15);
+                if (player.CurrentHealth <= 0)
+                {
+                    player.HandleFailure(PlayerFailureReason.BossDamage);
+                }
                 //bossSound.Sting();
             }
             if (OBJ.gameObject.CompareTag("ScorpionSting"))
             {
                 player.TakeDamage(30);
+                if (player.CurrentHealth <= 0)
+                {
+                    player.HandleFailure(PlayerFailureReason.BossDamage);
+                }
                 //bossSound.Sting();
             }
 

--- a/Assets/Scripts/Player/FallDamage.cs
+++ b/Assets/Scripts/Player/FallDamage.cs
@@ -57,6 +57,10 @@ public class FallDamage : MonoBehaviour
             if (fallReader >= damageVelocity)
             {
                 Player.TakeDamage(fallDamageFactor * fallReader);
+                if (Player.CurrentHealth <= 0)
+                {
+                    Player.HandleFailure(PlayerFailureReason.FallDamage);
+                }
             }
 
         }

--- a/Assets/Scripts/Player/PlayerFailureController.cs
+++ b/Assets/Scripts/Player/PlayerFailureController.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class PlayerFailureController : MonoBehaviour
+{
+    [SerializeField] Behaviour owner;
+    bool isResolvingFailure;
+
+    public void Initialize(Behaviour behaviour)
+    {
+        owner = behaviour;
+    }
+
+    void Awake()
+    {
+        if (owner == null)
+        {
+            owner = GetComponent<Behaviour>();
+        }
+    }
+
+    public void HandleFailure(PlayerFailureReason reason)
+    {
+        if (isResolvingFailure)
+        {
+            return;
+        }
+
+        if (owner == null)
+        {
+            owner = GetComponent<Behaviour>();
+            if (owner == null)
+            {
+                return;
+            }
+        }
+
+        isResolvingFailure = true;
+
+        if (owner.Lives > 1)
+        {
+            owner.Lives--;
+            owner.RestoreHealth();
+            owner.MoveToCheckpoint();
+            isResolvingFailure = false;
+            return;
+        }
+
+        owner.Lives = 0;
+        owner.ActivateLooseMenu();
+    }
+}

--- a/Assets/Scripts/Player/PlayerFailureController.cs.meta
+++ b/Assets/Scripts/Player/PlayerFailureController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4aa3be0aba8d4d7aa554c8a5d6996fc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerFailureReason.cs
+++ b/Assets/Scripts/Player/PlayerFailureReason.cs
@@ -1,0 +1,8 @@
+public enum PlayerFailureReason
+{
+    HealthDepleted,
+    Strike,
+    FallDamage,
+    BossDamage,
+    CompatibilityRestart
+}

--- a/Assets/Scripts/Player/PlayerFailureReason.cs.meta
+++ b/Assets/Scripts/Player/PlayerFailureReason.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76c10cec8f4b42e9969b7f94ddd2cf3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerHealthController.cs
+++ b/Assets/Scripts/Player/PlayerHealthController.cs
@@ -91,14 +91,7 @@ public class PlayerHealthController : MonoBehaviour
             return;
         }
 
-        if (owner.Lives > 0)
-        {
-            owner.RestartCheckpoint();
-        }
-        if (owner.Lives == 0)
-        {
-            owner.ActivateLooseMenu();
-        }
+        owner.HandleFailure(PlayerFailureReason.HealthDepleted);
     }
 
     public void TickHurtHealEffects()


### PR DESCRIPTION
### Motivation
- Centralize life/death resolution to a single handler to unify behavior across hazards and boss damage.
- Provide a single integration point for future failure flows (respawn vs game over) and keep backward compatibility with existing `RestartCheckpoint()` calls.

### Description
- Add `Assets/Scripts/Player/PlayerFailureController.cs` with `HandleFailure(PlayerFailureReason)` and an `isResolvingFailure` guard that prevents reentry. 
- Add `Assets/Scripts/Player/PlayerFailureReason.cs` enum containing `HealthDepleted`, `Strike`, `FallDamage`, `BossDamage`, and `CompatibilityRestart` reasons. 
- Route death/failure events to the new handler from `PlayerHealthController.HandleDeathState`, `Behaviour.OnCollisionEnter("Strike")`, `FallDamage`, boss damage handlers (`BossHandler` and `ScorpionDamage`), and add `Behaviour.HandleFailure(...)` as a thin forwarder to `Failure.HandleFailure(...)`. 
- Keep `Behaviour.RestartCheckpoint()` as a compatibility wrapper and add `Behaviour.RestoreHealth()`/`Behaviour.MoveToCheckpoint()` helpers used by the failure controller, and add the `PlayerFailureController` component to player prefabs with the `owner` reference wired. 

### Testing
- Ran `git diff --check` and fixed trailing-whitespace warnings; check passed. (success)
- Ran a prefab wiring validation script to ensure `PlayerFailureController` is present and `owner` is wired on player prefabs; validation passed. (success)
- Checked for Unity CLI in environment (not available), so no editor playtests were run here. (info)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd156e5868832a9962a44b7fabdd8a)