### PR TITLE
Cache player references and one-time wasp collision ignores

### DIFF
--- a/Assets/Scripts/Core/PlayerReference.cs
+++ b/Assets/Scripts/Core/PlayerReference.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+public static class PlayerReference
+{
+    static Behaviour cachedPlayer;
+
+    public static bool TryGetPlayer(out Behaviour player)
+    {
+        if (cachedPlayer != null)
+        {
+            player = cachedPlayer;
+            return true;
+        }
+
+        var playerObject = GameObject.FindGameObjectWithTag("Player");
+        if (playerObject == null || !playerObject.TryGetComponent(out cachedPlayer))
+        {
+            player = null;
+            return false;
+        }
+
+        player = cachedPlayer;
+        return true;
+    }
+}

--- a/Assets/Scripts/Core/PlayerReference.cs.meta
+++ b/Assets/Scripts/Core/PlayerReference.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 881ab64733dc4d2dab8a14301830fec2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -72,8 +72,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
     {
         ApplyConfig();
         RBScorpion = gameObject.GetComponent<Rigidbody>();
-        var playerObject = GameObject.FindGameObjectWithTag("Player");
-        Player = playerObject != null ? playerObject.GetComponent<Behaviour>() : null;
+        PlayerReference.TryGetPlayer(out Player);
         if (feedback == null)
         {
             feedback = GetComponent<CombatFeedbackEmitter>();
@@ -501,8 +500,10 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         }
         if (OBJ.gameObject.CompareTag("Bridge"))
         {
-            var Tree = OBJ.gameObject.GetComponent<LogSpawner>();
-            Tree.DestroyTree(OBJ.transform);
+            if (OBJ.gameObject.TryGetComponent(out LogSpawner tree))
+            {
+                tree.DestroyTree(OBJ.transform);
+            }
             feedback?.EmitHazard();
             TakeDamage(10);
             combo = 10;

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -22,6 +22,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
     [SerializeField] Animator Wasp;
     [Header("Movement")]
     GameObject PlayerTarget;
+    Transform playerTransform;
     Behaviour PlayerHealth;
     public Vector3 Distance;
     public Quaternion rotGoal;
@@ -90,8 +91,11 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         SpawnPos = transform.position;
         Wasp = GetComponent<Animator>();
         CurrentHealth = MaxHealth;
-        PlayerTarget = GameObject.FindGameObjectWithTag("Player");
-        PlayerHealth = PlayerTarget != null ? PlayerTarget.GetComponent<Behaviour>() : null;
+        if (PlayerReference.TryGetPlayer(out PlayerHealth))
+        {
+            PlayerTarget = PlayerHealth.gameObject;
+            playerTransform = PlayerHealth.transform;
+        }
         if (feedback == null)
         {
             feedback = GetComponent<CombatFeedbackEmitter>();
@@ -230,7 +234,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
 
     void Update()
     {
-        Distance = PlayerTarget.transform.position - transform.position;
+        Distance = playerTransform.position - transform.position;
         PlayerDistance = Distance.magnitude;
         ChangeNav -= Time.deltaTime;
 
@@ -347,11 +351,6 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         {
             ChargeClock = 0.7f;
             ChangeNav = 0;
-            var other = GameObject.FindGameObjectWithTag("NPC");
-            if (other != null && other != gameObject)
-            {
-                Physics.IgnoreCollision(other.GetComponent<Collider>(), GetComponent<Collider>());
-            }
         }
         else if (next == WaspState.Patrol)
         {
@@ -411,7 +410,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
                 Sting();
             }
             Contact = true;
-            if (OBJ.gameObject.GetComponent<Behaviour>().isParried== true)
+            if (PlayerHealth.isParried == true)
             {
                 TakeDamage(20);
                 combo += 10;
@@ -582,8 +581,8 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         }
         else
         {
-            var playerArsenal = PlayerTarget.GetComponent<Behaviour>().Arsenal;
-            var currentWeapon = PlayerTarget.GetComponent<Behaviour>().arsenalBrowser;
+            var playerArsenal = PlayerHealth.Arsenal;
+            var currentWeapon = PlayerHealth.arsenalBrowser;
             switch (playerArsenal[currentWeapon])
             {
             case "Bare Hands":
@@ -608,7 +607,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
                 {
                     feedback?.EmitSlashHit();
                     Sound.LiteSwordDamage();
-                    //var playerAnimator = PlayerTarget.GetComponent<Behaviour>().Otter;
+                    //var playerAnimator = PlayerHealth.Otter;
                     //var currentClip = playerAnimator.GetComponent<AnimationClip>().ToString();
                     //if (currentClip=="Sword1" || currentClip == "Sword2")
                     //{

--- a/Assets/Scripts/Objects/Hive/WaspSpawner.cs
+++ b/Assets/Scripts/Objects/Hive/WaspSpawner.cs
@@ -7,6 +7,7 @@ public class WaspSpawner : MonoBehaviour, IRuntimeResettable
     public GameObject Wasp;
     public GameObject Hive;
     public Behaviour Player;
+    Transform playerTransform;
     public Vector3 Distance;
     [SerializeField] float SpawnDistance;
     public int WaspCounter=3;
@@ -19,13 +20,16 @@ public class WaspSpawner : MonoBehaviour, IRuntimeResettable
     int initialCounter;
     float initialRealClock;
     readonly List<GameObject> spawnedWasps = new List<GameObject>();
+    readonly List<Collider> spawnedWaspColliders = new List<Collider>();
     
     private void Start()
     { 
         Counter=WaspCounter;
         RealClock = SpawnClock;
-        var playerObject = GameObject.FindGameObjectWithTag("Player");
-        Player = playerObject != null ? playerObject.GetComponent<Behaviour>() : null;
+        if (PlayerReference.TryGetPlayer(out Player))
+        {
+            playerTransform = Player.transform;
+        }
 
         if (!ValidateReferences())
         {
@@ -59,6 +63,7 @@ public class WaspSpawner : MonoBehaviour, IRuntimeResettable
         }
 
         spawnedWasps.Clear();
+        spawnedWaspColliders.Clear();
     }
 
     bool ValidateReferences()
@@ -71,14 +76,14 @@ public class WaspSpawner : MonoBehaviour, IRuntimeResettable
 
     public void Update()
     {
-         Distance = Player.transform.position - gameObject.transform.position;
+         Distance = playerTransform.position - gameObject.transform.position;
 
         if (Mathf.Abs(Distance.magnitude) < SpawnDistance )
         {
             if (Counter > 0)
             {
                Quaternion RotWasp = Quaternion.LookRotation(Distance);
-               spawnedWasps.Add(Instantiate(Wasp, Hive.transform.position, RotWasp));
+               SpawnWasp(RotWasp);
                 Counter--;
             }
             if (Counter <=0)
@@ -98,5 +103,26 @@ public class WaspSpawner : MonoBehaviour, IRuntimeResettable
             Counter = 0;
             RealClock = 0;
         }
+    }
+
+    void SpawnWasp(Quaternion rotation)
+    {
+        var wasp = Instantiate(Wasp, Hive.transform.position, rotation);
+        spawnedWasps.Add(wasp);
+
+        if (!wasp.TryGetComponent(out Collider waspCollider))
+        {
+            return;
+        }
+
+        for (int i = 0; i < spawnedWaspColliders.Count; i++)
+        {
+            if (spawnedWaspColliders[i] != null)
+            {
+                Physics.IgnoreCollision(waspCollider, spawnedWaspColliders[i]);
+            }
+        }
+
+        spawnedWaspColliders.Add(waspCollider);
     }
 }

--- a/Assets/Scripts/Player/BossHandler.cs
+++ b/Assets/Scripts/Player/BossHandler.cs
@@ -18,8 +18,6 @@ public class BossHandler : MonoBehaviour
     void Start()
     {
         player = gameObject.GetComponent<Behaviour>();
-        var bossObject = GameObject.Find("ScorpionBoss");
-        Boss = bossObject != null ? bossObject.GetComponent<ScorpionScript>() : null;
 
         if (!ValidateReferences())
         {
@@ -42,7 +40,7 @@ public class BossHandler : MonoBehaviour
 
     private void Update()
     {
-        if (Boss.transform==null)
+        if (Boss == null)
         {
             BossBar.SetActive(false);
         }

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -19,8 +19,7 @@ public class Projectile : MonoBehaviour
     void Start()
     {
         var mainCamera = Camera.main;
-        var playerObject = GameObject.FindGameObjectWithTag("Player");
-        Player = playerObject != null ? playerObject.GetComponent<Behaviour>() : null;
+        PlayerReference.TryGetPlayer(out Player);
 
         if (!ValidateReferences(mainCamera))
         {
@@ -98,46 +97,6 @@ public class Projectile : MonoBehaviour
             return;
         }
 
-        if (OBJ.gameObject.CompareTag("NPC"))
-        {
-            OBJ.gameObject.GetComponent<NPC_Basic>().TakeDamage(Damage);
-            OBJ.gameObject.GetComponent<NPC_Basic>().combo += OBJ.gameObject.GetComponent<NPC_Basic>().hit2stun;
-            if (isFireBall == true)
-            {
-                Explode();
-            }
-            if (isFireBall == false)
-            {
-                RockHit();
-            }
-            Player.Plattering = "Bam! Take that";
-            Player.ChangeSpeech = 1f;
-        }
-        if (OBJ.gameObject.CompareTag("Scorpion"))
-        {
-            OBJ.gameObject.GetComponent<ScorpionScript>().TakeDamage(Damage);
-            OBJ.gameObject.GetComponent<ScorpionScript>().combo += 3;
-            if (isFireBall == true)
-            {
-                Explode();
-            }
-            if (isFireBall == false)
-            {
-                RockHit();
-            }
-        }
-        if (OBJ.gameObject.CompareTag("Hive"))
-        {
-            OBJ.gameObject.GetComponent<Static_Hive>().TakeDamage(Damage);
-            if (isFireBall == true)
-            {
-                Explode();
-            }
-            if (isFireBall == false)
-            {
-                RockHit();
-            }
-        }
         if (OBJ.gameObject.CompareTag("Isle"))
         {
             if (isFireBall == true)


### PR DESCRIPTION
### Motivation
- Eliminate repeated runtime `FindGameObjectWithTag` / `GameObject.Find` lookups and reduce per-frame `GetComponent` calls by caching player references. 
- Move wasp-vs-wasp collision ignores out of per-frame logic into one-time spawn-time setup to improve physics performance and determinism. 
- Replace unsafe component lookups with safer `TryGetComponent` usage and rely on `IDamageable` dispatch where appropriate. 

### Description
- Added `Assets/Scripts/Core/PlayerReference.cs` with `public static bool TryGetPlayer(out Behaviour player)` to cache the player `Behaviour` lookup. 
- Updated `NPC_Basic` to use `PlayerReference.TryGetPlayer`, cache `playerTransform` and `PlayerHealth`, remove the runtime search that found other NPCs for collision ignoring, and use cached `PlayerHealth` fields for arsenal/parry logic. 
- Updated `Projectile` to use `PlayerReference.TryGetPlayer(out Player)` and rely on `TryDamage`/`IDamageable` for hit dispatch, removing repeated `GetComponent`-based damage paths. 
- Updated `WaspSpawner` to cache `playerTransform`, track spawned wasp colliders in `spawnedWaspColliders`, and call `SpawnWasp` which sets up one-time `Physics.IgnoreCollision` between spawned wasps. 
- Updated `ScorpionScript` to use `PlayerReference.TryGetPlayer` and switched `LogSpawner` access to `TryGetComponent` before calling `DestroyTree`. 
- Removed the scene-name lookup for the scorpion boss in `BossHandler` and rely on a serialized/prefab-wired `Boss` reference, and adjusted the null-check used when toggling the boss UI. 

### Testing
- Ran brace-balance checks for all modified C# files, result: succeeded. 
- Ran `git diff --cached --check` and static regex scans for removed runtime lookup patterns, result: no remaining occurrences in the modified files. 
- Verified changed files compile structurally via balanced-brace validation and basic runtime-safety replacements (`TryGetComponent` / null checks), result: succeeded. 
- Unity editor / playmode tests were not executed in the container because the Unity editor is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd1fd99394832a93eb69e70db91840)