### PR TITLE
Add RuntimeBootstrapOwner component and prefab validation

### DIFF
--- a/Assets/Editor/RuntimeServicePrefabValidator.cs
+++ b/Assets/Editor/RuntimeServicePrefabValidator.cs
@@ -17,6 +17,7 @@ public static class RuntimeServicePrefabValidator
     public static bool ValidatePrefabRegistrations(bool logSuccess)
     {
         var prefabPathsByType = new Dictionary<System.Type, List<string>>();
+        var prefabPathsByOwnerId = new Dictionary<string, List<string>>();
         var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { "Assets" });
 
         foreach (var prefabGuid in prefabGuids)
@@ -26,6 +27,23 @@ public static class RuntimeServicePrefabValidator
             if (prefab == null)
             {
                 continue;
+            }
+
+            foreach (var owner in prefab.GetComponentsInChildren<RuntimeBootstrapOwner>(true))
+            {
+                if (owner == null || string.IsNullOrEmpty(owner.OwnerId))
+                {
+                    continue;
+                }
+
+                List<string> ownerPrefabPaths;
+                if (!prefabPathsByOwnerId.TryGetValue(owner.OwnerId, out ownerPrefabPaths))
+                {
+                    ownerPrefabPaths = new List<string>();
+                    prefabPathsByOwnerId.Add(owner.OwnerId, ownerPrefabPaths);
+                }
+
+                ownerPrefabPaths.Add(prefabPath);
             }
 
             foreach (var component in prefab.GetComponentsInChildren<MonoBehaviour>(true))
@@ -47,28 +65,38 @@ public static class RuntimeServicePrefabValidator
             }
         }
 
-        var duplicates = prefabPathsByType
+        var duplicateTypes = prefabPathsByType
             .Where(entry => entry.Value.Count > 1)
             .OrderBy(entry => entry.Key.FullName)
             .ToArray();
+        var duplicateOwnerIds = prefabPathsByOwnerId
+            .Where(entry => entry.Value.Count > 1)
+            .OrderBy(entry => entry.Key)
+            .ToArray();
 
-        if (duplicates.Length == 0)
-        {
-            if (logSuccess)
-            {
-                Debug.Log("Runtime service prefab validation passed: no duplicate RuntimeServices.Register component types found.");
-            }
-
-            return true;
-        }
-
-        foreach (var duplicate in duplicates)
+        foreach (var duplicate in duplicateTypes)
         {
             Debug.LogError("Duplicate RuntimeServices.Register component type found: "
                 + duplicate.Key.FullName + "\n" + string.Join("\n", duplicate.Value.ToArray()));
         }
 
-        return false;
+        foreach (var duplicate in duplicateOwnerIds)
+        {
+            Debug.LogError("Duplicate RuntimeBootstrapOwner ownerId found: "
+                + duplicate.Key + "\n" + string.Join("\n", duplicate.Value.ToArray()));
+        }
+
+        if (duplicateTypes.Length > 0 || duplicateOwnerIds.Length > 0)
+        {
+            return false;
+        }
+
+        if (logSuccess)
+        {
+            Debug.Log("Runtime service prefab validation passed: no duplicate RuntimeServices.Register component types or RuntimeBootstrapOwner ownerIds found.");
+        }
+
+        return true;
     }
 
     static bool RegistersRuntimeService(MonoBehaviour component)

--- a/Assets/Prefabs/Objects/UI/GameMusic.prefab
+++ b/Assets/Prefabs/Objects/UI/GameMusic.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 4968688398559378346}
   - component: {fileID: 4968688398559378347}
   - component: {fileID: 4968688398559378348}
+  - component: {fileID: 4968688398559378349}
   m_Layer: 5
   m_Name: GameMusic
   m_TagString: Music
@@ -225,3 +226,23 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier:
   config: {fileID: 11400000, guid: 8db2a0ec65f8404a940e01a7e59e8c34, type: 2}
+--- !u!114 &4968688398559378349
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4968688398559378331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49b9e682cc2d4b438ad8dd6a5e8f5b91, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  ownerId: runtime-bootstrap
+  lifetime: 0
+  ownedServices:
+  - {fileID: 4968688398559378344}
+  - {fileID: 4968688398559378345}
+  - {fileID: 4968688398559378346}
+  - {fileID: 4968688398559378347}
+  - {fileID: 4968688398559378348}

--- a/Assets/Scripts/Runtime.meta
+++ b/Assets/Scripts/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d5b3f3ce69a4e099e349771cc821f35
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/RuntimeBootstrapOwner.cs
+++ b/Assets/Scripts/Runtime/RuntimeBootstrapOwner.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public sealed class RuntimeBootstrapOwner : MonoBehaviour
+{
+    static readonly Dictionary<string, RuntimeBootstrapOwner> OwnersById = new Dictionary<string, RuntimeBootstrapOwner>();
+
+    [SerializeField] string ownerId;
+    [SerializeField] ServiceLifetime lifetime;
+    [SerializeField] Component[] ownedServices;
+
+    public string OwnerId { get { return ownerId; } }
+    public ServiceLifetime Lifetime { get { return lifetime; } }
+    public Component[] OwnedServices { get { return ownedServices; } }
+
+    void Awake()
+    {
+        if (lifetime == ServiceLifetime.Persistent)
+        {
+            DontDestroyOnLoad(gameObject);
+        }
+
+        ValidateUniqueOwnerId();
+    }
+
+    void OnDestroy()
+    {
+        RuntimeBootstrapOwner owner;
+        if (!string.IsNullOrEmpty(ownerId) && OwnersById.TryGetValue(ownerId, out owner) && owner == this)
+        {
+            OwnersById.Remove(ownerId);
+        }
+    }
+
+    void ValidateUniqueOwnerId()
+    {
+        if (string.IsNullOrEmpty(ownerId))
+        {
+            Debug.LogError("RuntimeBootstrapOwner requires a non-empty ownerId.", this);
+            return;
+        }
+
+        RuntimeBootstrapOwner existing;
+        if (OwnersById.TryGetValue(ownerId, out existing) && existing != null && existing != this)
+        {
+            Debug.LogError("Duplicate RuntimeBootstrapOwner ownerId found: " + ownerId + ".", this);
+            return;
+        }
+
+        OwnersById[ownerId] = this;
+    }
+
+#if UNITY_EDITOR
+    void OnValidate()
+    {
+        if (string.IsNullOrEmpty(ownerId))
+        {
+            return;
+        }
+
+        foreach (var owner in FindObjectsOfType<RuntimeBootstrapOwner>(true))
+        {
+            if (owner != this && owner.ownerId == ownerId)
+            {
+                Debug.LogError("Duplicate RuntimeBootstrapOwner ownerId found: " + ownerId + ".", this);
+                return;
+            }
+        }
+    }
+#endif
+}

--- a/Assets/Scripts/Runtime/RuntimeBootstrapOwner.cs.meta
+++ b/Assets/Scripts/Runtime/RuntimeBootstrapOwner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49b9e682cc2d4b438ad8dd6a5e8f5b91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SceneScripts/DoNotDestroy.cs
+++ b/Assets/Scripts/SceneScripts/DoNotDestroy.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
 
+/// <summary>Legacy compatibility marker. Prefer RuntimeBootstrapOwner for runtime bootstrap persistence metadata.</summary>
+[AddComponentMenu("Legacy/DoNotDestroy (Legacy)")]
 public class DoNotDestroy : MonoBehaviour
 {
     private static readonly System.Collections.Generic.HashSet<System.Type> PersistentTypes =

--- a/Docs/RUNTIME_SERVICES.md
+++ b/Docs/RUNTIME_SERVICES.md
@@ -1,18 +1,21 @@
 # Runtime Services
 
-`RuntimeServices` owns singleton-style registrations by component type. Persistent services must live only on `Assets/Prefabs/Objects/UI/GameMusic.prefab`, the runtime-service owner prefab. Player prefabs must keep only player-local or scene-local systems.
+`RuntimeServices` owns singleton-style registrations by component type. Persistent services must live only on `Assets/Prefabs/Objects/UI/GameMusic.prefab`, the runtime bootstrap owner prefab. Player prefabs must keep only player-local or scene-local systems.
 
 | Service | Lifetime | Owner prefab | Notes |
 | --- | --- | --- | --- |
-| `SceneTransitionService` | Persistent (`DontDestroyOnLoad`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global scene loading and scene-service reset coordinator. |
-| `CursorStateService` | Persistent (`DontDestroyOnLoad`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global cursor visibility/lock owner. |
-| `GameFlowController` | Persistent (`DontDestroyOnLoad`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global boot/play/pause/game-over state owner. |
-| `GameInputReader` | Persistent (`DontDestroyOnLoad`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global input polling and input-mode owner. |
-| `DebugBootstrapper` | Persistent (`DontDestroyOnLoad`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Development/debug runtime feature bootstrapper. |
+| `SceneTransitionService` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global scene loading and scene-service reset coordinator. |
+| `CursorStateService` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global cursor visibility/lock owner. |
+| `GameFlowController` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global boot/play/pause/game-over state owner. |
+| `GameInputReader` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global input polling and input-mode owner. |
+| `DebugBootstrapper` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Development/debug runtime feature bootstrapper. |
 | `CheckpointService` | Scene-local | `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` | Player/scene checkpoint state; destroyed on scene reset. |
 
 ## Prefab rules
 
+- Runtime bootstrap prefabs must include exactly one `RuntimeBootstrapOwner` with a stable, unique `ownerId` and `ownedServices` references to the services it owns.
+- `RuntimeBootstrapOwner.ownerId` values must be unique across prefabs; `Tools/Runtime Services/Validate Prefab Registrations` reports duplicate owner ids.
+- `DoNotDestroy` is legacy compatibility only. Do not use it as the sole ownership marker for new runtime services; attach `RuntimeBootstrapOwner` instead.
 - Do not add persistent `RuntimeServices.Register(..., ServiceLifetime.Persistent)` components to player prefabs.
 - Keep `GameFlowController` and `GameInputReader` off `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` and `Assets/Prefabs/OtterPlayer/Player Updated.prefab`.
 - Keep player-specific systems, including scene-local `CheckpointService`, on the player prefab that owns that state.


### PR DESCRIPTION
### Motivation
- Centralize runtime bootstrap ownership metadata on prefabs instead of relying solely on `DoNotDestroy` markers. 
- Prevent multiple bootstrap owners with the same logical identity by surfacing duplicate `ownerId` errors at edit-time.

### Description
- Add `RuntimeBootstrapOwner` component (`Assets/Scripts/Runtime/RuntimeBootstrapOwner.cs`) with serialized fields `string ownerId`, `ServiceLifetime lifetime`, and `Component[] ownedServices` and editor-time duplicate `ownerId` validation.
- Attach a `RuntimeBootstrapOwner` instance to the runtime bootstrap prefab (`Assets/Prefabs/Objects/UI/GameMusic.prefab`) with `ownerId: runtime-bootstrap` and references in `ownedServices`.
- Keep `DoNotDestroy` for legacy compatibility and mark it as legacy via an `AddComponentMenu` and doc comment (`Assets/Scripts/SceneScripts/DoNotDestroy.cs`).
- Extend the prefab validator (`Assets/Editor/RuntimeServicePrefabValidator.cs`) to collect and report duplicate `RuntimeBootstrapOwner.ownerId` values.
- Update runtime documentation (`Docs/RUNTIME_SERVICES.md`) to describe `RuntimeBootstrapOwner` rules and mark `DoNotDestroy` as legacy.

### Testing
- Ran a repository-wide Unity meta GUID duplication check script; result: passed (no duplicate GUIDs found).
- Ran a prefab metadata verification script asserting the `GameMusic.prefab` contains the new `RuntimeBootstrapOwner` GUID, `ownerId: runtime-bootstrap`, and the expected `ownedServices` fileIDs; result: passed.
- Editor validation change (`Tools/Runtime Services/Validate Prefab Registrations`) was updated to report duplicate `ownerId`s, but the Unity Editor menu was not executed in CI (no headless Unity run performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0d36dc0c832a8c22868c7cd4cf19)