### PR TITLE
Add debug QA bootstrap tools (editor/dev-only, config-driven)

### DIFF
--- a/Assets/Config/DebugQaConfig.asset
+++ b/Assets/Config/DebugQaConfig.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 90b490181f194c50ac017c264d12fcab, type: 3}
-  m_Name: DefaultDebugQAConfig
-  m_EditorClassIdentifier:
+  m_Name: DebugQaConfig
+  m_EditorClassIdentifier: 
   enableRuntimeReferenceValidation: 1
   logPrefabConfigApplication: 0
   disableCombatDamage: 0
-  enableDebugBootstrapper: 0
+  enableDebugBootstrapper: 1
   enableFpsDisplay: 1
   enableSceneResetShortcut: 1
   enableCheckpointTeleport: 1

--- a/Assets/Config/DebugQaConfig.asset.meta
+++ b/Assets/Config/DebugQaConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8db2a0ec65f8404a940e01a7e59e8c34
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Objects/UI/GameMusic.prefab
+++ b/Assets/Prefabs/Objects/UI/GameMusic.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 4968688398559378345}
   - component: {fileID: 4968688398559378346}
   - component: {fileID: 4968688398559378347}
+  - component: {fileID: 4968688398559378348}
   m_Layer: 5
   m_Name: GameMusic
   m_TagString: Music
@@ -211,3 +212,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b95fb80eea43429e8636de54a40675ab, type: 3}
   m_Name:
   m_EditorClassIdentifier:
+--- !u!114 &4968688398559378348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4968688398559378331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e72c9914200b49f79fd31e4d4df4a5a3, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  config: {fileID: 11400000, guid: 8db2a0ec65f8404a940e01a7e59e8c34, type: 2}

--- a/Assets/Scripts/Config/DebugQAConfig.cs
+++ b/Assets/Scripts/Config/DebugQAConfig.cs
@@ -6,4 +6,21 @@ public class DebugQAConfig : ScriptableObject
     public bool enableRuntimeReferenceValidation = true;
     public bool logPrefabConfigApplication;
     public bool disableCombatDamage;
+
+    [Header("Debug QA Runtime")]
+    public bool enableDebugBootstrapper;
+    public bool enableFpsDisplay = true;
+    public bool enableSceneResetShortcut = true;
+    public bool enableCheckpointTeleport = true;
+    public bool enableDamageTrigger = true;
+
+    [Header("Shortcuts")]
+    public KeyCode sceneResetKey = KeyCode.F5;
+    public KeyCode checkpointTeleportKey = KeyCode.F6;
+    public KeyCode damageTriggerKey = KeyCode.F7;
+
+    [Header("Tuning")]
+    [Min(1)] public int fpsFontSize = 16;
+    [Min(0f)] public float debugDamageAmount = 100f;
+    public Vector3 checkpointTeleportOffset = Vector3.up;
 }

--- a/Assets/Scripts/Core/SceneTransitionService.cs
+++ b/Assets/Scripts/Core/SceneTransitionService.cs
@@ -27,7 +27,7 @@ public class SceneTransitionService : MonoBehaviour
     public static void ReloadActiveScene()
     {
         var activeScene = SceneManager.GetActiveScene();
-        GetOrCreate().LoadSceneInternal(activeScene.name, activeScene.name == SceneNames.Menu);
+        GetOrCreate().LoadSceneInternal(activeScene.name, activeScene.name == SceneNames.Menu, true);
     }
 
     public static void LoadScene(string sceneName)

--- a/Assets/Scripts/Debug.meta
+++ b/Assets/Scripts/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c27e1ea1e4b4fd1a897dbde6679e5b7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Debug/DebugBootstrapper.cs
+++ b/Assets/Scripts/Debug/DebugBootstrapper.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public sealed class DebugBootstrapper : MonoBehaviour
+{
+    [SerializeField] DebugQAConfig config;
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    const string RootName = "Debug QA Runtime";
+    static GameObject root;
+
+    void Awake()
+    {
+        if (config == null || !config.enableDebugBootstrapper)
+        {
+            enabled = false;
+            return;
+        }
+
+        if (root != null)
+        {
+            return;
+        }
+
+        root = new GameObject(RootName);
+        DontDestroyOnLoad(root);
+
+        if (config.enableFpsDisplay)
+        {
+            root.AddComponent<FpsDisplay>().Configure(config);
+        }
+
+        if (config.enableSceneResetShortcut)
+        {
+            root.AddComponent<DebugSceneResetShortcut>().Configure(config);
+        }
+
+        if (config.enableCheckpointTeleport)
+        {
+            root.AddComponent<DebugCheckpointTeleport>().Configure(config);
+        }
+
+        if (config.enableDamageTrigger)
+        {
+            root.AddComponent<DebugDamageTrigger>().Configure(config);
+        }
+    }
+#endif
+}

--- a/Assets/Scripts/Debug/DebugBootstrapper.cs.meta
+++ b/Assets/Scripts/Debug/DebugBootstrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e72c9914200b49f79fd31e4d4df4a5a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Debug/DebugCheckpointTeleport.cs
+++ b/Assets/Scripts/Debug/DebugCheckpointTeleport.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+public sealed class DebugCheckpointTeleport : MonoBehaviour
+{
+    [SerializeField] DebugQAConfig config;
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    public void Configure(DebugQAConfig debugConfig) => config = debugConfig;
+
+    void Update()
+    {
+        if (config == null || !config.enableCheckpointTeleport || !Input.GetKeyDown(config.checkpointTeleportKey))
+        {
+            return;
+        }
+
+        if (!PlayerReference.TryGetPlayer(out Behaviour player) || player == null)
+        {
+            return;
+        }
+
+        Vector3 position = CheckpointService.GetOrCreate().RespawnPosition(config.checkpointTeleportOffset);
+        player.transform.position = position;
+
+        Rigidbody body = player.GetComponent<Rigidbody>();
+        if (body != null)
+        {
+            body.velocity = Vector3.zero;
+            body.angularVelocity = Vector3.zero;
+        }
+    }
+#else
+    public void Configure(DebugQAConfig debugConfig) => config = debugConfig;
+#endif
+}

--- a/Assets/Scripts/Debug/DebugCheckpointTeleport.cs.meta
+++ b/Assets/Scripts/Debug/DebugCheckpointTeleport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15f5e13e5ba946558eb6cf7f60f1b155
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Debug/DebugDamageTrigger.cs
+++ b/Assets/Scripts/Debug/DebugDamageTrigger.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+public sealed class DebugDamageTrigger : MonoBehaviour
+{
+    [SerializeField] DebugQAConfig config;
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    public void Configure(DebugQAConfig debugConfig) => config = debugConfig;
+
+    void Update()
+    {
+        if (config == null || !config.enableDamageTrigger || !Input.GetKeyDown(config.damageTriggerKey))
+        {
+            return;
+        }
+
+        if (PlayerReference.TryGetPlayer(out Behaviour player) && player != null)
+        {
+            player.TakeDamage(new DamageEvent
+            {
+                Amount = Mathf.Max(0f, config.debugDamageAmount),
+                Source = gameObject,
+                Point = player.transform.position,
+                Type = DamageType.Generic,
+                CanStun = false
+            });
+        }
+    }
+#else
+    public void Configure(DebugQAConfig debugConfig) => config = debugConfig;
+#endif
+}

--- a/Assets/Scripts/Debug/DebugDamageTrigger.cs.meta
+++ b/Assets/Scripts/Debug/DebugDamageTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54e60a3b110a44cba156ce1910d0c47e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Debug/DebugSceneResetShortcut.cs
+++ b/Assets/Scripts/Debug/DebugSceneResetShortcut.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+public sealed class DebugSceneResetShortcut : MonoBehaviour
+{
+    [SerializeField] DebugQAConfig config;
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    public void Configure(DebugQAConfig debugConfig) => config = debugConfig;
+
+    void Update()
+    {
+        if (config != null && config.enableSceneResetShortcut && Input.GetKeyDown(config.sceneResetKey))
+        {
+            SceneTransitionService.ReloadActiveScene();
+        }
+    }
+#else
+    public void Configure(DebugQAConfig debugConfig) => config = debugConfig;
+#endif
+}

--- a/Assets/Scripts/Debug/DebugSceneResetShortcut.cs.meta
+++ b/Assets/Scripts/Debug/DebugSceneResetShortcut.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 012ef5156f0843c1987e4cae5633333a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Debug/FpsDisplay.cs
+++ b/Assets/Scripts/Debug/FpsDisplay.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+public sealed class FpsDisplay : MonoBehaviour
+{
+    [SerializeField] DebugQAConfig config;
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    float smoothedDeltaTime;
+    GUIStyle style;
+
+    public void Configure(DebugQAConfig debugConfig) => config = debugConfig;
+
+    void Update()
+    {
+        smoothedDeltaTime += (Time.unscaledDeltaTime - smoothedDeltaTime) * 0.1f;
+    }
+
+    void OnGUI()
+    {
+        if (config == null || !config.enableFpsDisplay)
+        {
+            return;
+        }
+
+        if (style == null)
+        {
+            style = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = Mathf.Max(12, config.fpsFontSize)
+            };
+            style.normal.textColor = Color.white;
+        }
+
+        float fps = smoothedDeltaTime > 0f ? 1f / smoothedDeltaTime : 0f;
+        GUI.Label(new Rect(10f, 10f, 220f, 32f), $"FPS: {fps:0}", style);
+    }
+#else
+    public void Configure(DebugQAConfig debugConfig) => config = debugConfig;
+#endif
+}

--- a/Assets/Scripts/Debug/FpsDisplay.cs.meta
+++ b/Assets/Scripts/Debug/FpsDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30e01ffb95c84f46bb82963142996872
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Provide a small set of QA runtime helpers (FPS, scene-reset shortcut, checkpoint teleport, damage trigger) guarded to editor/development builds. 
- Make debug runtime opt-in via a config asset and attach to an editable prefab instead of adding objects directly into scenes. 
- Keep production builds unaffected by wrapping runtime logic with build defines.

### Description
- Added `Assets/Scripts/Debug/` with `DebugBootstrapper.cs`, `FpsDisplay.cs`, `DebugSceneResetShortcut.cs`, `DebugCheckpointTeleport.cs`, and `DebugDamageTrigger.cs`, and supporting `.meta` files. 
- Extended `Assets/Scripts/Config/DebugQAConfig.cs` with runtime toggles, shortcut keys, and tuning fields and added `Assets/Config/DebugQaConfig.asset` as the enabled config. 
- Bootstrapper creates a single persistent `Debug QA Runtime` root at runtime and attaches enabled helpers; all runtime behavior is wrapped in `#if UNITY_EDITOR || DEVELOPMENT_BUILD`. 
- Attached `DebugBootstrapper` to `Assets/Prefabs/Objects/UI/GameMusic.prefab` with the new config reference and updated `SceneTransitionService.ReloadActiveScene()` to call `LoadSceneInternal(..., true)` so reset shortcut forces service reset.

### Testing
- Ran a Python validation script that confirms the new debug scripts and asset exist, the prefab includes the bootstrapper and config GUIDs, and no scenes contain `DebugBootstrapper`; validation passed. 
- Ran `git diff --check` to ensure no leftover inspector/trailing whitespace errors; check passed after fix. 
- Attempted `dotnet --version` in the container (not available) and reported as an environment note.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd236d64a0832aae02947409f7725c)