### PR TITLE
Add prefab ownership docs, runtime service expansion, validation and hierarchy guides

### DIFF
--- a/Docs/DEBUG_TOOLS.md
+++ b/Docs/DEBUG_TOOLS.md
@@ -1,0 +1,28 @@
+# Debug Tools
+
+## Ownership
+
+| Tool/component | Owner | Lifetime | Gate |
+| --- | --- | --- | --- |
+| `DebugBootstrapper` | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Persistent | `UNITY_EDITOR || DEVELOPMENT_BUILD`; `DebugQAConfig.enableDebugBootstrapper` |
+| `FpsDisplay` | Spawned under `Debug QA Runtime` | Persistent debug runtime | `DebugQAConfig.enableFpsDisplay` |
+| `DebugSceneResetShortcut` | Spawned under `Debug QA Runtime` | Persistent debug runtime | `DebugQAConfig.enableSceneResetShortcut` |
+| `DebugCheckpointTeleport` | Spawned under `Debug QA Runtime` | Persistent debug runtime | `DebugQAConfig.enableCheckpointTeleport` |
+| `DebugDamageTrigger` | Spawned under `Debug QA Runtime` | Persistent debug runtime | `DebugQAConfig.enableDamageTrigger` |
+| `CombatDebugGate` | Player prefab | Player-local | `DebugQAConfig.disableCombatDamage` |
+| `PrefabRuntimeHardening` | Owning prefab | Prefab-local | `DebugQAConfig.enableRuntimeReferenceValidation` |
+| UI debug widgets | `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab` | Scene UI | UI object active state / scene wiring |
+
+## Rules
+
+- Persistent debug runtime belongs only to `GameMusic.prefab`.
+- Do not add debug bootstrap components to player, enemy, hive, or canvas prefabs.
+- Keep debug shortcuts config-driven; do not hard-code new keys outside `DebugQAConfig`.
+- Debug validation may report missing refs but must not silently create gameplay dependencies.
+- Player-local damage gating belongs on the player prefab, not on enemy prefabs.
+
+## Optional refs
+
+- `DebugBootstrapper.config` may be null only when all debug runtime features are intentionally disabled.
+- Individual debug tool components must tolerate disabled config flags.
+- UI debug refs may be null only for inactive/debug-only screens that are not used in the current scene.

--- a/Docs/HIERARCHY_GUIDE.md
+++ b/Docs/HIERARCHY_GUIDE.md
@@ -1,0 +1,39 @@
+# Hierarchy Guide
+
+See also: [Hierarchy and Reference Checklist](HierarchyAndReferenceChecklist.md).
+
+## Scope
+
+- Current Level 1/Menu scene hierarchies are frozen for cleanup-only changes.
+- New conventions apply to future scenes and editable prefab internals only.
+- Imported/third-party prefab contents should not be edited directly; create a local editable variant first.
+
+## Future scene root groups
+
+- `_Runtime` — runtime bootstrap objects, scene services, managers, spawners, generated runtime containers.
+- `_Player` — player root, player controller dependencies, player colliders, player VFX/SFX, spawn points.
+- `_Camera` — active cameras, camera rigs, Cinemachine objects, bounds, camera helpers.
+- `_UI` — canvases, event systems, HUD/menu roots, UI animation/audio hooks.
+- `_Enemies` — enemy roots, spawn points, encounter containers, patrol/waypoint helpers.
+- `_Hazards` — traps, damage volumes, environmental hazards, temporary danger zones, hazard VFX/SFX.
+- `_Interactables` — pickups, doors, switches, bridges, NPC interaction anchors, objectives, non-hazard triggers.
+- `_Audio` — music emitters, ambient loops, mixer-routing helpers, one-shot pools, scene-local audio triggers.
+
+## Future prefab groups
+
+- `_Runtime` — prefab-local service/state helpers only; no persistent global services unless this prefab is the documented owner.
+- `_Visuals` — meshes, skinned meshes, renderers, model roots.
+- `_Colliders` — movement, trigger, detection, and physics colliders.
+- `_Hitboxes` — damage/parry/strike volumes and combat ownership markers.
+- `_Audio` — emitters and prefab-local audio routing.
+- `_VFX` — particles, trails, decals, effect anchors.
+- `_UI` — world-space UI, floating text, HUD anchors.
+- `_Sockets` — stable attachment/spawn/IK/weapon/camera anchors.
+- `_Debug` — debug-only helpers and validation markers.
+
+## Reference rules
+
+- Prefer serialized refs, typed components, interfaces, and `TryGetComponent` over tags or hierarchy names.
+- Avoid new `Transform.Find`, global `Find`, hard-coded child paths, and string tag dependencies.
+- Before renaming children, check animation clips, Timeline, VFX bindings, UI events, audio hooks, and scene refs.
+- Preserve existing tags/layers unless all consumers, physics masks, raycasts, and camera masks are audited.

--- a/Docs/PREFAB_OWNERSHIP.md
+++ b/Docs/PREFAB_OWNERSHIP.md
@@ -1,0 +1,57 @@
+# Prefab Ownership
+
+## Rules
+
+- A prefab owns only the serialized references, child hierarchy, runtime services, and debug hooks listed for that prefab.
+- Required refs must stay assigned; missing refs are runtime defects.
+- Optional refs may be null only when the feature is disabled or scene-provided.
+- Persistent services must live on `Assets/Prefabs/Objects/UI/GameMusic.prefab` only.
+- Scene/player state must stay on the prefab that owns the state.
+- Do not move persistent services into player, enemy, hive, or UI canvas prefabs.
+- Do not add `RuntimeServices.Register(..., ServiceLifetime.Persistent)` to prefab variants unless this document is updated first.
+
+## Ownership matrix
+
+| Prefab | Owns | Required refs | Optional refs | Service lifetime | Debug ownership | Variant risk |
+| --- | --- | --- | --- | --- | --- | --- |
+| `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` | Canonical shapekey player runtime: controller stack, combat, inventory, health, camera helpers, HUD anchors, local audio/VFX, checkpoint state. | Core player components referenced by `PrefabRuntimeHardening.requiredComponents`; player root, movement/controller, health/combat/inventory/interaction dependencies, `CheckpointService`. | UI text/debug text, waypoint/objective UI hooks, camera/audio/VFX helpers that can be scene-provided. | `CheckpointService` is `Scene`; no persistent services allowed. | Owns `CombatDebugGate` and player-local runtime-reference validation only. | High: child names, animator bindings, blend-shape/skinned-mesh paths, tags/layers, and scene references may be variant-overridden. |
+| `Assets/Prefabs/OtterPlayer/Player Updated.prefab` | Legacy/alternate player presentation and player-local scripts. | Existing player-local controller/health/combat/UI/audio refs serialized on the prefab. | Debug text, presentation-only UI/VFX/audio links. | No persistent services; do not add `GameFlowController`, `GameInputReader`, or other global services. | No global debug ownership; debug refs are player-local only. | High: likely diverges from canonical player; do not assume overrides propagate between player prefabs. |
+| `Assets/Prefabs/Wasp/LVL1 Wasp.prefab` | Level 1 wasp enemy root, AI, health, combat feedback, audio, floating UI/VFX. | `PrefabRuntimeHardening.requiredComponents`; required child objects for hit/visual/UI/audio anchors. | Cosmetic VFX/audio emitters and floating debug/UI text. | None. | Owns enemy-local runtime-reference validation only. | Medium: imported/model child paths and animation/event refs can break on rename. |
+| `Assets/Prefabs/Scorpion/ScorpionBoss.prefab` | Boss scorpion enemy root, AI, health, boss hitboxes, combat feedback, audio/VFX. | `PrefabRuntimeHardening.requiredComponents`; required child objects for boss hitbox/visual/audio anchors. | Presentation VFX/audio and combat-feedback emitters. | None. | Owns boss-local runtime-reference validation only. | High: boss hitboxes and animation/event bindings are sensitive to hierarchy edits. |
+| `Assets/Prefabs/Scorpion/Scorpion.prefab` | Non-boss scorpion enemy root, AI, health, hitboxes, combat feedback, audio/VFX. | Existing serialized AI/health/hitbox/audio/VFX refs. | Presentation VFX/audio and combat-feedback emitters. | None. | No global debug ownership. | High: many nested/remains child scripts; prefab variant overrides are easy to orphan. |
+| `Assets/Prefabs/Hive/NewHive.prefab` | Hive objective/spawner root, hive health, wasp spawning, combat feedback, UI marker. | `Static_Hive`, `WaspSpawner`, `NPC_Health`, spawn/feedback refs serialized on the prefab. | UI marker, floating text, cosmetic feedback/audio. | None. | No global debug ownership. | Medium: spawn-point and objective references are gameplay-critical. |
+| `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab` | Player HUD/menu/dialogue/shop/lose-menu UI hierarchy and presenters. | Canvas hierarchy, HUD presenter refs, dialogue/shop/menu controller refs, event/navigation links. | Debug reference widgets, inactive screens, scene-provided player refs. | Scene UI only; no persistent runtime services. | Owns UI debug widgets only; not the debug runtime bootstrapper. | High: UI object names, animation paths, navigation, and serialized button events are brittle. |
+| `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Runtime bootstrap owner, global music, scene transitions, cursor, game flow, input, debug bootstrapper. | `RuntimeBootstrapOwner.ownerId=runtime-bootstrap`; `ownedServices` refs to global services; `MusicPlaylist`; `DoNotDestroy` legacy shim. | `DebugBootstrapper.config` may disable individual debug tools. | `SceneTransitionService`, `CursorStateService`, `GameFlowController`, `GameInputReader`, and `DebugBootstrapper` are `Persistent`. | Sole owner of persistent debug bootstrap/runtime debug tools. | Medium: duplicated variants create duplicate singleton services and duplicate `ownerId`s. |
+
+## Required vs optional refs
+
+- Required refs are dependencies without fallback, or refs listed in `PrefabRuntimeHardening.requiredComponents` / `requiredObjects`.
+- Optional refs are refs with feature-gated usage, null-safe code paths, scene lookup fallback, or cosmetic-only behavior.
+- When promoting an optional ref to required, add it to `PrefabRuntimeHardening` where available and update this file.
+- When removing a required ref, migrate callers to typed optional access first.
+
+## Service lifetime
+
+- `Persistent`: survives scene transitions; only `GameMusic.prefab` may own these services.
+- `Scene`: reset/destroyed on scene reload; player/scene-owned state only.
+- `None`: normal prefab component; no `RuntimeServices.Register` ownership.
+
+## Debug ownership
+
+- Persistent debug runtime: `GameMusic.prefab` via `DebugBootstrapper`.
+- Player combat/debug gates: player prefab only.
+- Reference validation: each prefab may own its own `PrefabRuntimeHardening` component.
+- UI debug widgets: `PlayerCanvas.prefab` only.
+
+## Prefab-variant risks
+
+- Variants can override component arrays with stale fileIDs; revalidate required refs after base-prefab edits.
+- Avoid renaming child objects used by animation clips, Timeline, VFX, UI events, or scene serialized refs.
+- Avoid changing tags/layers unless all consumers and physics/camera masks are audited.
+- Keep singleton/runtime-service components out of variants unless the base prefab owns that service.
+
+## Allowed future hierarchy conventions
+
+- New editable prefabs may group children by `_Runtime`, `_Visuals`, `_Colliders`, `_Hitboxes`, `_Audio`, `_VFX`, `_UI`, `_Sockets`, and `_Debug`.
+- New scenes may use root groups from `Docs/HIERARCHY_GUIDE.md`.
+- Existing Level 1/Menu scene hierarchies remain frozen; prefer prefab-local cleanup and explicit serialized refs.

--- a/Docs/RUNTIME_SERVICES.md
+++ b/Docs/RUNTIME_SERVICES.md
@@ -1,22 +1,25 @@
 # Runtime Services
 
-`RuntimeServices` owns singleton-style registrations by component type. Persistent services must live only on `Assets/Prefabs/Objects/UI/GameMusic.prefab`, the runtime bootstrap owner prefab. Player prefabs must keep only player-local or scene-local systems.
+`RuntimeServices` registers singleton-style services by component type. Ownership is prefab-based, not scene-name-based.
 
-| Service | Lifetime | Owner prefab | Notes |
-| --- | --- | --- | --- |
-| `SceneTransitionService` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global scene loading and scene-service reset coordinator. |
-| `CursorStateService` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global cursor visibility/lock owner. |
-| `GameFlowController` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global boot/play/pause/game-over state owner. |
-| `GameInputReader` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Global input polling and input-mode owner. |
-| `DebugBootstrapper` | Persistent (`RuntimeBootstrapOwner`) | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | Development/debug runtime feature bootstrapper. |
-| `CheckpointService` | Scene-local | `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` | Player/scene checkpoint state; destroyed on scene reset. |
+## Service lifetime table
 
-## Prefab rules
+| Service | Lifetime | Owner prefab | Required refs | Optional refs | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `SceneTransitionService` | `Persistent` | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | `RuntimeBootstrapOwner.ownedServices` entry. | None. | Global scene loading and scene-service reset coordinator. |
+| `CursorStateService` | `Persistent` | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | `RuntimeBootstrapOwner.ownedServices` entry. | None. | Global cursor visibility/lock owner. |
+| `GameFlowController` | `Persistent` | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | `RuntimeBootstrapOwner.ownedServices` entry. | UI listeners may be scene-provided. | Global boot/play/pause/game-over state owner. |
+| `GameInputReader` | `Persistent` | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | `RuntimeBootstrapOwner.ownedServices` entry. | None. | Global input polling and input-mode owner. |
+| `DebugBootstrapper` | `Persistent` | `Assets/Prefabs/Objects/UI/GameMusic.prefab` | `RuntimeBootstrapOwner.ownedServices` entry; `DebugQAConfig` when debug tools are enabled. | Individual debug tools may be disabled by config. | Development/debug runtime feature bootstrapper. |
+| `CheckpointService` | `Scene` | `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` | Player root/local checkpoint state. | Respawn offset callers. | Player/scene checkpoint state; destroyed on scene reset. |
 
-- Runtime bootstrap prefabs must include exactly one `RuntimeBootstrapOwner` with a stable, unique `ownerId` and `ownedServices` references to the services it owns.
-- `RuntimeBootstrapOwner.ownerId` values must be unique across prefabs; `Tools/Runtime Services/Validate Prefab Registrations` reports duplicate owner ids.
-- `DoNotDestroy` is legacy compatibility only. Do not use it as the sole ownership marker for new runtime services; attach `RuntimeBootstrapOwner` instead.
-- Do not add persistent `RuntimeServices.Register(..., ServiceLifetime.Persistent)` components to player prefabs.
-- Keep `GameFlowController` and `GameInputReader` off `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` and `Assets/Prefabs/OtterPlayer/Player Updated.prefab`.
-- Keep player-specific systems, including scene-local `CheckpointService`, on the player prefab that owns that state.
-- Use `Tools/Runtime Services/Validate Prefab Registrations` before committing prefab ownership changes.
+## Rules
+
+- Persistent services must live only on `Assets/Prefabs/Objects/UI/GameMusic.prefab`.
+- `RuntimeBootstrapOwner.ownerId` must be stable and globally unique; current id is `runtime-bootstrap`.
+- `RuntimeBootstrapOwner.ownedServices` must list every persistent service component owned by `GameMusic.prefab`.
+- `DoNotDestroy` is legacy compatibility only; do not use it as the sole ownership marker for new runtime services.
+- Do not add persistent `RuntimeServices.Register(..., ServiceLifetime.Persistent)` components to player, enemy, hive, or UI canvas prefabs.
+- Keep `GameFlowController` and `GameInputReader` off both player prefabs.
+- Keep player/scene-local systems, including `CheckpointService`, on the prefab that owns the state.
+- Run `Tools/Runtime Services/Validate Prefab Registrations` before committing prefab ownership changes.

--- a/Docs/VALIDATION_RULES.md
+++ b/Docs/VALIDATION_RULES.md
@@ -1,0 +1,39 @@
+# Validation Rules
+
+## Required checks
+
+- Run `Tools/Runtime Services/Validate Prefab Registrations` after adding, moving, removing, or variant-overriding any component that calls `RuntimeServices.Register`.
+- Run prefab play-mode smoke tests after changing required refs, tags, layers, animation paths, hitboxes, or UI event wiring.
+- Keep `PrefabRuntimeHardening.requiredComponents` and `requiredObjects` aligned with this documentation.
+
+## Runtime service validation
+
+- No duplicate `RuntimeServices.Register` component type may exist across project prefabs unless explicitly documented.
+- No duplicate `RuntimeBootstrapOwner.ownerId` may exist across project prefabs.
+- Persistent services must be registered from `GameMusic.prefab` only.
+- Scene services must be safe to destroy through `RuntimeServices.ResetSceneServices()`.
+
+## Reference validation
+
+- Required refs: non-null serialized components/objects needed for startup, gameplay, damage, input, UI navigation, spawning, or scene transition.
+- Optional refs: null-safe, feature-gated, scene-provided, or cosmetic refs.
+- `PrefabRuntimeHardening` should cover required refs that can be validated on `Awake` without scene dependencies.
+- Do not add validation for refs intentionally resolved from the active scene.
+
+## Debug validation
+
+- `DebugQAConfig.enableRuntimeReferenceValidation` may disable validation for debug sessions only; do not rely on that for production fixes.
+- `DebugBootstrapper` must remain persistent and owned by `GameMusic.prefab`.
+- Debug-only controls must compile out or stay gated by `UNITY_EDITOR || DEVELOPMENT_BUILD`.
+
+## Prefab variant validation
+
+- After editing a base prefab, inspect variants for stale overrides, missing fileIDs, removed components, and duplicate services.
+- Do not apply variant overrides that remove required components/objects without updating validation and ownership docs.
+- Recheck animation clips, Timeline, VFX, button events, and scene serialized refs after hierarchy renames.
+
+## Hierarchy validation
+
+- Do not rename or regroup Level 1/Menu scene objects for cleanup-only changes.
+- New hierarchy conventions are allowed only for future scenes or editable prefabs.
+- Prefer explicit serialized refs over hard-coded names, child paths, tags, or global `Find` calls.


### PR DESCRIPTION
### Motivation

- Provide explicit ownership and validation guidance for prefabs that contain runtime state, debug hooks, and scene-local services to avoid duplicate singletons and brittle prefab variants. 
- Capture required/optional refs, service lifetime, debug ownership, prefab-variant risks, and allowed future hierarchy conventions for maintainers and CI checks.

### Description

- Added `Docs/PREFAB_OWNERSHIP.md` with an ownership matrix documenting the following prefabs: `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab`, `Assets/Prefabs/OtterPlayer/Player Updated.prefab`, `Assets/Prefabs/Wasp/LVL1 Wasp.prefab`, `Assets/Prefabs/Scorpion/ScorpionBoss.prefab`, `Assets/Prefabs/Scorpion/Scorpion.prefab`, `Assets/Prefabs/Hive/NewHive.prefab`, `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`, and `Assets/Prefabs/Objects/UI/GameMusic.prefab` including required refs, optional refs, service lifetime, debug ownership, variant risks, and allowed future hierarchy conventions. 
- Updated `Docs/RUNTIME_SERVICES.md` to a structured service lifetime table and explicit rules tying persistent services to `GameMusic.prefab` and `RuntimeBootstrapOwner.ownerId` requirements. 
- Added `Docs/VALIDATION_RULES.md` and `Docs/DEBUG_TOOLS.md` describing validation steps, runtime-service validation constraints, and debug-tool ownership/gating. 
- Added `Docs/HIERARCHY_GUIDE.md` and linked it to the existing `Docs/HierarchyAndReferenceChecklist.md` to standardize future scene/prefab grouping conventions.

### Testing

- Ran `rg -n "HierarchyAndReferenceChecklist|Persistent|runtime-bootstrap|PrefabRuntimeHardening|DebugBootstrapper" Docs` to verify new docs contain the expected references; the search returned matches. 
- Ran `git diff --check` to verify no whitespace/conflict issues; the check passed. 
- Confirmed staged changes and created the documentation change set locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff142a5e7c832a854ef6d0a4d2fe3a)