### PR TITLE
Add runtime reset service and implement runtime resets for enemies/hives/spawners

### DIFF
--- a/Assets/Prefabs/OtterPlayer/Player Updated.prefab
+++ b/Assets/Prefabs/OtterPlayer/Player Updated.prefab
@@ -66570,6 +66570,7 @@ GameObject:
   - component: {fileID: 7624992565179513018}
   - component: {fileID: 7624992565179513016}
   - component: {fileID: 157913311816747088}
+  - component: {fileID: 157913311816747089}
   m_Layer: 3
   m_Name: Player Updated
   m_TagString: Player
@@ -66852,6 +66853,19 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier:
   owner: {fileID: 7624992565179513156}
+  runtimeResetService: {fileID: 157913311816747089}
+--- !u!114 &157913311816747089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7624992565179513158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9c64e666ce0249b09bc64c4b77ce67d8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!114 &7624992565179513157
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/IRuntimeResettable.cs
+++ b/Assets/Scripts/Core/IRuntimeResettable.cs
@@ -1,0 +1,4 @@
+public interface IRuntimeResettable
+{
+    void RuntimeReset();
+}

--- a/Assets/Scripts/Core/IRuntimeResettable.cs.meta
+++ b/Assets/Scripts/Core/IRuntimeResettable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af86819aac2940908cdd08e17abc6bf1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/RuntimeResetService.cs
+++ b/Assets/Scripts/Core/RuntimeResetService.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+[DisallowMultipleComponent]
+public sealed class RuntimeResetService : MonoBehaviour
+{
+    static RuntimeResetService instance;
+    readonly List<IRuntimeResettable> resettables = new List<IRuntimeResettable>();
+    Scene cachedScene;
+
+    public static RuntimeResetService Instance => instance;
+
+    void Awake()
+    {
+        instance = this;
+        CacheSceneResettables();
+    }
+
+    void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+        if (instance == this)
+        {
+            instance = null;
+        }
+    }
+
+    void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        CacheSceneResettables();
+    }
+
+    public void ResetAll()
+    {
+        if (cachedScene != gameObject.scene)
+        {
+            CacheSceneResettables();
+        }
+
+        for (int i = 0; i < resettables.Count; i++)
+        {
+            var resettable = resettables[i];
+            if (resettable is Object unityObject && unityObject == null)
+            {
+                continue;
+            }
+
+            resettable?.RuntimeReset();
+        }
+    }
+
+    void CacheSceneResettables()
+    {
+        cachedScene = gameObject.scene;
+        resettables.Clear();
+
+        var behaviours = FindObjectsOfType<MonoBehaviour>(true);
+        for (int i = 0; i < behaviours.Length; i++)
+        {
+            var behaviour = behaviours[i];
+            if (behaviour == null || behaviour == this || behaviour.gameObject.scene != cachedScene)
+            {
+                continue;
+            }
+
+            if (behaviour is IRuntimeResettable resettable)
+            {
+                resettables.Add(resettable);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/RuntimeResetService.cs.meta
+++ b/Assets/Scripts/Core/RuntimeResetService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c64e666ce0249b09bc64c4b77ce67d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -1,6 +1,7 @@
+using System.Collections.Generic;
 using UnityEngine;
 
-public class ScorpionScript : MonoBehaviour, IDamageable
+public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
 {
     [Header("Config")]
     [SerializeField] BossConfig bossConfig;
@@ -46,7 +47,24 @@ public class ScorpionScript : MonoBehaviour, IDamageable
     public GameObject StunEffect;
     public NPC_Audio Sound;
 
-
+    Vector3 initialPosition;
+    Quaternion initialRotation;
+    int initialHealth;
+    int initialCombo;
+    float initialStunnedClock;
+    float initialChargeClock;
+    bool initialIsAttacking;
+    EnemyState initialState;
+    Vector3 initialVelocity;
+    Vector3 initialAngularVelocity;
+    RigidbodyConstraints initialConstraints;
+    bool initialUseGravity;
+    Transform initialExplosionParent;
+    Vector3 initialExplosionLocalPosition;
+    Quaternion initialExplosionLocalRotation;
+    bool initialExplosionActive;
+    readonly Dictionary<string, bool> initialAnimatorBools = new Dictionary<string, bool>();
+    readonly List<GameObject> spawnedOnDeath = new List<GameObject>();
 
     private void Start()
     {
@@ -70,6 +88,115 @@ public class ScorpionScript : MonoBehaviour, IDamageable
         resetCharge = chargeClock;
         initialStun = StunnedClock;
         combo = 0;
+        CaptureRuntimeState();
+    }
+
+    void CaptureRuntimeState()
+    {
+        initialPosition = transform.position;
+        initialRotation = transform.rotation;
+        initialHealth = CurrentHealth;
+        initialCombo = combo;
+        initialStunnedClock = StunnedClock;
+        initialChargeClock = chargeClock;
+        initialIsAttacking = isAttacking;
+        initialState = state;
+
+        if (RBScorpion != null)
+        {
+            initialVelocity = RBScorpion.velocity;
+            initialAngularVelocity = RBScorpion.angularVelocity;
+            initialConstraints = RBScorpion.constraints;
+            initialUseGravity = RBScorpion.useGravity;
+        }
+
+        if (Explosion != null)
+        {
+            initialExplosionParent = Explosion.transform.parent;
+            initialExplosionLocalPosition = Explosion.transform.localPosition;
+            initialExplosionLocalRotation = Explosion.transform.localRotation;
+            initialExplosionActive = Explosion.activeSelf;
+        }
+
+        CaptureAnimatorBools();
+    }
+
+    void CaptureAnimatorBools()
+    {
+        initialAnimatorBools.Clear();
+        if (Scorpion == null)
+        {
+            return;
+        }
+
+        foreach (var parameter in Scorpion.parameters)
+        {
+            if (parameter.type == AnimatorControllerParameterType.Bool)
+            {
+                initialAnimatorBools[parameter.name] = Scorpion.GetBool(parameter.name);
+            }
+        }
+    }
+
+    public void RuntimeReset()
+    {
+        gameObject.SetActive(true);
+        transform.SetPositionAndRotation(initialPosition, initialRotation);
+        CurrentHealth = initialHealth;
+        combo = initialCombo;
+        StunnedClock = initialStunnedClock;
+        chargeClock = initialChargeClock;
+        isAttacking = initialIsAttacking;
+        state = initialState;
+
+        if (RBScorpion != null)
+        {
+            RBScorpion.velocity = initialVelocity;
+            RBScorpion.angularVelocity = initialAngularVelocity;
+            RBScorpion.constraints = initialConstraints;
+            RBScorpion.useGravity = initialUseGravity;
+        }
+
+        if (Scorpion != null)
+        {
+            foreach (var animatorBool in initialAnimatorBools)
+            {
+                Scorpion.SetBool(animatorBool.Key, animatorBool.Value);
+            }
+        }
+
+        if (Explosion != null)
+        {
+            Explosion.transform.SetParent(initialExplosionParent);
+            Explosion.transform.localPosition = initialExplosionLocalPosition;
+            Explosion.transform.localRotation = initialExplosionLocalRotation;
+            Explosion.SetActive(initialExplosionActive);
+        }
+
+        if (HitEffect != null)
+        {
+            HitEffect.SetActive(false);
+        }
+
+        if (StunEffect != null)
+        {
+            StunEffect.SetActive(false);
+        }
+
+        if (BossHealth != null)
+        {
+            BossHealth.SetNPCHealth(CurrentHealth);
+        }
+
+        for (int i = spawnedOnDeath.Count - 1; i >= 0; i--)
+        {
+            if (spawnedOnDeath[i] != null)
+            {
+                Destroy(spawnedOnDeath[i]);
+            }
+        }
+
+        spawnedOnDeath.Clear();
     }
 
     bool ValidateReferences()
@@ -340,7 +467,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable
         Explosion.transform.parent = null;
         foreach (var item in drops)
         {
-            Instantiate(item, gameObject.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+            spawnedOnDeath.Add(Instantiate(item, gameObject.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity));
         }
         gameObject.SetActive(false);
     }

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -1,8 +1,9 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 
-public class NPC_Basic : MonoBehaviour, IDamageable
+public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
 {
     enum WaspState
     {
@@ -64,6 +65,22 @@ public class NPC_Basic : MonoBehaviour, IDamageable
     public GameObject Wing;
     public GameObject Leg;
     public GameObject Reward;
+
+    Vector3 initialPosition;
+    Quaternion initialRotation;
+    int initialHealth;
+    float initialChangeNav;
+    float initialRecovery;
+    float initialChargeClock;
+    bool initialContact;
+    bool initialFloating;
+    WaspState initialState;
+    Vector3 initialVelocity;
+    Vector3 initialAngularVelocity;
+    RigidbodyConstraints initialConstraints;
+    bool initialUseGravity;
+    readonly Dictionary<string, bool> initialAnimatorBools = new Dictionary<string, bool>();
+    readonly List<GameObject> spawnedOnDeath = new List<GameObject>();
     // Start is called before the first frame update    
     public void Start()
     {
@@ -84,6 +101,110 @@ public class NPC_Basic : MonoBehaviour, IDamageable
         RandoMovement();
         NPC.velocity = Vector3.forward;
         BuzzSource.SetActive(true);
+        CaptureRuntimeState();
+    }
+
+    void CaptureRuntimeState()
+    {
+        initialPosition = transform.position;
+        initialRotation = transform.rotation;
+        initialHealth = CurrentHealth;
+        initialChangeNav = ChangeNav;
+        initialRecovery = Recovery;
+        initialChargeClock = ChargeClock;
+        initialContact = Contact;
+        initialFloating = floating;
+        initialState = state;
+
+        if (NPC != null)
+        {
+            initialVelocity = NPC.velocity;
+            initialAngularVelocity = NPC.angularVelocity;
+            initialConstraints = NPC.constraints;
+            initialUseGravity = NPC.useGravity;
+        }
+
+        CaptureAnimatorBools();
+    }
+
+    void CaptureAnimatorBools()
+    {
+        initialAnimatorBools.Clear();
+        if (Wasp == null)
+        {
+            return;
+        }
+
+        foreach (var parameter in Wasp.parameters)
+        {
+            if (parameter.type == AnimatorControllerParameterType.Bool)
+            {
+                initialAnimatorBools[parameter.name] = Wasp.GetBool(parameter.name);
+            }
+        }
+    }
+
+    public void RuntimeReset()
+    {
+        StopFloat();
+        gameObject.SetActive(true);
+        transform.SetPositionAndRotation(initialPosition, initialRotation);
+        SpawnPos = initialPosition;
+        CurrentHealth = initialHealth;
+        ChangeNav = initialChangeNav;
+        Recovery = initialRecovery;
+        ChargeClock = initialChargeClock;
+        Contact = initialContact;
+        floating = initialFloating;
+        state = initialState;
+        combo = 0;
+        refreshPatrolMovement = false;
+
+        if (NPC != null)
+        {
+            NPC.velocity = initialVelocity;
+            NPC.angularVelocity = initialAngularVelocity;
+            NPC.constraints = initialConstraints;
+            NPC.useGravity = initialUseGravity;
+        }
+
+        if (Wasp != null)
+        {
+            foreach (var animatorBool in initialAnimatorBools)
+            {
+                Wasp.SetBool(animatorBool.Key, animatorBool.Value);
+            }
+        }
+
+        if (NPCHealthBar != null)
+        {
+            NPCHealthBar.SetNPCHealth(CurrentHealth);
+        }
+
+        if (HitEffect != null)
+        {
+            HitEffect.SetActive(false);
+        }
+
+        if (SlashEffect != null)
+        {
+            SlashEffect.SetActive(false);
+        }
+
+        if (BuzzSource != null)
+        {
+            BuzzSource.SetActive(true);
+        }
+
+        for (int i = spawnedOnDeath.Count - 1; i >= 0; i--)
+        {
+            if (spawnedOnDeath[i] != null)
+            {
+                Destroy(spawnedOnDeath[i]);
+            }
+        }
+
+        spawnedOnDeath.Clear();
     }
 
     bool ValidateReferences()
@@ -264,20 +385,20 @@ public class NPC_Basic : MonoBehaviour, IDamageable
         StopFloat();
         PlayerHealth.Plattering = ("HA! gotcha");
         PlayerHealth.ChangeSpeech = 1;
-        Instantiate(Explosion, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Body, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Head, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Wing, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Wing, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation);
-        Instantiate(Reward, transform.position + new Vector3(0, 7, 0), transform.rotation);
-        Instantiate(Reward, transform.position + new Vector3(0, 7, 0), transform.rotation);
-        GameObject.Destroy(gameObject);
+        spawnedOnDeath.Add(Instantiate(Explosion, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Body, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Head, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Wing, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Wing, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Leg, transform.position + new Vector3(0, 1, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Reward, transform.position + new Vector3(0, 7, 0), transform.rotation));
+        spawnedOnDeath.Add(Instantiate(Reward, transform.position + new Vector3(0, 7, 0), transform.rotation));
+        gameObject.SetActive(false);
     }
 
     private void OnCollisionEnter(Collision OBJ)

--- a/Assets/Scripts/Objects/Hive/Static_Hive.cs
+++ b/Assets/Scripts/Objects/Hive/Static_Hive.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 
-public class Static_Hive : MonoBehaviour, IDamageable
+public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
 {
     public int MaxHealth = 10000;
     public int CurrentHealth;
@@ -21,6 +21,17 @@ public class Static_Hive : MonoBehaviour, IDamageable
     public AudioSource Sound;
     public GameObject HitEffect;
 
+    Vector3 initialPosition;
+    Quaternion initialRotation;
+    int initialHealth;
+    bool initialHiveActive;
+    Transform initialExplosionParent;
+    Vector3 initialExplosionLocalPosition;
+    Quaternion initialExplosionLocalRotation;
+    bool initialExplosionActive;
+    bool deathResolved;
+    readonly List<GameObject> spawnedOnDeath = new List<GameObject>();
+
     //Start is called before the first frame update
     public void Start()
     {
@@ -31,6 +42,63 @@ public class Static_Hive : MonoBehaviour, IDamageable
 
         CurrentHealth = MaxHealth;
         Explosion.SetActive(false);
+        CaptureRuntimeState();
+    }
+
+    void CaptureRuntimeState()
+    {
+        initialPosition = transform.position;
+        initialRotation = transform.rotation;
+        initialHealth = CurrentHealth;
+        initialHiveActive = Hive.activeSelf;
+
+        if (Explosion != null)
+        {
+            initialExplosionParent = Explosion.transform.parent;
+            initialExplosionLocalPosition = Explosion.transform.localPosition;
+            initialExplosionLocalRotation = Explosion.transform.localRotation;
+            initialExplosionActive = Explosion.activeSelf;
+        }
+    }
+
+    public void RuntimeReset()
+    {
+        transform.SetPositionAndRotation(initialPosition, initialRotation);
+        CurrentHealth = initialHealth;
+        deathResolved = false;
+
+        if (Hive != null)
+        {
+            Hive.SetActive(initialHiveActive);
+        }
+
+        if (Explosion != null)
+        {
+            Explosion.transform.SetParent(initialExplosionParent);
+            Explosion.transform.localPosition = initialExplosionLocalPosition;
+            Explosion.transform.localRotation = initialExplosionLocalRotation;
+            Explosion.SetActive(initialExplosionActive);
+        }
+
+        if (HitEffect != null)
+        {
+            HitEffect.SetActive(false);
+        }
+
+        if (HiveBar != null)
+        {
+            HiveBar.SetNPCHealth(CurrentHealth);
+        }
+
+        for (int i = spawnedOnDeath.Count - 1; i >= 0; i--)
+        {
+            if (spawnedOnDeath[i] != null)
+            {
+                Destroy(spawnedOnDeath[i]);
+            }
+        }
+
+        spawnedOnDeath.Clear();
     }
 
     bool ValidateReferences()
@@ -55,7 +123,7 @@ public class Static_Hive : MonoBehaviour, IDamageable
     private void LateUpdate()
     {
         HitEffect.SetActive(false);
-        if (CurrentHealth <= 0)
+        if (CurrentHealth <= 0 && !deathResolved)
         {
             Death();
         }
@@ -63,18 +131,19 @@ public class Static_Hive : MonoBehaviour, IDamageable
 
     public void Death()
     {
+        deathResolved = true;
         Explosion.SetActive(true);
         Explosion.transform.parent = null;
         foreach (var OBJ in SpawnedObjects)
         {
-            Instantiate(OBJ, gameObject.transform.position, Quaternion.identity);
+            spawnedOnDeath.Add(Instantiate(OBJ, gameObject.transform.position, Quaternion.identity));
 
         }
         for (int i = 0; i < 30; i++)
         {
-            Instantiate(Wasp, gameObject.transform.position, Quaternion.identity);
+            spawnedOnDeath.Add(Instantiate(Wasp, gameObject.transform.position, Quaternion.identity).gameObject);
         }
-        Destroy(Hive);
+        Hive.SetActive(false);
     }
 
     public void TakeDamage(int Damage) => TakeDamage(new DamageEvent { Amount = Damage, Source = null, Point = transform.position, Type = DamageType.Generic, CanStun = false });

--- a/Assets/Scripts/Objects/Hive/WaspSpawner.cs
+++ b/Assets/Scripts/Objects/Hive/WaspSpawner.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class WaspSpawner : MonoBehaviour
+public class WaspSpawner : MonoBehaviour, IRuntimeResettable
 {
     public GameObject Wasp;
     public GameObject Hive;
@@ -13,6 +13,12 @@ public class WaspSpawner : MonoBehaviour
     int Counter;
     public float SpawnClock=15f;
    public float RealClock;
+
+    Vector3 initialPosition;
+    Quaternion initialRotation;
+    int initialCounter;
+    float initialRealClock;
+    readonly List<GameObject> spawnedWasps = new List<GameObject>();
     
     private void Start()
     { 
@@ -25,6 +31,34 @@ public class WaspSpawner : MonoBehaviour
         {
             return;
         }
+
+        CaptureRuntimeState();
+    }
+
+    void CaptureRuntimeState()
+    {
+        initialPosition = transform.position;
+        initialRotation = transform.rotation;
+        initialCounter = Counter;
+        initialRealClock = RealClock;
+    }
+
+    public void RuntimeReset()
+    {
+        transform.SetPositionAndRotation(initialPosition, initialRotation);
+        Counter = initialCounter;
+        RealClock = initialRealClock;
+        Distance = Vector3.zero;
+
+        for (int i = spawnedWasps.Count - 1; i >= 0; i--)
+        {
+            if (spawnedWasps[i] != null)
+            {
+                Destroy(spawnedWasps[i]);
+            }
+        }
+
+        spawnedWasps.Clear();
     }
 
     bool ValidateReferences()
@@ -44,7 +78,7 @@ public class WaspSpawner : MonoBehaviour
             if (Counter > 0)
             {
                Quaternion RotWasp = Quaternion.LookRotation(Distance);
-               Instantiate(Wasp, Hive.transform.position, RotWasp);
+               spawnedWasps.Add(Instantiate(Wasp, Hive.transform.position, RotWasp));
                 Counter--;
             }
             if (Counter <=0)

--- a/Assets/Scripts/Player/PlayerFailureController.cs
+++ b/Assets/Scripts/Player/PlayerFailureController.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 public class PlayerFailureController : MonoBehaviour
 {
     [SerializeField] Behaviour owner;
+    [SerializeField] RuntimeResetService runtimeResetService;
     bool isResolvingFailure;
 
     public void Initialize(Behaviour behaviour)
@@ -16,6 +17,11 @@ public class PlayerFailureController : MonoBehaviour
         if (owner == null)
         {
             owner = GetComponent<Behaviour>();
+        }
+
+        if (runtimeResetService == null)
+        {
+            runtimeResetService = GetComponent<RuntimeResetService>();
         }
     }
 
@@ -42,11 +48,25 @@ public class PlayerFailureController : MonoBehaviour
             owner.Lives--;
             owner.RestoreHealth();
             owner.MoveToCheckpoint();
+            ResetRuntimeState();
             isResolvingFailure = false;
             return;
         }
 
         owner.Lives = 0;
         owner.ActivateLooseMenu();
+    }
+
+    void ResetRuntimeState()
+    {
+        if (runtimeResetService == null)
+        {
+            runtimeResetService = RuntimeResetService.Instance;
+        }
+
+        if (runtimeResetService != null)
+        {
+            runtimeResetService.ResetAll();
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a single scene-level mechanism to reset transient runtime state after a checkpoint respawn. 
- Ensure enemies, spawners and static objects return to their initial runtime state (position/rotation/health/timers/animator/rigidbody) without reloading scenes. 
- Attach the service to a persistent prefab so resets run from code that handles player respawn.

### Description
- Add `IRuntimeResettable` and `RuntimeResetService` which discovers resettables per scene, caches them, and exposes `ResetAll()`; discovery runs on `Awake` and on `SceneManager.sceneLoaded` and uses `FindObjectsOfType<MonoBehaviour>(true)`. 
- Wire `PlayerFailureController` to call `ResetAll()` after `MoveToCheckpoint()` and add a `RuntimeResetService` field resolved from the prefab or `RuntimeResetService.Instance`. 
- Implement `RuntimeReset()` for `NPC_Basic` and `ScorpionScript` capturing and restoring position, rotation, health, timers/state, animator bools, rigidbody velocity/angular velocity/constraints/useGravity, and clearing/rehoming spawned death objects. 
- Implement `RuntimeReset()` for `WaspSpawner` and `Static_Hive` capturing and restoring counters/timers/active state/health and cleaning up spawned objects; death paths now track spawned objects and disable originals instead of immediate destruction.

### Testing
- Ran `git diff --check` and no whitespace/patch errors were reported. 
- Unity editor/CLI was not available in CI (`unity` CLI missing), so editor compile/run tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd1a374e38832aa9bc1fc50144eaef)