### PR TITLE
Route combat feedback through timed emitter

### DIFF
--- a/Assets/Prefabs/Hive/NewHive.prefab
+++ b/Assets/Prefabs/Hive/NewHive.prefab
@@ -351,6 +351,7 @@ GameObject:
   - component: {fileID: 4619415292314880598}
   - component: {fileID: 1833881584578269942}
   - component: {fileID: 5834629351513488892}
+  - component: {fileID: 9003000000000000001}
   m_Layer: 10
   m_Name: NewHive
   m_TagString: Hive
@@ -478,6 +479,31 @@ MonoBehaviour:
   Explosion: {fileID: 5339181585990677648}
   Sound: {fileID: 5834629351513488892}
   HitEffect: {fileID: 7810621778169316528}
+  feedback: {fileID: 9003000000000000001}
+--- !u!114 &9003000000000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7115676670349774032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5eddf2f5ce7442378a32f39e80880024, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  hitEffect:
+    target: {fileID: 7810621778169316528}
+    duration: 0.08
+  slashHitEffect:
+    target: {fileID: 0}
+    duration: 0.08
+  deathEffect:
+    target: {fileID: 5339181585990677648}
+    duration: 0.08
+  hazardEffect:
+    target: {fileID: 7810621778169316528}
+    duration: 0.08
 --- !u!114 &4619415292314880598
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Scorpion/Scorpion.prefab
+++ b/Assets/Prefabs/Scorpion/Scorpion.prefab
@@ -53838,6 +53838,7 @@ GameObject:
   - component: {fileID: 6003487228124988380}
   - component: {fileID: 3962957574859753933}
   - component: {fileID: 6003487228124988373}
+  - component: {fileID: 6003487228124988372}
   m_Layer: 10
   m_Name: Scorpion
   m_TagString: Scorpion
@@ -53909,6 +53910,31 @@ MonoBehaviour:
   Explosion: {fileID: 8530238590734212565}
   StunEffect: {fileID: 2948367004167687818}
   Sound: {fileID: 7866589409725028557}
+  feedback: {fileID: 6003487228124988372}
+--- !u!114 &6003487228124988372
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6003487228124988382}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5eddf2f5ce7442378a32f39e80880024, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  hitEffect:
+    target: {fileID: 3298826728073757572}
+    duration: 0.08
+  slashHitEffect:
+    target: {fileID: 0}
+    duration: 0.08
+  deathEffect:
+    target: {fileID: 8530238590734212565}
+    duration: 0.08
+  hazardEffect:
+    target: {fileID: 3298826728073757572}
+    duration: 0.08
 --- !u!114 &6003487228124988379
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Scorpion/ScorpionBoss.prefab
+++ b/Assets/Prefabs/Scorpion/ScorpionBoss.prefab
@@ -51334,6 +51334,7 @@ GameObject:
   - component: {fileID: 6107630362012945911}
   - component: {fileID: 3561575782887557094}
   - component: {fileID: 9002000000000000001}
+  - component: {fileID: 9002000000000000002}
   m_Layer: 10
   m_Name: ScorpionBoss
   m_TagString: Scorpion
@@ -51401,6 +51402,31 @@ MonoBehaviour:
   Explosion: {fileID: 8211043342563841022}
   StunEffect: {fileID: 3420684630745268385}
   Sound: {fileID: 3272819708306223537}
+  feedback: {fileID: 9002000000000000002}
+--- !u!114 &9002000000000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6107630362012945909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5eddf2f5ce7442378a32f39e80880024, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  hitEffect:
+    target: {fileID: 3050568388787473839}
+    duration: 0.08
+  slashHitEffect:
+    target: {fileID: 0}
+    duration: 0.08
+  deathEffect:
+    target: {fileID: 8211043342563841022}
+    duration: 0.08
+  hazardEffect:
+    target: {fileID: 3050568388787473839}
+    duration: 0.08
 --- !u!114 &6107630362012945904
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Wasp/LVL1 Wasp.prefab
+++ b/Assets/Prefabs/Wasp/LVL1 Wasp.prefab
@@ -15354,6 +15354,7 @@ GameObject:
   - component: {fileID: 4992882469211511398}
   - component: {fileID: 8675218551507148661}
   - component: {fileID: 9001000000000000001}
+  - component: {fileID: 9001000000000000002}
   m_Layer: 10
   m_Name: LVL1 Wasp
   m_TagString: NPC
@@ -15453,6 +15454,7 @@ MonoBehaviour:
   HitEffect: {fileID: 7022265487677813612}
   SlashEffect: {fileID: 8559851003464421313}
   Explosion: {fileID: 1892078723244562, guid: 46876a2780737ec45a19d62f88e5ce56, type: 3}
+  feedback: {fileID: 9001000000000000002}
   Sound: {fileID: 7731927592017154948}
   BuzzSource: {fileID: 3110248994183801233}
   Body: {fileID: 3724478295433116455, guid: 7a893927e808bf64082005bcae3b4f22, type: 3}
@@ -15460,6 +15462,30 @@ MonoBehaviour:
   Wing: {fileID: 8956572691331247483, guid: 5d9e03612385e4843bf7e18348a81546, type: 3}
   Leg: {fileID: 8780894494686982430, guid: a9033b1178bcea14db0934d547c5b242, type: 3}
   Reward: {fileID: 7679416759401954559, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
+--- !u!114 &9001000000000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2969994238874094856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5eddf2f5ce7442378a32f39e80880024, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  hitEffect:
+    target: {fileID: 7022265487677813612}
+    duration: 0.08
+  slashHitEffect:
+    target: {fileID: 8559851003464421313}
+    duration: 0.08
+  deathEffect:
+    target: {fileID: 0}
+    duration: 0.08
+  hazardEffect:
+    target: {fileID: 0}
+    duration: 0.08
 --- !u!114 &2735624339671731889
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Combat/CombatFeedbackEmitter.cs
+++ b/Assets/Scripts/Combat/CombatFeedbackEmitter.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+public sealed class CombatFeedbackEmitter : MonoBehaviour
+{
+    [SerializeField] TimedActiveEffect hitEffect = new TimedActiveEffect();
+    [SerializeField] TimedActiveEffect slashHitEffect = new TimedActiveEffect();
+    [SerializeField] TimedActiveEffect deathEffect = new TimedActiveEffect();
+    [SerializeField] TimedActiveEffect hazardEffect = new TimedActiveEffect();
+
+    public void EmitHit() => hitEffect?.Activate(this);
+
+    public void EmitSlashHit() => slashHitEffect?.Activate(this);
+
+    public void EmitDeath() => deathEffect?.Activate(this);
+
+    public void EmitHazard() => hazardEffect?.Activate(this);
+
+    public void ResetFeedback()
+    {
+        hitEffect?.DeactivateImmediate(this);
+        slashHitEffect?.DeactivateImmediate(this);
+        deathEffect?.DeactivateImmediate(this);
+        hazardEffect?.DeactivateImmediate(this);
+    }
+}

--- a/Assets/Scripts/Combat/CombatFeedbackEmitter.cs.meta
+++ b/Assets/Scripts/Combat/CombatFeedbackEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5eddf2f5ce7442378a32f39e80880024
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -46,6 +46,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
     public GameObject Explosion;
     public GameObject StunEffect;
     public NPC_Audio Sound;
+    [SerializeField] CombatFeedbackEmitter feedback;
 
     Vector3 initialPosition;
     Quaternion initialRotation;
@@ -64,6 +65,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
     Quaternion initialExplosionLocalRotation;
     bool initialExplosionActive;
     readonly Dictionary<string, bool> initialAnimatorBools = new Dictionary<string, bool>();
+    bool isDead;
     readonly List<GameObject> spawnedOnDeath = new List<GameObject>();
 
     private void Start()
@@ -72,6 +74,10 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         RBScorpion = gameObject.GetComponent<Rigidbody>();
         var playerObject = GameObject.FindGameObjectWithTag("Player");
         Player = playerObject != null ? playerObject.GetComponent<Behaviour>() : null;
+        if (feedback == null)
+        {
+            feedback = GetComponent<CombatFeedbackEmitter>();
+        }
 
         if (!ValidateReferences())
         {
@@ -83,7 +89,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
 
         CurrentHealth = MaxHealth;
         Explosion.SetActive(false);
-        HitEffect.SetActive(false);
+        feedback?.ResetFeedback();
         paceUp = chargeSpeed + 2;
         resetCharge = chargeClock;
         initialStun = StunnedClock;
@@ -148,6 +154,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         chargeClock = initialChargeClock;
         isAttacking = initialIsAttacking;
         state = initialState;
+        isDead = false;
 
         if (RBScorpion != null)
         {
@@ -173,10 +180,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
             Explosion.SetActive(initialExplosionActive);
         }
 
-        if (HitEffect != null)
-        {
-            HitEffect.SetActive(false);
-        }
+        feedback?.ResetFeedback();
 
         if (StunEffect != null)
         {
@@ -210,6 +214,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
             RuntimeReferenceValidator.Require(Jaw2A, this, nameof(Jaw2A)) &
             RuntimeReferenceValidator.Require(Jaw2B, this, nameof(Jaw2B)) &
             RuntimeReferenceValidator.Require(Sting, this, nameof(Sting)) &
+            RuntimeReferenceValidator.Require(feedback, this, nameof(feedback)) &
             RuntimeReferenceValidator.Require(HitEffect, this, nameof(HitEffect)) &
             RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion)) &
             RuntimeReferenceValidator.Require(StunEffect, this, nameof(StunEffect)) &
@@ -304,7 +309,6 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
 
     private void Update()
     {
-        HitEffect.SetActive(false);
         Distance = Player.transform.position - RBScorpion.position;
         currentDistance = Mathf.Abs(Distance.magnitude);
 
@@ -402,7 +406,6 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
         RBScorpion.velocity = new Vector3(Distance.x, 0, Distance.z).normalized * speed + new Vector3(0, RBScorpion.velocity.y, 0);
 
-        HitEffect.SetActive(false);
         Scorpion.SetBool("Walk", true);
         Scorpion.SetBool("Backwards", false);
         Scorpion.SetBool("Attack", false);
@@ -433,7 +436,14 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
     public void TakeDamage(DamageEvent damageEvent)
     {
         transform.rotation = rotGoal;
-        HitEffect.SetActive(true);
+        if (damageEvent.Type == DamageType.Hazard)
+        {
+            feedback?.EmitHazard();
+        }
+        else
+        {
+            feedback?.EmitHit();
+        }
         CurrentHealth -= Mathf.RoundToInt(damageEvent.Amount);
         combo++;
         if (damageEvent.CanStun && (damageEvent.Type == DamageType.Projectile || damageEvent.Type == DamageType.Fire))
@@ -462,7 +472,14 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
     }
     private void Death()
     {
+        if (isDead)
+        {
+            return;
+        }
+
+        isDead = true;
         isAttacking = false;
+        feedback?.EmitDeath();
         Explosion.SetActive(true);
         Explosion.transform.parent = null;
         foreach (var item in drops)
@@ -486,6 +503,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         {
             var Tree = OBJ.gameObject.GetComponent<LogSpawner>();
             Tree.DestroyTree(OBJ.transform);
+            feedback?.EmitHazard();
             TakeDamage(10);
             combo = 10;
         }

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -55,6 +55,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
     public GameObject HitEffect;
     public GameObject SlashEffect;
     public GameObject Explosion;
+    [SerializeField] CombatFeedbackEmitter feedback;
 
     [Header("Sound")]
     public NPC_Audio Sound;
@@ -80,6 +81,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
     RigidbodyConstraints initialConstraints;
     bool initialUseGravity;
     readonly Dictionary<string, bool> initialAnimatorBools = new Dictionary<string, bool>();
+    bool isDead;
     readonly List<GameObject> spawnedOnDeath = new List<GameObject>();
     // Start is called before the first frame update    
     public void Start()
@@ -90,13 +92,17 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         CurrentHealth = MaxHealth;
         PlayerTarget = GameObject.FindGameObjectWithTag("Player");
         PlayerHealth = PlayerTarget != null ? PlayerTarget.GetComponent<Behaviour>() : null;
+        if (feedback == null)
+        {
+            feedback = GetComponent<CombatFeedbackEmitter>();
+        }
 
         if (!ValidateReferences())
         {
             return;
         }
 
-        HitEffect.SetActive(false);
+        feedback?.ResetFeedback();
         SetState(WaspState.Patrol);
         RandoMovement();
         NPC.velocity = Vector3.forward;
@@ -157,6 +163,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         Contact = initialContact;
         floating = initialFloating;
         state = initialState;
+        isDead = false;
         combo = 0;
         refreshPatrolMovement = false;
 
@@ -181,15 +188,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
             NPCHealthBar.SetNPCHealth(CurrentHealth);
         }
 
-        if (HitEffect != null)
-        {
-            HitEffect.SetActive(false);
-        }
-
-        if (SlashEffect != null)
-        {
-            SlashEffect.SetActive(false);
-        }
+        feedback?.ResetFeedback();
 
         if (BuzzSource != null)
         {
@@ -214,6 +213,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
             RuntimeReferenceValidator.Require(PlayerTarget, this, "Player tag") &
             RuntimeReferenceValidator.Require(PlayerHealth, this, nameof(PlayerHealth)) &
             RuntimeReferenceValidator.Require(NPCHealthBar, this, nameof(NPCHealthBar)) &
+            RuntimeReferenceValidator.Require(feedback, this, nameof(feedback)) &
             RuntimeReferenceValidator.Require(HitEffect, this, nameof(HitEffect)) &
             RuntimeReferenceValidator.Require(SlashEffect, this, nameof(SlashEffect)) &
             RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion)) &
@@ -281,12 +281,6 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         else
         {
             StopFloat();
-        }
-
-        if (PlayerDistance > 3)
-        {
-            HitEffect.SetActive(false);
-            SlashEffect.SetActive(false);
         }
 
         if (PlayerDistance > 6)
@@ -382,7 +376,14 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
 
     private void Death()
     {
+        if (isDead)
+        {
+            return;
+        }
+
+        isDead = true;
         StopFloat();
+        feedback?.EmitDeath();
         PlayerHealth.Plattering = ("HA! gotcha");
         PlayerHealth.ChangeSpeech = 1;
         spawnedOnDeath.Add(Instantiate(Explosion, transform.position + new Vector3(0, 1, 0), transform.rotation));
@@ -574,31 +575,38 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         Wasp.SetBool("Beat", true);
         Wasp.SetBool("Sting", false);
         CurrentHealth -= Mathf.RoundToInt(damageEvent.Amount);
-        var playerArsenal = PlayerTarget.GetComponent<Behaviour>().Arsenal;
-        var currentWeapon = PlayerTarget.GetComponent<Behaviour>().arsenalBrowser;
-        switch (playerArsenal[currentWeapon])
+        if (damageEvent.Type == DamageType.Hazard)
         {
+            feedback?.EmitHazard();
+            Sound.Beat();
+        }
+        else
+        {
+            var playerArsenal = PlayerTarget.GetComponent<Behaviour>().Arsenal;
+            var currentWeapon = PlayerTarget.GetComponent<Behaviour>().arsenalBrowser;
+            switch (playerArsenal[currentWeapon])
+            {
             case "Bare Hands":
                 {
-                    HitEffect.SetActive(true);
+                    feedback?.EmitHit();
                     Sound.Beat();
                     break;
                 }
             case "Hammers":
                 {
-                    HitEffect.SetActive(true);
+                    feedback?.EmitHit();
                     Sound.Beat();
                     break;
                 }
             case "Bow":
                 {
-                    HitEffect.SetActive(true);
+                    feedback?.EmitHit();
                     Sound.Beat();
                     break;
                 }
             case "ArmorSet":
                 {
-                    SlashEffect.SetActive(true);
+                    feedback?.EmitSlashHit();
                     Sound.LiteSwordDamage();
                     //var playerAnimator = PlayerTarget.GetComponent<Behaviour>().Otter;
                     //var currentClip = playerAnimator.GetComponent<AnimationClip>().ToString();
@@ -614,6 +622,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
                     //}
                     break;
                 }
+            }
         }
         combo++;
         if (damageEvent.CanStun && (damageEvent.Type == DamageType.Projectile || damageEvent.Type == DamageType.Fire))

--- a/Assets/Scripts/Objects/Hive/Static_Hive.cs
+++ b/Assets/Scripts/Objects/Hive/Static_Hive.cs
@@ -20,6 +20,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
     public GameObject Explosion;
     public AudioSource Sound;
     public GameObject HitEffect;
+    [SerializeField] CombatFeedbackEmitter feedback;
 
     Vector3 initialPosition;
     Quaternion initialRotation;
@@ -30,11 +31,17 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
     Quaternion initialExplosionLocalRotation;
     bool initialExplosionActive;
     bool deathResolved;
+    bool isDead;
     readonly List<GameObject> spawnedOnDeath = new List<GameObject>();
 
     //Start is called before the first frame update
     public void Start()
     {
+        if (feedback == null)
+        {
+            feedback = GetComponent<CombatFeedbackEmitter>();
+        }
+
         if (!ValidateReferences())
         {
             return;
@@ -42,6 +49,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
 
         CurrentHealth = MaxHealth;
         Explosion.SetActive(false);
+        feedback?.ResetFeedback();
         CaptureRuntimeState();
     }
 
@@ -66,6 +74,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
         transform.SetPositionAndRotation(initialPosition, initialRotation);
         CurrentHealth = initialHealth;
         deathResolved = false;
+        isDead = false;
 
         if (Hive != null)
         {
@@ -80,10 +89,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
             Explosion.SetActive(initialExplosionActive);
         }
 
-        if (HitEffect != null)
-        {
-            HitEffect.SetActive(false);
-        }
+        feedback?.ResetFeedback();
 
         if (HiveBar != null)
         {
@@ -107,6 +113,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
             RuntimeReferenceValidator.Require(Hive, this, nameof(Hive)) &
             RuntimeReferenceValidator.Require(Wasp, this, nameof(Wasp)) &
             RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion)) &
+            RuntimeReferenceValidator.Require(feedback, this, nameof(feedback)) &
             RuntimeReferenceValidator.Require(Sound, this, nameof(Sound)) &
             RuntimeReferenceValidator.Require(HitEffect, this, nameof(HitEffect));
 
@@ -122,7 +129,6 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
     }
     private void LateUpdate()
     {
-        HitEffect.SetActive(false);
         if (CurrentHealth <= 0 && !deathResolved)
         {
             Death();
@@ -131,7 +137,14 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
 
     public void Death()
     {
+        if (isDead)
+        {
+            return;
+        }
+
+        isDead = true;
         deathResolved = true;
+        feedback?.EmitDeath();
         Explosion.SetActive(true);
         Explosion.transform.parent = null;
         foreach (var OBJ in SpawnedObjects)
@@ -150,7 +163,14 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
 
     public void TakeDamage(DamageEvent damageEvent)
     {
-        HitEffect.SetActive(true);
+        if (damageEvent.Type == DamageType.Hazard)
+        {
+            feedback?.EmitHazard();
+        }
+        else
+        {
+            feedback?.EmitHit();
+        }
         CurrentHealth -= Mathf.RoundToInt(damageEvent.Amount);
         Sound.Play();
         HiveBar.SetNPCHealth(CurrentHealth);

--- a/Assets/Scripts/Player/AnimatedAttack.cs
+++ b/Assets/Scripts/Player/AnimatedAttack.cs
@@ -23,7 +23,9 @@ public class AnimatedAttack : MonoBehaviour
         {
             if (enemy.name != null)
             {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
                 Debug.Log("Hit " + enemy.name);
+#endif
             }
             if (enemy.TryGetComponent(out IDamageable damageable))
             {

--- a/Assets/Scripts/Utilities.meta
+++ b/Assets/Scripts/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9366564d4623422dabacb624802a4fe4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utilities/TimedActiveEffect.cs
+++ b/Assets/Scripts/Utilities/TimedActiveEffect.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using UnityEngine;
+
+[System.Serializable]
+public sealed class TimedActiveEffect
+{
+    [SerializeField] GameObject target;
+    [SerializeField, Min(0f)] float duration = 0.08f;
+
+    Coroutine deactivateRoutine;
+
+    public GameObject Target => target;
+
+    public void Activate(MonoBehaviour owner) => Activate(owner, duration);
+
+    public void Activate(MonoBehaviour owner, float activeSeconds)
+    {
+        if (owner == null || target == null)
+        {
+            return;
+        }
+
+        if (deactivateRoutine != null)
+        {
+            owner.StopCoroutine(deactivateRoutine);
+        }
+
+        target.SetActive(true);
+        deactivateRoutine = owner.StartCoroutine(DeactivateAfter(activeSeconds));
+    }
+
+    public void DeactivateImmediate(MonoBehaviour owner)
+    {
+        if (owner != null && deactivateRoutine != null)
+        {
+            owner.StopCoroutine(deactivateRoutine);
+        }
+
+        deactivateRoutine = null;
+
+        if (target != null)
+        {
+            target.SetActive(false);
+        }
+    }
+
+    IEnumerator DeactivateAfter(float activeSeconds)
+    {
+        if (activeSeconds > 0f)
+        {
+            yield return new WaitForSeconds(activeSeconds);
+        }
+
+        if (target != null)
+        {
+            target.SetActive(false);
+        }
+
+        deactivateRoutine = null;
+    }
+}

--- a/Assets/Scripts/Utilities/TimedActiveEffect.cs.meta
+++ b/Assets/Scripts/Utilities/TimedActiveEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cddcfc4e5d64724a9dfd6ae5991c1e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Centralize visual/audio hit/death/hazard feedback into a one-shot, timed emitter to replace per-frame `SetActive(false)` polling and avoid duplicated death effects.

### Description
- Add `TimedActiveEffect` (`Assets/Scripts/Utilities/TimedActiveEffect.cs`) and `CombatFeedbackEmitter` (`Assets/Scripts/Combat/CombatFeedbackEmitter.cs`) to provide reusable timed one-shot activation APIs (`Activate`, `DeactivateImmediate`, `EmitHit/EmitSlashHit/EmitDeath/EmitHazard`).
- Update `NPC_Basic`, `ScorpionScript`, and `Static_Hive` to use a serialized `feedback` field, route hit/death/hazard events through the emitter, add `isDead` guards to `Death` handlers, and reset feedback on start/reset; update `ValidateReferences` to require `feedback`.
- Wire feedback emitter instances on `LVL1 Wasp`, `Scorpion`, `ScorpionBoss`, and `NewHive` prefabs and connect effect targets in prefabs.
- Replace direct `HitEffect`/`SlashEffect` toggles with `feedback?.Emit...()` calls and build-gate the `Debug.Log("Hit ...")` in `AnimatedAttack.cs` under `#if UNITY_EDITOR || DEVELOPMENT_BUILD`.

### Testing
- Ran `git diff --check` with no reported issues (passed).
- Verified per-frame `HitEffect.SetActive(false)` / `SlashEffect.SetActive(false)` removals via `rg` (no remaining matches in modified scripts).
- Verified prefab wiring exists by searching for `feedback:` and the emitter GUID in updated prefabs (present).
- Confirmed `Debug.Log` hit message is wrapped with `#if UNITY_EDITOR || DEVELOPMENT_BUILD` (present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd1dfc4688832a955dfd5c1ba476f8)