### PR TITLE
Add RequireTaggedComponent and validate tagged dependencies

### DIFF
--- a/Assets/Scripts/Core/RuntimeReferenceValidator.cs
+++ b/Assets/Scripts/Core/RuntimeReferenceValidator.cs
@@ -27,4 +27,58 @@ public static class RuntimeReferenceValidator
 
         return false;
     }
+
+    public static bool RequireTaggedComponent<T>(string tag, MonoBehaviour owner, out T component) where T : Component
+    {
+        component = null;
+
+        GameObject taggedObject = null;
+        try
+        {
+            taggedObject = GameObject.FindGameObjectWithTag(tag);
+        }
+        catch (UnityException)
+        {
+            BuildSafeLogger.ErrorOnce(
+                $"{OwnerName(owner)}.{tag}.InvalidTag",
+                $"Required tag '{tag}' is not defined for {OwnerName(owner)}.",
+                owner,
+                missingTag: tag);
+
+            if (owner != null)
+            {
+                owner.enabled = false;
+            }
+
+            return false;
+        }
+
+        if (!Require(taggedObject, owner, tag + " tag"))
+        {
+            return false;
+        }
+
+        component = taggedObject.GetComponent<T>();
+        if (component != null)
+        {
+            return true;
+        }
+
+        BuildSafeLogger.WarnOnce(
+            $"{OwnerName(owner)}.{tag}.{typeof(T).Name}",
+            $"Tagged object '{tag}' is missing required component {typeof(T).Name} for {OwnerName(owner)}.",
+            owner,
+            missingField: typeof(T).Name,
+            missingTag: tag);
+
+        if (owner != null)
+        {
+            owner.enabled = false;
+        }
+
+        return false;
+    }
+
+    static string OwnerName(MonoBehaviour owner) => owner != null ? owner.GetType().Name : "<null owner>";
+
 }

--- a/Assets/Scripts/NPC/Beaver/BeaverNPC.cs
+++ b/Assets/Scripts/NPC/Beaver/BeaverNPC.cs
@@ -36,7 +36,16 @@ public class BeaverNPC : MonoBehaviour
         Beaver = GetComponent<Rigidbody>();
         BeaverAnimator = GetComponent<Animator>();
         beavers = GameObject.FindGameObjectsWithTag("FriendlyNPC");
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
+
+        bool valid = RuntimeReferenceValidator.Require(Beaver, this, nameof(Beaver)) &
+            RuntimeReferenceValidator.Require(BeaverAnimator, this, nameof(BeaverAnimator)) &
+            RuntimeReferenceValidator.RequireTaggedComponent("Player", this, out Player);
+
+        if (!valid)
+        {
+            return;
+        }
+
         awakePos = transform.position;
         moving = true;
         onward = true;

--- a/Assets/Scripts/NPC/Beaver/Trader.cs
+++ b/Assets/Scripts/NPC/Beaver/Trader.cs
@@ -20,8 +20,18 @@ public class Trader : MonoBehaviour
     void Start()
     {
         FormalLook = transform.rotation;
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
-        PlayerRoot = GameObject.FindGameObjectWithTag("PlayerRoot").GetComponent<Transform>();
+
+        bool valid = RuntimeReferenceValidator.Require(Merchant, this, nameof(Merchant)) &
+            RuntimeReferenceValidator.Require(TradeText, this, nameof(TradeText)) &
+            RuntimeReferenceValidator.Require(DialoguePanel, this, nameof(DialoguePanel)) &
+            RuntimeReferenceValidator.Require(Shop, this, nameof(Shop)) &
+            RuntimeReferenceValidator.RequireTaggedComponent("Player", this, out Player) &
+            RuntimeReferenceValidator.RequireTaggedComponent("PlayerRoot", this, out PlayerRoot);
+
+        if (!valid)
+        {
+            return;
+        }
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/Player/OBJProgressUponDeath.cs
+++ b/Assets/Scripts/Player/OBJProgressUponDeath.cs
@@ -9,7 +9,8 @@ public class OBJProgressUponDeath : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<ObjectiveUI>();
+        RuntimeReferenceValidator.Require(OBJ, this, nameof(OBJ));
+        RuntimeReferenceValidator.RequireTaggedComponent("Player", this, out Player);
     }
 
     // Update is called once per frame


### PR DESCRIPTION
### Motivation
- Provide a reusable runtime validator for dependencies located via tags to centralize logging and fail-safe behavior when tagged objects or components are missing.
- Replace ad-hoc `FindGameObjectWithTag(...).GetComponent<T>()` lookups to reduce null/ref errors and surface clear build-safe logs.

### Description
- Add `RequireTaggedComponent<T>(string tag, MonoBehaviour owner, out T component)` to `Assets/Scripts/Core/RuntimeReferenceValidator.cs` to locate a tagged object, validate it, fetch the required component, and emit `BuildSafeLogger` warnings/errors while disabling the owner on failure.
- Replace direct tag lookups in `Assets/Scripts/NPC/Beaver/Trader.cs` with calls to `RuntimeReferenceValidator.RequireTaggedComponent` and runtime field validation for `Merchant`, `TradeText`, `DialoguePanel`, and `Shop`.
- Add startup runtime validation to `Assets/Scripts/NPC/Beaver/BeaverNPC.cs` for `Beaver`, `BeaverAnimator`, and the tagged `Player` component.
- Replace tag lookup in `Assets/Scripts/Player/OBJProgressUponDeath.cs` with `RuntimeReferenceValidator.RequireTaggedComponent` and validate `OBJ` at start.

### Testing
- Ran static checks via `git diff --check` which reported no issues and succeeded.
- Verified no forbidden scene files were modified using `test -z "$(git diff --name-only -- 'Assets/Scenes/Level 1.unity' 'Assets/Scenes/Menu.unity')"`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd2602c000832a8932354c329d1ebd)