### PR TITLE
Refactor enemy AI states

### DIFF
--- a/Assets/Scripts/Combat/EnemyState.cs
+++ b/Assets/Scripts/Combat/EnemyState.cs
@@ -1,0 +1,11 @@
+public enum EnemyState
+{
+    Idle,
+    Patrol,
+    Detect,
+    Chase,
+    Attack,
+    Recover,
+    Stunned,
+    Dead
+}

--- a/Assets/Scripts/Combat/EnemyState.cs.meta
+++ b/Assets/Scripts/Combat/EnemyState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3574f73e45ef464f861b9adedf964d69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class ScorpionScript : MonoBehaviour, IDamageable
@@ -32,7 +30,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable
     public Collider Jaw2A;
     public Collider Jaw2B;
     public Collider Sting;
-    public string state = "Idle";
+    [SerializeField] private EnemyState state = EnemyState.Idle;
 
     [Header("Mobility")]
     public float lookDistance;
@@ -119,59 +117,59 @@ public class ScorpionScript : MonoBehaviour, IDamageable
         attackDistance = bossConfig.attackDistance;
     }
 
+    public void SetState(EnemyState next)
+    {
+        if (state == next)
+        {
+            return;
+        }
+
+        if (state == EnemyState.Dead || (state == EnemyState.Stunned && next != EnemyState.Recover && next != EnemyState.Dead))
+        {
+            return;
+        }
+
+        state = next;
+
+        if (next == EnemyState.Recover)
+        {
+            Recovered();
+            state = EnemyState.Idle;
+        }
+        else if (next == EnemyState.Dead)
+        {
+            Death();
+        }
+    }
+
     public void FixedUpdate()
     {
         Distance = Player.transform.position - RBScorpion.position;
         currentDistance = Mathf.Abs(Distance.magnitude);
         switch (state)
         {
-            case "Idle":
-                {
-                    Idle();
-                    break;
-                }
-            case "Look":
-                {
-                    LookAtPlayer();
-                    break;
-                }
-            case "Charge":
-                {
-                    var speed = chargeSpeed;
-                    if (Input.GetKey(KeyCode.LeftShift))
-                    {
-                        speed = paceUp;
-                        Scorpion.speed = 1.05f;
-                    }
-                    else
-                    {
-                        speed = chargeSpeed;
-                        Scorpion.speed = 1;
-                    }
-
-                    Charge(speed);
-                    break;
-                }
-            case "Stop":
-                {
-                    StopAndAttack();
-                    break;
-                }
-            case "Reverse":
-                {
-                    Reverse();
-                    break;
-                }
-            case "Stunned":
-                {
-                    Stunned();
-                    break;
-                }
-            case "Recovered":
-                {
-                    Recovered();
-                    break;
-                }
+            case EnemyState.Idle:
+                Idle();
+                break;
+            case EnemyState.Detect:
+                LookAtPlayer();
+                break;
+            case EnemyState.Chase:
+                Scorpion.speed = 1;
+                Charge(chargeSpeed);
+                break;
+            case EnemyState.Patrol:
+                Reverse();
+                break;
+            case EnemyState.Attack:
+                StopAndAttack();
+                break;
+            case EnemyState.Stunned:
+                Stunned();
+                break;
+            case EnemyState.Recover:
+                Recovered();
+                break;
         }
 
 
@@ -180,102 +178,65 @@ public class ScorpionScript : MonoBehaviour, IDamageable
     private void Update()
     {
         HitEffect.SetActive(false);
-        if (combo >= comboLimit)
-        {
-            Stunned();
-            StunnedClock -= Time.deltaTime;
-            if (StunnedClock <= 0)
-            {
-                Recovered();
-            }
-        }
+        Distance = Player.transform.position - RBScorpion.position;
+        currentDistance = Mathf.Abs(Distance.magnitude);
+
         if (CurrentHealth <= 0)
         {
-            Death();
+            SetState(EnemyState.Dead);
+            return;
         }
-        if (combo<comboLimit)
-        {
-            if (combo==1)
-            {
-                state = "Look";
-            }
-            if (combo==3)
-            {
-                state = "Charge";
-            }
-            if (currentDistance > lookDistance)
-            {
-                state = "Idle";
-            }
-            if(currentDistance <= lookDistance)
-            {
-                if (combo<comboLimit-5)
-                {
-                    if (Input.GetKey(KeyCode.Mouse0) || Input.GetKey(KeyCode.Mouse1))
-                    {
-                        if (currentDistance<chargeDistance-10)
-                        {
-                            state = "Reverse";
-                        }
-                        else
-                        {
-                            state = "Look";
-                        }
-                        
-                    }
-                    else
-                    {
-                        if (currentDistance > chargeDistance)
-                        {
-                            state = "Look";
-                        }
-                        if (currentDistance <= chargeDistance)
-                        {
 
-                            if (chargeClock > 0)
-                            {
-                                state = "Charge";
-                                chargeClock -= Time.deltaTime;
-                            }
-                            if (chargeClock <= 0)
-                            {
-                                if (currentDistance > attackDistance)
-                                {
-                                    state = "Charge";
-                                }
-                                else
-                                {
-                                    state = "Stop";
-
-                                    if (Input.GetKeyUp(KeyCode.Mouse0) || Input.GetKeyUp(KeyCode.Mouse1))
-                                    {
-                                        chargeClock = resetCharge;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    state = "Charge";
-                }
-      
-            }
-            
-
-        }
         if (combo >= comboLimit)
         {
-            state = "Stunned";
+            SetState(EnemyState.Stunned);
             StunnedClock -= Time.deltaTime;
             if (StunnedClock <= 0)
             {
-                state = "Recovered";
+                SetState(EnemyState.Recover);
             }
+
+            return;
         }
 
+        if (currentDistance > lookDistance)
+        {
+            SetState(EnemyState.Idle);
+            return;
+        }
 
+        if (combo == 1)
+        {
+            SetState(EnemyState.Detect);
+        }
+
+        if (combo == 3 || combo >= comboLimit - 5)
+        {
+            SetState(EnemyState.Chase);
+            return;
+        }
+
+        if (currentDistance > chargeDistance)
+        {
+            SetState(EnemyState.Detect);
+            return;
+        }
+
+        if (chargeClock > 0)
+        {
+            SetState(EnemyState.Chase);
+            chargeClock -= Time.deltaTime;
+            return;
+        }
+
+        if (currentDistance > attackDistance)
+        {
+            SetState(EnemyState.Chase);
+            return;
+        }
+
+        SetState(EnemyState.Attack);
+        chargeClock = resetCharge;
     }
 
     private void Idle()
@@ -369,7 +330,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable
         isAttacking = false;
         Scorpion.SetBool("Stunned", false);
         combo = 0;
-        StunnedClock = 10;
+        StunnedClock = initialStun;
         StunEffect.SetActive(false);
     }
     private void Death()
@@ -388,7 +349,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable
     {
         if (OBJ.gameObject.CompareTag("Strike"))
         {
-            Death();
+            SetState(EnemyState.Dead);
         }
         if (OBJ.gameObject.CompareTag("Damage"))
         {

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -1,10 +1,18 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 
 public class NPC_Basic : MonoBehaviour, IDamageable
 {
+    enum WaspState
+    {
+        Patrol,
+        Chase,
+        ContactRecover,
+        Stunned,
+        Dead
+    }
+
     [Header("Config")]
     [SerializeField] EnemyAIConfig aiConfig;
 
@@ -14,7 +22,6 @@ public class NPC_Basic : MonoBehaviour, IDamageable
     [Header("Movement")]
     GameObject PlayerTarget;
     Behaviour PlayerHealth;
-    GameObject AnotherWasp;
     public Vector3 Distance;
     public Quaternion rotGoal;
     readonly float steer = 0.5f;
@@ -24,6 +31,9 @@ public class NPC_Basic : MonoBehaviour, IDamageable
     public float Recovery = 10f;
     float ChargeClock = 0.7f;
     bool Contact = false;
+    WaspState state = WaspState.Patrol;
+    Coroutine floatCoroutine;
+    bool refreshPatrolMovement;
     float a;
     float b;
     float c;
@@ -70,6 +80,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable
         }
 
         HitEffect.SetActive(false);
+        SetState(WaspState.Patrol);
         RandoMovement();
         NPC.velocity = Vector3.forward;
         BuzzSource.SetActive(true);
@@ -96,95 +107,161 @@ public class NPC_Basic : MonoBehaviour, IDamageable
         return valid;
     }
 
-    // Update is called once per frame
-    public void FixedUpdate()
+    void Update()
     {
-        AnotherWasp = GameObject.FindGameObjectWithTag("NPC");
-        Vector3 Distance = PlayerTarget.transform.position - transform.position;
+        Distance = PlayerTarget.transform.position - transform.position;
         PlayerDistance = Distance.magnitude;
         ChangeNav -= Time.deltaTime;
-        if (combo < hit2stun)
+
+        if (CurrentHealth <= 0)
         {
-            if (floating == true)
-            {
-                Wasp.SetBool("Sting", false);
-                currentPos = transform.position;
-                FloatOnAir(currentPos);
-            }
-            else
-            {
-                rotGoal = Quaternion.LookRotation(NPC.velocity);
-                transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
-                if (Distance.magnitude >= AggroDistance)
-                {
-                    if (ChangeNav <= 0)
-                    {
-                        BuzzSource.SetActive(true);
-                        Wasp.SetBool("Sting", false);
-                        RandoMovement();
-                    }
-                    else
-                    {
-                        TurnBack();
-                    }
-                }
-
-                if (PlayerDistance < AggroDistance)
-                {
-                    if (Contact == false)
-                    {
-                        BuzzSource.SetActive(true);
-                        ChargeClock = 0.7f;
-                        Physics.IgnoreCollision(AnotherWasp.GetComponent<Collider>(), transform.GetComponent<Collider>());
-                        NPC.velocity = (Distance.normalized * AttackSpeed);
-                        Wasp.SetBool("Sting", true);
-                        ChangeNav = 0;
-                    }
-                    if (Contact == true)
-                    {
-                        Wasp.SetBool("Sting", false);
-                        NPC.AddForce(new Vector3(-Distance.x, 0.01f, -Distance.z).normalized * 0.1f);
-                        transform.rotation = (Quaternion.LookRotation(Distance));
-                        ChargeClock -= Time.deltaTime;
-                        if (ChargeClock <= 0)
-                            Contact = false;
-                    }
-                    
-                }
-            }
-
+            SetState(WaspState.Dead);
+            return;
         }
-        else
+
+        if (combo >= hit2stun)
         {
-            Stunned();
+            SetState(WaspState.Stunned);
             Recovery -= Time.deltaTime;
             if (Recovery <= 0)
             {
-                Recovered();
                 combo = 0;
+                SetState(WaspState.Patrol);
             }
         }
+        else if (Contact)
+        {
+            SetState(WaspState.ContactRecover);
+            ChargeClock -= Time.deltaTime;
+            if (ChargeClock <= 0)
+            {
+                Contact = false;
+            }
+        }
+        else if (PlayerDistance < AggroDistance)
+        {
+            SetState(WaspState.Chase);
+        }
+        else
+        {
+            if (ChangeNav <= 0)
+            {
+                refreshPatrolMovement = true;
+                ChangeNav = 5f;
+            }
 
-        if (!Input.GetKey(KeyCode.Mouse0) || PlayerDistance > 3)
+            SetState(WaspState.Patrol);
+        }
+
+        if (floating)
+        {
+            StartFloat(transform.position);
+        }
+        else
+        {
+            StopFloat();
+        }
+
+        if (PlayerDistance > 3)
         {
             HitEffect.SetActive(false);
             SlashEffect.SetActive(false);
         }
-    }
-    private void LateUpdate()
-    { 
-        if (!Input.GetKey(KeyCode.Mouse0)||Distance.magnitude>6)
+
+        if (PlayerDistance > 6)
         {
             Wasp.SetBool("Beat", false);
         }
-        if (CurrentHealth <= 0)
+    }
+
+    public void FixedUpdate()
+    {
+        if (floating || state == WaspState.Dead)
+        {
+            return;
+        }
+
+        switch (state)
+        {
+            case WaspState.Patrol:
+                RotateTowardVelocity();
+                if (refreshPatrolMovement)
+                {
+                    BuzzSource.SetActive(true);
+                    Wasp.SetBool("Sting", false);
+                    RandoMovement();
+                    refreshPatrolMovement = false;
+                }
+                else
+                {
+                    TurnBack();
+                }
+                break;
+            case WaspState.Chase:
+                RotateTowardVelocity();
+                BuzzSource.SetActive(true);
+                Wasp.SetBool("Sting", true);
+                NPC.velocity = Distance.normalized * AttackSpeed;
+                break;
+            case WaspState.ContactRecover:
+                Wasp.SetBool("Sting", false);
+                NPC.AddForce(new Vector3(-Distance.x, 0.01f, -Distance.z).normalized * 0.1f);
+                transform.rotation = Quaternion.LookRotation(Distance);
+                break;
+            case WaspState.Stunned:
+                Stunned();
+                break;
+        }
+    }
+
+    void SetState(WaspState next)
+    {
+        if (state == next || state == WaspState.Dead)
+        {
+            return;
+        }
+
+        if (state == WaspState.Stunned && next != WaspState.Patrol && next != WaspState.Dead)
+        {
+            return;
+        }
+
+        state = next;
+
+        if (next == WaspState.Chase)
+        {
+            ChargeClock = 0.7f;
+            ChangeNav = 0;
+            var other = GameObject.FindGameObjectWithTag("NPC");
+            if (other != null && other != gameObject)
+            {
+                Physics.IgnoreCollision(other.GetComponent<Collider>(), GetComponent<Collider>());
+            }
+        }
+        else if (next == WaspState.Patrol)
+        {
+            Recovered();
+        }
+        else if (next == WaspState.Dead)
         {
             Death();
         }
     }
 
+    void RotateTowardVelocity()
+    {
+        if (NPC.velocity.sqrMagnitude <= 0.001f)
+        {
+            return;
+        }
+
+        rotGoal = Quaternion.LookRotation(NPC.velocity);
+        transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+    }
+
     private void Death()
     {
+        StopFloat();
         PlayerHealth.Plattering = ("HA! gotcha");
         PlayerHealth.ChangeSpeech = 1;
         Instantiate(Explosion, transform.position + new Vector3(0, 1, 0), transform.rotation);
@@ -220,7 +297,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable
         }
         if (OBJ.gameObject.CompareTag("Strike"))
         {
-            Death();
+            SetState(WaspState.Dead);
         }
         if (OBJ.gameObject.CompareTag("Damage"))
         {
@@ -246,10 +323,27 @@ public class NPC_Basic : MonoBehaviour, IDamageable
     }
 
 
-    void FloatOnAir(Vector3 initialPosition)
+    void StartFloat(Vector3 initialPosition)
     {
-        StartCoroutine(FloatObject(initialPosition));
+        if (floatCoroutine != null)
+        {
+            return;
+        }
+
+        floatCoroutine = StartCoroutine(FloatObject(initialPosition));
     }
+
+    void StopFloat()
+    {
+        if (floatCoroutine == null)
+        {
+            return;
+        }
+
+        StopCoroutine(floatCoroutine);
+        floatCoroutine = null;
+    }
+
     private IEnumerator FloatObject(Vector3 initialPosition)
     {
         float direction = -1.0f;
@@ -269,6 +363,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable
     }
    public void Stunned()
     {
+        StopFloat();
         BuzzSource.SetActive(false);
         floating = false;
         NPC.constraints = RigidbodyConstraints.None;
@@ -308,6 +403,11 @@ public class NPC_Basic : MonoBehaviour, IDamageable
 
     }
 
+    void OnDisable()
+    {
+        StopFloat();
+    }
+
     float AggroDistance => aiConfig != null ? aiConfig.aggroDistance : 50f;
     float LeashDistance => aiConfig != null ? aiConfig.leashDistance : 30f;
     float RecoverySeconds => aiConfig != null ? aiConfig.recoverySeconds : 10f;
@@ -337,7 +437,6 @@ public class NPC_Basic : MonoBehaviour, IDamageable
             b = Random.Range(-0.1f, 0.1f);
             c = Random.Range(-1, 1);
             NPC.velocity = new Vector3(a, b, c);
-            ChangeNav = 5f;
         }
         else 
             NPC.velocity = (SpawnPos - transform.position).normalized * 5;


### PR DESCRIPTION
### Motivation
- Unify and type-safe enemy state machines by replacing fragile string-based states with enums and guarded transitions.
- Separate decision logic (per-frame) from Rigidbody movement (physics) to improve deterministic behavior and avoid polling player input from AI.
- Reduce coroutine leaks and make float/stun handling deterministic via a single coroutine handle and cleanup.

### Description
- Added shared enum `EnemyState` in `Assets/Scripts/Combat/EnemyState.cs` with `Idle, Patrol, Detect, Chase, Attack, Recover, Stunned, Dead`.
- Converted `ScorpionScript.state` from a public string to a private `EnemyState` and added `SetState(EnemyState next)` with guards that prevent invalid transitions and handle `Recover`/`Dead` actions.
- Moved scorpion decision/timer logic into `Update()` and left Rigidbody movement/animation dispatch in `FixedUpdate()` while removing direct `Input` checks from enemy AI.
- Refactored `NPC_Basic` (wasp) to an explicit internal `WaspState` with states `Patrol, Chase, ContactRecover, Stunned, Dead`, made decisions in `Update()`, movement in `FixedUpdate()`, removed direct player input polling, and added a single coroutine handle with `StartFloat`/`StopFloat` and `OnDisable` cleanup.

### Testing
- Ran `git diff --check` with no whitespace errors (passed).
- Ran a brace/parse sanity check via a Python script that validated matched braces in modified C# files (passed).
- Searched for `Input.` usage in the modified files with `rg` to confirm enemy AI no longer polls player input (no matches reported).
- Verified absence of local C# project files for CLI compile (`.csproj`/`.sln`) as part of CI sanity checks (informational).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd18a89328832a8b24497510b5c1e2)