### PR TITLE
Centralize scene transitions and game flow control

### DIFF
--- a/Assets/Prefabs/Objects/UI/GameMusic.prefab
+++ b/Assets/Prefabs/Objects/UI/GameMusic.prefab
@@ -14,6 +14,8 @@ GameObject:
   - component: {fileID: 4968688398559378343}
   - component: {fileID: 4968688398559378344}
   - component: {fileID: 4968688398559378345}
+  - component: {fileID: 4968688398559378346}
+  - component: {fileID: 4968688398559378347}
   m_Layer: 5
   m_Name: GameMusic
   m_TagString: Music
@@ -183,5 +185,29 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ceed2cbf5f3d470f81d4370ba7bdfa0a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &4968688398559378346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4968688398559378331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9df28112db774dffa98adda7788af9e2, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &4968688398559378347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4968688398559378331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b95fb80eea43429e8636de54a40675ab, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Scripts/Core/GameFlowController.cs
+++ b/Assets/Scripts/Core/GameFlowController.cs
@@ -9,7 +9,7 @@ public class GameFlowController : MonoBehaviour
 
     public static GameFlowController GetOrCreate()
     {
-        return RuntimeServices.GetOrCreate<GameFlowController>(ServiceLifetime.Scene);
+        return RuntimeServices.GetOrCreate<GameFlowController>(ServiceLifetime.Persistent);
     }
 
     private void Awake()
@@ -25,7 +25,7 @@ public class GameFlowController : MonoBehaviour
             return;
         }
 
-        if (!RuntimeServices.Register(this, ServiceLifetime.Scene))
+        if (!RuntimeServices.Register(this, ServiceLifetime.Persistent))
         {
             return;
         }
@@ -46,23 +46,81 @@ public class GameFlowController : MonoBehaviour
     {
         State = GameFlowState.Playing;
         Time.timeScale = 1f;
+        SetGameplayInput();
     }
 
-    public void SetPaused(bool paused)
+    public bool SetPaused(bool paused)
     {
+        if (State == GameFlowState.GameOver)
+        {
+            BuildSafeLogger.WarnOnce(
+                nameof(GameFlowController) + ".BlockedPauseDuringGameOver",
+                "Blocked pause state change during game over.",
+                this,
+                null,
+                null,
+                nameof(SetPaused));
+            return false;
+        }
+
         State = paused ? GameFlowState.Paused : GameFlowState.Playing;
         Time.timeScale = paused ? 0f : 1f;
+        if (paused)
+        {
+            SetUiInput();
+            return true;
+        }
+
+        SetGameplayInput();
+        return true;
     }
 
-    public void SetGameOver()
+    public bool SetGameOver()
     {
+        if (State == GameFlowState.GameOver)
+        {
+            BuildSafeLogger.WarnOnce(
+                nameof(GameFlowController) + ".BlockedDuplicateGameOver",
+                "Blocked duplicate game-over request.",
+                this,
+                null,
+                null,
+                nameof(SetGameOver));
+            return false;
+        }
+
         State = GameFlowState.GameOver;
         Time.timeScale = 0f;
+        SetInputDisabled();
+        return true;
+    }
+
+    public void SetShop()
+    {
+        State = GameFlowState.Shop;
+        Time.timeScale = 1f;
+        SetUiInput();
     }
 
     public void BeginSceneTransition()
     {
         State = GameFlowState.Transitioning;
         Time.timeScale = 1f;
+        SetInputDisabled();
+    }
+
+    void SetGameplayInput()
+    {
+        GameInputReader.GetOrCreate().EnableGameplayInput();
+    }
+
+    void SetUiInput()
+    {
+        GameInputReader.GetOrCreate().EnableUiInput();
+    }
+
+    void SetInputDisabled()
+    {
+        GameInputReader.GetOrCreate().DisableGameplayInput();
     }
 }

--- a/Assets/Scripts/Core/SceneTransitionService.cs
+++ b/Assets/Scripts/Core/SceneTransitionService.cs
@@ -7,6 +7,7 @@ public class SceneTransitionService : MonoBehaviour
     public static SceneTransitionService Instance { get; private set; }
 
     internal bool isLoading;
+    string loadingSceneName;
 
     public static SceneTransitionService GetOrCreate()
     {
@@ -82,6 +83,7 @@ public class SceneTransitionService : MonoBehaviour
     private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
         isLoading = false;
+        loadingSceneName = null;
     }
 
     private void LoadSceneInternal(string sceneName, bool showCursor)
@@ -91,7 +93,7 @@ public class SceneTransitionService : MonoBehaviour
 
     private void LoadSceneInternal(string sceneName, bool showCursor, bool resetSceneServices)
     {
-        if (!PrepareLoad(showCursor))
+        if (!PrepareLoad(sceneName, showCursor, resetSceneServices))
         {
             return;
         }
@@ -106,7 +108,7 @@ public class SceneTransitionService : MonoBehaviour
 
     private AsyncOperation LoadSceneAsyncInternal(string sceneName, bool showCursor)
     {
-        if (!PrepareLoad(showCursor))
+        if (!PrepareLoad(sceneName, showCursor, false))
         {
             return null;
         }
@@ -114,13 +116,37 @@ public class SceneTransitionService : MonoBehaviour
         return SceneManager.LoadSceneAsync(sceneName);
     }
 
-    private bool PrepareLoad(bool showCursor)
+    private bool PrepareLoad(string sceneName, bool showCursor, bool forceReload)
     {
+        if (string.IsNullOrEmpty(sceneName))
+        {
+            BuildSafeLogger.WarnOnce(
+                nameof(SceneTransitionService) + ".BlockedEmptySceneLoad",
+                "Blocked empty scene load request.",
+                this,
+                null,
+                null,
+                nameof(PrepareLoad));
+            return false;
+        }
+
         if (isLoading)
         {
             BuildSafeLogger.WarnOnce(
-                nameof(SceneTransitionService) + ".BlockedDuplicateSceneLoad",
-                "Blocked duplicate scene load request.",
+                nameof(SceneTransitionService) + ".BlockedDuplicateSceneLoad." + loadingSceneName,
+                "Blocked duplicate scene load request: " + sceneName + ".",
+                this,
+                null,
+                null,
+                nameof(PrepareLoad));
+            return false;
+        }
+
+        if (!forceReload && SceneManager.GetActiveScene().name == sceneName)
+        {
+            BuildSafeLogger.WarnOnce(
+                nameof(SceneTransitionService) + ".BlockedAlreadyActiveScene." + sceneName,
+                "Blocked scene load because scene is already active: " + sceneName + ".",
                 this,
                 null,
                 null,
@@ -129,37 +155,14 @@ public class SceneTransitionService : MonoBehaviour
         }
 
         isLoading = true;
+        loadingSceneName = sceneName;
         GameFlowController.GetOrCreate().BeginSceneTransition();
-        Time.timeScale = 1f;
 
         if (showCursor)
         {
             CursorStateService.GetOrCreate().ShowCursor();
         }
 
-        DisablePlayerInput();
         return true;
-    }
-
-    private void DisablePlayerInput()
-    {
-        var playerObject = GameObject.FindGameObjectWithTag("Player");
-        if (playerObject == null)
-        {
-            BuildSafeLogger.WarnOnce(
-                nameof(SceneTransitionService) + ".MissingPlayer",
-                "Cannot disable player input because Player tag was not found.",
-                this,
-                null,
-                "Player",
-                nameof(DisablePlayerInput));
-            return;
-        }
-
-        var player = playerObject.GetComponent<Behaviour>();
-        if (player != null)
-        {
-            player.enabled = false;
-        }
     }
 }

--- a/Assets/Scripts/Input/GameInputReader.cs
+++ b/Assets/Scripts/Input/GameInputReader.cs
@@ -30,21 +30,21 @@ public class GameInputReader : MonoBehaviour
 
     public static GameInputReader GetOrCreate()
     {
-        return RuntimeServices.GetOrCreate<GameInputReader>(ServiceLifetime.Scene);
+        return RuntimeServices.GetOrCreate<GameInputReader>(ServiceLifetime.Persistent);
     }
 
-    public void EnableGameplayInput()
+    internal void EnableGameplayInput()
     {
         Mode = InputMode.Gameplay;
     }
 
-    public void DisableGameplayInput()
+    internal void DisableGameplayInput()
     {
         Mode = InputMode.Disabled;
         ClearGameplayInput();
     }
 
-    public void EnableUiInput()
+    internal void EnableUiInput()
     {
         Mode = InputMode.Ui;
         ClearGameplayInput();
@@ -58,7 +58,7 @@ public class GameInputReader : MonoBehaviour
             return;
         }
 
-        if (!RuntimeServices.Register(this, ServiceLifetime.Scene))
+        if (!RuntimeServices.Register(this, ServiceLifetime.Persistent))
         {
             return;
         }

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -725,17 +725,19 @@ public class Behaviour : MonoBehaviour, IDamageable
     public void ActivateLooseMenu()
     {
         //MusicOP.StopMusic();
-        GameFlowController.GetOrCreate().SetGameOver();
+        if (!GameFlowController.GetOrCreate().SetGameOver())
+        {
+            return;
+        }
+
         ShowCursor();
         ShowLosePanel();
-        GetInputReader().DisableGameplayInput();
     }
     public void HideLooseMenu()
     {
         //MusicOP.ResumeMusic();
         GameFlowController.GetOrCreate().SetPlaying();
         HideCursor();
-        GetInputReader().EnableGameplayInput();
         HideLosePanel();
     }
 
@@ -949,7 +951,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
 
         inputReader = GameInputReader.GetOrCreate();
-        inputReader.EnableGameplayInput();
+        GameFlowController.GetOrCreate().SetPlaying();
         Inventory.Initialize(this);
         Interaction.Initialize(this, inputReader);
         Combat.Initialize(this);

--- a/Assets/Scripts/Player/PlayerInteractionController.cs
+++ b/Assets/Scripts/Player/PlayerInteractionController.cs
@@ -15,7 +15,6 @@ public class PlayerInteractionController : MonoBehaviour
     public void ShowCursor()
     {
         CursorStateService.GetOrCreate().ShowCursor();
-        GetInputReader().EnableUiInput();
     }
 
     public void HideCursor()
@@ -25,7 +24,7 @@ public class PlayerInteractionController : MonoBehaviour
         var gameFlow = GameFlowController.Instance;
         if (gameFlow == null || gameFlow.State == GameFlowState.Playing)
         {
-            GetInputReader().EnableGameplayInput();
+            GameFlowController.GetOrCreate().SetPlaying();
         }
     }
 
@@ -36,7 +35,7 @@ public class PlayerInteractionController : MonoBehaviour
         {
             ShowCursor();
             owner.isAtTrader = true;
-            GetInputReader().EnableUiInput();
+            GameFlowController.GetOrCreate().SetShop();
             owner.FreeLook.enabled = false;
             owner.CamForTraders.enabled = true;
             owner.CamForTraders.m_LookAt = trader.transform;
@@ -49,7 +48,7 @@ public class PlayerInteractionController : MonoBehaviour
     public void ExitTrader()
     {
         owner.isAtTrader = false;
-        GetInputReader().EnableGameplayInput();
+        GameFlowController.GetOrCreate().SetPlaying();
         owner.CamForTraders.enabled = false;
         owner.CamForTraders.m_LookAt = null;
         owner.FreeLook.enabled = true;

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -13,6 +13,20 @@ public class PauseMenuController : MonoBehaviour
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
 
+    protected virtual void OnEnable()
+    {
+        inputReader = GameInputReader.GetOrCreate();
+        inputReader.PausePressedEvent += HandlePausePressed;
+    }
+
+    protected virtual void OnDisable()
+    {
+        if (inputReader != null)
+        {
+            inputReader.PausePressedEvent -= HandlePausePressed;
+        }
+    }
+
     protected virtual void Start()
     {
         var playerObject = GameObject.FindGameObjectWithTag("Player");
@@ -22,8 +36,6 @@ public class PauseMenuController : MonoBehaviour
         }
 
         gameFlow = GameFlowController.GetOrCreate();
-        inputReader = GameInputReader.GetOrCreate();
-        inputReader.EnableGameplayInput();
         gameFlow.SetPlaying();
         Player = playerObject.GetComponent<Behaviour>();
         if (!RuntimeReferenceValidator.Require(Player, this, nameof(Player)) ||
@@ -60,11 +72,6 @@ public class PauseMenuController : MonoBehaviour
 
     public void Pause()
     {
-        if (inputReader != null && inputReader.PausePressed)
-        {
-            ChangeBolean();
-        }
-
         if (ActivePause)
         {
             ShowPausePanel();
@@ -84,6 +91,11 @@ public class PauseMenuController : MonoBehaviour
     {
         ActivePause = !ActivePause;
         SetPaused(ActivePause);
+    }
+
+    void HandlePausePressed()
+    {
+        ChangeBolean();
     }
 
     public void RestartCheckpointFromMenu()
@@ -141,19 +153,10 @@ public class PauseMenuController : MonoBehaviour
             gameFlow = GameFlowController.GetOrCreate();
         }
 
-        gameFlow.SetPaused(paused);
-        if (inputReader == null)
+        if (!gameFlow.SetPaused(paused))
         {
-            inputReader = GameInputReader.GetOrCreate();
+            ActivePause = false;
         }
-
-        if (paused || (Player != null && Player.isAtTrader))
-        {
-            inputReader.EnableUiInput();
-            return;
-        }
-
-        inputReader.EnableGameplayInput();
     }
 
     static void SetPanel(GameObject panel, bool active, PauseMenuController owner, string fieldName)


### PR DESCRIPTION
### Motivation
- Route all scene loads through `SceneTransitionService` and centralize play/pause/game-over state via `GameFlowController` to ensure consistent input and time-scale handling.
- Prevent unsafe direct input toggles and duplicate/invalid transitions (duplicate scene loads, duplicate game-over, pause during game-over).
- Ensure event subscriptions are paired (`OnEnable`/`OnDisable`) and put persistent services on an editable prefab for authorship.

### Description
- Make `GameFlowController` persistent and add guarded state APIs: `SetPlaying()`, `SetPaused(bool)` (returns bool), `SetGameOver()` (returns bool), `SetShop()`, and `BeginSceneTransition()`, and internal helpers to route input via `GameInputReader` instead of callers directly toggling input.
- Harden `SceneTransitionService` by adding `loadingSceneName`, a `PrepareLoad(string, bool, bool)` path that blocks empty names, duplicate loads, and requests to load the already-active scene unless `forceReload` is set, and call `GameFlowController.BeginSceneTransition()` on start of loads.
- Restrict `GameInputReader` to a persistent service and change input-mode mutators to `internal` so only controlled flow (`GameFlowController`) may enable/disable input.
- Update callers to use `GameFlowController` instead of directly toggling input or scene loading: `Behaviour` (lose menu/start), `PlayerInteractionController` (trader/shop/enter/exit), and pause flow in `PauseMenuController` now relies on `GameFlowController.SetPaused()`.
- Move pause input handling to paired `OnEnable`/`OnDisable` subscription in `PauseMenuController` and use the `SetPaused` return value to block illegal transitions.
- Add `GameFlowController` and `GameInputReader` components to the editable persistent prefab `Assets/Prefabs/Objects/UI/GameMusic.prefab` so services are authorable and persist across scenes.

### Testing
- Ran `git diff --check` to catch whitespace and YAML issues (fixed); result: no remaining check errors.
- Ran static Python checks searching for direct `SceneManager.LoadScene` and direct input-mode calls; result: no direct scene loads or direct input-mode calls remain outside the service/controller.
- Scanned event subscription patterns (`PausePressedEvent` and `sceneLoaded`) to verify paired `OnEnable`/`OnDisable` usage; result: paired subscriptions present.
- Attempted Unity batch validation but skipped because the Unity editor is not available in PATH.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd22257af4832aa38e2ff21933a43b)