### PR TITLE
Gate gameplay logs with BuildSafeLogger and add editor-config asset

### DIFF
--- a/Assets/Config.meta
+++ b/Assets/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a14cc812f0a24881a7c4132b7c4880f5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Config/LoggingConfig.asset
+++ b/Assets/Config/LoggingConfig.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d86e5a7da0b45d0a634e78212a8289f, type: 3}
+  m_Name: LoggingConfig
+  m_EditorClassIdentifier:
+  logInfo: 1
+  logWarnings: 1
+  logErrors: 1
+  includeSceneName: 1
+  includeOwnerPath: 1

--- a/Assets/Config/LoggingConfig.asset.meta
+++ b/Assets/Config/LoggingConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a02f71227d2745d7984ef0bb82ec785b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/BuildSafeLogger.cs
+++ b/Assets/Scripts/Core/BuildSafeLogger.cs
@@ -1,10 +1,14 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 public static class BuildSafeLogger
 {
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
+    const string LoggingConfigAssetPath = "Assets/Config/LoggingConfig.asset";
     const string LoggingConfigResourcePath = "RuntimeConfig/LoggingConfig";
     static LoggingConfig loggingConfig;
     private static readonly HashSet<string> infoKeys = new HashSet<string>();
@@ -43,7 +47,26 @@ public static class BuildSafeLogger
     }
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
-    static LoggingConfig Config => loggingConfig != null ? loggingConfig : (loggingConfig = Resources.Load<LoggingConfig>(LoggingConfigResourcePath)) ?? ScriptableObject.CreateInstance<LoggingConfig>();
+    static LoggingConfig Config
+    {
+        get
+        {
+            if (loggingConfig != null)
+            {
+                return loggingConfig;
+            }
+
+#if UNITY_EDITOR
+            loggingConfig = AssetDatabase.LoadAssetAtPath<LoggingConfig>(LoggingConfigAssetPath);
+            if (loggingConfig != null)
+            {
+                return loggingConfig;
+            }
+#endif
+
+            return (loggingConfig = Resources.Load<LoggingConfig>(LoggingConfigResourcePath)) ?? ScriptableObject.CreateInstance<LoggingConfig>();
+        }
+    }
 
     private static string ResolveKey(string key, string message, Object owner, string missingField, string missingTag, string missingMethod)
     {

--- a/Assets/Scripts/Objects/Newbridge/MergeCollidersOnCollision.cs
+++ b/Assets/Scripts/Objects/Newbridge/MergeCollidersOnCollision.cs
@@ -10,7 +10,7 @@ public class MergeCollidersOnCollision : MonoBehaviour
     {
         if (collision.gameObject.tag == "Player")
         {
-            Debug.Log("Part added to bridge: " + collision.gameObject.name);
+            BuildSafeLogger.InfoOnce("MergeCollidersOnCollision.PartAdded", "Part added to bridge: " + collision.gameObject.name, this);
             MergeColliders(FirstPart, collision.gameObject);
         }
         

--- a/Assets/Scripts/Objects/Newbridge/NewConstructor.cs
+++ b/Assets/Scripts/Objects/Newbridge/NewConstructor.cs
@@ -132,7 +132,7 @@ public class NewConstructor : MonoBehaviour
         }
         if (bridgeParts.Length==8)
         {
-            Debug.Log("Reached bridge limit! Use a nut to extend");
+            BuildSafeLogger.InfoOnce("NewConstructor.BridgeLimitReached", "Reached bridge limit! Use a nut to extend", this);
         }
         
     }

--- a/Assets/Scripts/Player/AnimatedAttack.cs
+++ b/Assets/Scripts/Player/AnimatedAttack.cs
@@ -21,12 +21,6 @@ public class AnimatedAttack : MonoBehaviour
         Collider[] hitEnemies = Physics.OverlapSphere(origin, range, enemyLayers);
         foreach (Collider enemy in hitEnemies)
         {
-            if (enemy.name != null)
-            {
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
-                Debug.Log("Hit " + enemy.name);
-#endif
-            }
             if (enemy.TryGetComponent(out IDamageable damageable))
             {
                 damageable.TakeDamage(new DamageEvent

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -486,7 +486,7 @@ public class Behaviour : MonoBehaviour, IDamageable
             }
             else
             {
-                Debug.LogWarning("The game object's name is not a valid integer: " + OBJ.gameObject.name);
+                BuildSafeLogger.WarnOnce("Behaviour.SwitchMusic.InvalidName." + OBJ.gameObject.name, "The game object's name is not a valid integer: " + OBJ.gameObject.name, this);
             }
 
         }

--- a/Assets/Scripts/UI/MusicPlaylist.cs
+++ b/Assets/Scripts/UI/MusicPlaylist.cs
@@ -15,12 +15,12 @@ public class MusicPlaylist : MonoBehaviour
         MusicSource = GetComponent<AudioSource>();
         if (MusicSource == null)
         {
-            Debug.LogError("No AudioSource component found on the GameObject.");
+            BuildSafeLogger.ErrorOnce("MusicPlaylist.MissingAudioSource", "No AudioSource component found on the GameObject.", this, missingField: nameof(MusicSource));
             return;
         }
         if (MusicClip.Length == 0)
         {
-            Debug.LogError("No music clips assigned in the MusicClip array.");
+            BuildSafeLogger.ErrorOnce("MusicPlaylist.NoMusicClips", "No music clips assigned in the MusicClip array.", this, missingField: nameof(MusicClip));
             return;
         }
         StartPlaylist();
@@ -81,7 +81,7 @@ public class MusicPlaylist : MonoBehaviour
         }
         else
         {
-            Debug.LogWarning("Invalid song index: " + newSongIndex);
+            BuildSafeLogger.WarnOnce("MusicPlaylist.InvalidSongIndex." + newSongIndex, "Invalid song index: " + newSongIndex, this);
         }
     }
 }

--- a/Assets/Scripts/UI/WayPoint.cs
+++ b/Assets/Scripts/UI/WayPoint.cs
@@ -29,7 +29,7 @@ public class WayPoint : MonoBehaviour
         }
         else
         {
-            Debug.LogError("Index i is out of bounds.");
+            BuildSafeLogger.ErrorOnce("WayPoint.Start.IndexOutOfBounds", "Index i is out of bounds.", this);
         }
     }
 
@@ -91,12 +91,12 @@ public class WayPoint : MonoBehaviour
                 }
                 else
                 {
-                    Debug.LogWarning("Parsed index is out of bounds: " + i);
+                    BuildSafeLogger.WarnOnce("WayPoint.Trigger.ParsedIndexOutOfBounds", "Parsed index is out of bounds: " + i, this);
                 }
             }
             else
             {
-                Debug.LogWarning("Failed to parse waypoint name: " + OBJ.gameObject.name);
+                BuildSafeLogger.WarnOnce("WayPoint.Trigger.ParseFailed." + OBJ.gameObject.name, "Failed to parse waypoint name: " + OBJ.gameObject.name, this);
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Reduce high-frequency and noisy `Debug.Log*` output from gameplay code by routing through once-only helpers. 
- Centralize log gating to respect `UNITY_EDITOR || DEVELOPMENT_BUILD` builds and a runtime config. 
- Provide an editable `LoggingConfig` asset under `Assets/Config/` so editors can tune logging without modifying resources.

### Description
- Load `Assets/Config/LoggingConfig.asset` in-editor via `AssetDatabase.LoadAssetAtPath` and fall back to `Resources.Load` in `BuildSafeLogger` (added `LoggingConfigAssetPath`, `#if UNITY_EDITOR` `using UnityEditor;`).
- Replace gameplay/UI `Debug.Log`, `Debug.LogWarning`, and `Debug.LogError` calls with `BuildSafeLogger.InfoOnce`, `WarnOnce`, and `ErrorOnce` in `Assets/Scripts/UI/WayPoint.cs`, `Assets/Scripts/UI/MusicPlaylist.cs`, `Assets/Scripts/Objects/Newbridge/MergeCollidersOnCollision.cs`, `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`, and `Assets/Scripts/Player/Behaviour.cs`.
- Remove per-combat-hit logging from `Assets/Scripts/Player/AnimatedAttack.cs` to avoid logging every hit.
- Add `Assets/Config/LoggingConfig.asset` and `Assets/Config.meta` (copied from existing `Resources` asset) so the config is available at `Assets/Config/`.

### Testing
- Ran `git diff --check` with no conflicts detected (success). 
- Verified no remaining `Debug.Log*` usages in gameplay scripts with `rg -n "Debug\.Log|Debug\.LogWarning|Debug\.LogError" Assets/Scripts -g '*.cs' -g '!Assets/Scripts/Core/BuildSafeLogger.cs'` (success).
- Committed changes successfully; Unity/editor compile/playmode tests were not run because a Unity executable was not available in the environment (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd21117aa8832aac7c7bbb40ad681e)