### PR TITLE
Add prefab integration validator (Tools/BeaverMania/Validation)

### DIFF
--- a/Assets/Scripts/Validation.meta
+++ b/Assets/Scripts/Validation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16ee673547e54ab3977461a8f9a1f123
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Validation/Editor.meta
+++ b/Assets/Scripts/Validation/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac438ac65ec74d3fb2bdc2d651857cb6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Validation/Editor/PrefabIntegrationValidator.cs
+++ b/Assets/Scripts/Validation/Editor/PrefabIntegrationValidator.cs
@@ -1,0 +1,380 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+
+public static class PrefabIntegrationValidator
+{
+    const string MenuRoot = "Tools/BeaverMania/Validation/";
+    const string RegisterCall = "RuntimeServices.Register";
+    const string PersistentBootstrapPrefab = "Assets/Prefabs/Objects/UI/GameMusic.prefab";
+    const string PlayerBootstrapPrefab = "Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab";
+    const string RuntimeBootstrapOwnerId = "runtime-bootstrap";
+
+    static readonly Regex LocalIdRegex = new Regex(@"^--- !u!\d+ &(\-?\d+)$", RegexOptions.Compiled | RegexOptions.Multiline);
+    static readonly Regex ObjectReferenceRegex = new Regex(@"\{fileID: (\-?\d+)(?:, guid: ([0-9a-fA-F]{32}))?(?:, type: \d+)?\}", RegexOptions.Compiled);
+
+    static readonly string[] ApprovedServicePrefabs =
+    {
+        PersistentBootstrapPrefab,
+        PlayerBootstrapPrefab
+    };
+
+    static readonly FocusPrefabRule[] FocusPrefabRules =
+    {
+        new FocusPrefabRule(PlayerBootstrapPrefab, typeof(PrefabRuntimeHardening), null),
+        new FocusPrefabRule("Assets/Prefabs/Wasp/LVL1 Wasp.prefab", typeof(PrefabRuntimeHardening), null),
+        new FocusPrefabRule("Assets/Prefabs/Scorpion/ScorpionBoss.prefab", typeof(PrefabRuntimeHardening), null),
+        new FocusPrefabRule(PersistentBootstrapPrefab, typeof(RuntimeBootstrapOwner), RuntimeBootstrapOwnerId)
+    };
+
+    [MenuItem(MenuRoot + "Run Prefab Integration Validation")]
+    public static void RunPrefabIntegrationValidationMenu()
+    {
+        RunValidation(true, true, true, true, true);
+    }
+
+    [MenuItem(MenuRoot + "Validate References")]
+    public static void ValidateReferencesMenu()
+    {
+        RunValidation(true, true, false, false, false);
+    }
+
+    [MenuItem(MenuRoot + "Validate Service Ownership")]
+    public static void ValidateServiceOwnershipMenu()
+    {
+        RunValidation(false, false, true, true, true);
+    }
+
+    public static bool RunValidation(
+        bool validateMissingScripts,
+        bool validateSerializedReferences,
+        bool validateDuplicateServices,
+        bool validateFocusOwnership,
+        bool validateServiceLocations)
+    {
+        var prefabPaths = AssetDatabase.FindAssets("t:Prefab")
+            .Select(AssetDatabase.GUIDToAssetPath)
+            .Where(path => !string.IsNullOrEmpty(path))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        var context = new ValidationContext(prefabPaths);
+
+        if (validateMissingScripts)
+        {
+            ValidateMissingMonoBehaviours(context);
+        }
+
+        if (validateSerializedReferences)
+        {
+            ValidateSerializedObjectReferences(context);
+        }
+
+        if (validateDuplicateServices || validateServiceLocations)
+        {
+            CollectServiceComponents(context);
+        }
+
+        if (validateDuplicateServices)
+        {
+            ValidateDuplicateServiceComponents(context);
+        }
+
+        if (validateFocusOwnership)
+        {
+            ValidateFocusPrefabOwnershipMarkers(context);
+        }
+
+        if (validateServiceLocations)
+        {
+            ValidateServiceComponentLocations(context);
+        }
+
+        context.LogReport();
+        return context.Errors.Count == 0;
+    }
+
+    static void ValidateMissingMonoBehaviours(ValidationContext context)
+    {
+        foreach (var prefabPath in context.PrefabPaths)
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            if (prefab == null)
+            {
+                continue;
+            }
+
+            foreach (var transform in prefab.GetComponentsInChildren<Transform>(true).OrderBy(TransformPath, StringComparer.Ordinal))
+            {
+                var components = transform.GetComponents<Component>();
+                for (var i = 0; i < components.Length; i++)
+                {
+                    if (components[i] == null)
+                    {
+                        context.AddError("MissingMonoBehaviour", prefabPath, TransformPath(transform) + " componentIndex=" + i);
+                    }
+                }
+            }
+        }
+    }
+
+    static void ValidateSerializedObjectReferences(ValidationContext context)
+    {
+        foreach (var prefabPath in context.PrefabPaths)
+        {
+            if (!File.Exists(prefabPath))
+            {
+                continue;
+            }
+
+            var yaml = File.ReadAllText(prefabPath);
+            var localIds = new HashSet<string>(LocalIdRegex.Matches(yaml).Cast<Match>().Select(match => match.Groups[1].Value));
+            var refs = new SortedSet<string>(StringComparer.Ordinal);
+
+            foreach (Match match in ObjectReferenceRegex.Matches(yaml))
+            {
+                var fileId = match.Groups[1].Value;
+                var guid = match.Groups[2].Success ? match.Groups[2].Value : string.Empty;
+                if (fileId == "0")
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(guid))
+                {
+                    if (string.IsNullOrEmpty(AssetDatabase.GUIDToAssetPath(guid)))
+                    {
+                        refs.Add("missing asset guid=" + guid + " fileID=" + fileId);
+                    }
+
+                    continue;
+                }
+
+                if (!localIds.Contains(fileId) && !IsPrefabInstanceBackedYamlDocument(yaml, match.Index))
+                {
+                    refs.Add("missing local fileID=" + fileId);
+                }
+            }
+
+            foreach (var reference in refs)
+            {
+                context.AddError("MissingSerializedObjectReference", prefabPath, reference);
+            }
+        }
+    }
+
+    static void CollectServiceComponents(ValidationContext context)
+    {
+        foreach (var prefabPath in context.PrefabPaths)
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            if (prefab == null)
+            {
+                continue;
+            }
+
+            foreach (var component in prefab.GetComponentsInChildren<MonoBehaviour>(true))
+            {
+                if (component == null || !RegistersRuntimeService(component))
+                {
+                    continue;
+                }
+
+                context.ServiceComponents.Add(new ServiceComponentRecord(
+                    prefabPath,
+                    component.GetType(),
+                    TransformPath(component.transform),
+                    IsNestedPrefabInstance(component.gameObject)));
+            }
+        }
+
+        context.ServiceComponents.Sort(ServiceComponentRecord.Compare);
+    }
+
+    static void ValidateDuplicateServiceComponents(ValidationContext context)
+    {
+        foreach (var group in context.ServiceComponents.GroupBy(record => record.Type.FullName).OrderBy(group => group.Key, StringComparer.Ordinal))
+        {
+            var prefabPaths = group.Select(record => record.PrefabPath).Distinct().OrderBy(path => path, StringComparer.Ordinal).ToArray();
+            if (prefabPaths.Length <= 1)
+            {
+                continue;
+            }
+
+            context.AddError("DuplicateServiceComponent", prefabPaths[0], group.Key + " prefabs=" + string.Join(", ", prefabPaths));
+        }
+    }
+
+    static void ValidateFocusPrefabOwnershipMarkers(ValidationContext context)
+    {
+        foreach (var rule in FocusPrefabRules.OrderBy(rule => rule.PrefabPath, StringComparer.Ordinal))
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(rule.PrefabPath);
+            if (prefab == null)
+            {
+                context.AddError("MissingFocusPrefab", rule.PrefabPath, "prefab not found");
+                continue;
+            }
+
+            if (rule.MarkerType == typeof(RuntimeBootstrapOwner))
+            {
+                var owners = prefab.GetComponentsInChildren<RuntimeBootstrapOwner>(true);
+                if (!owners.Any(owner => owner != null && owner.OwnerId == rule.RequiredOwnerId))
+                {
+                    context.AddError("MissingOwnershipMarker", rule.PrefabPath, "RuntimeBootstrapOwner.ownerId=" + rule.RequiredOwnerId);
+                }
+
+                continue;
+            }
+
+            if (!prefab.GetComponentsInChildren(rule.MarkerType, true).Cast<Component>().Any(component => component != null))
+            {
+                context.AddError("MissingOwnershipMarker", rule.PrefabPath, rule.MarkerType.FullName);
+            }
+        }
+    }
+
+    static void ValidateServiceComponentLocations(ValidationContext context)
+    {
+        foreach (var record in context.ServiceComponents)
+        {
+            if (!ApprovedServicePrefabs.Contains(record.PrefabPath))
+            {
+                context.AddError("UnapprovedServicePrefab", record.PrefabPath, record.Type.FullName + " at " + record.TransformPath);
+            }
+
+            if (record.IsNestedPrefabInstance && !ApprovedServicePrefabs.Contains(record.PrefabPath))
+            {
+                context.AddError("NestedServicePrefabInstance", record.PrefabPath, record.Type.FullName + " at " + record.TransformPath);
+            }
+        }
+    }
+
+    static bool IsPrefabInstanceBackedYamlDocument(string yaml, int index)
+    {
+        var documentStart = yaml.LastIndexOf("--- !u!", index, StringComparison.Ordinal);
+        if (documentStart < 0)
+        {
+            return false;
+        }
+
+        var nextDocument = yaml.IndexOf("\n--- !u!", documentStart + 1, StringComparison.Ordinal);
+        var documentLength = nextDocument < 0 ? yaml.Length - documentStart : nextDocument - documentStart;
+        var document = yaml.Substring(documentStart, documentLength);
+        return document.Contains("m_PrefabInstance: {fileID: ") && !document.Contains("m_PrefabInstance: {fileID: 0}");
+    }
+
+    static bool RegistersRuntimeService(MonoBehaviour component)
+    {
+        var script = MonoScript.FromMonoBehaviour(component);
+        return script != null && script.text.Contains(RegisterCall);
+    }
+
+    static bool IsNestedPrefabInstance(GameObject gameObject)
+    {
+        return PrefabUtility.IsPartOfPrefabInstance(gameObject) && PrefabUtility.GetNearestPrefabInstanceRoot(gameObject) != null;
+    }
+
+    static string TransformPath(Transform transform)
+    {
+        var names = new Stack<string>();
+        while (transform != null)
+        {
+            names.Push(transform.name);
+            transform = transform.parent;
+        }
+
+        return string.Join("/", names.ToArray());
+    }
+
+    sealed class FocusPrefabRule
+    {
+        public readonly string PrefabPath;
+        public readonly Type MarkerType;
+        public readonly string RequiredOwnerId;
+
+        public FocusPrefabRule(string prefabPath, Type markerType, string requiredOwnerId)
+        {
+            PrefabPath = prefabPath;
+            MarkerType = markerType;
+            RequiredOwnerId = requiredOwnerId;
+        }
+    }
+
+    sealed class ServiceComponentRecord
+    {
+        public readonly string PrefabPath;
+        public readonly Type Type;
+        public readonly string TransformPath;
+        public readonly bool IsNestedPrefabInstance;
+
+        public ServiceComponentRecord(string prefabPath, Type type, string transformPath, bool isNestedPrefabInstance)
+        {
+            PrefabPath = prefabPath;
+            Type = type;
+            TransformPath = transformPath;
+            IsNestedPrefabInstance = isNestedPrefabInstance;
+        }
+
+        public static int Compare(ServiceComponentRecord left, ServiceComponentRecord right)
+        {
+            var typeCompare = string.Compare(left.Type.FullName, right.Type.FullName, StringComparison.Ordinal);
+            if (typeCompare != 0)
+            {
+                return typeCompare;
+            }
+
+            var prefabCompare = string.Compare(left.PrefabPath, right.PrefabPath, StringComparison.Ordinal);
+            if (prefabCompare != 0)
+            {
+                return prefabCompare;
+            }
+
+            return string.Compare(left.TransformPath, right.TransformPath, StringComparison.Ordinal);
+        }
+    }
+
+    sealed class ValidationContext
+    {
+        public readonly string[] PrefabPaths;
+        public readonly List<string> Errors = new List<string>();
+        public readonly List<ServiceComponentRecord> ServiceComponents = new List<ServiceComponentRecord>();
+
+        public ValidationContext(string[] prefabPaths)
+        {
+            PrefabPaths = prefabPaths;
+        }
+
+        public void AddError(string rule, string prefabPath, string detail)
+        {
+            Errors.Add(rule + " | " + prefabPath + " | " + detail);
+        }
+
+        public void LogReport()
+        {
+            Errors.Sort(StringComparer.Ordinal);
+
+            var builder = new StringBuilder();
+            builder.AppendLine("[BeaverMania Prefab Integration Validation]");
+            builder.AppendLine("Prefabs scanned: " + PrefabPaths.Length);
+            builder.AppendLine("Errors: " + Errors.Count);
+            foreach (var error in Errors)
+            {
+                builder.AppendLine("ERROR | " + error);
+            }
+
+            if (Errors.Count == 0)
+            {
+                Debug.Log(builder.ToString());
+            }
+            else
+            {
+                Debug.LogError(builder.ToString());
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Validation/Editor/PrefabIntegrationValidator.cs.meta
+++ b/Assets/Scripts/Validation/Editor/PrefabIntegrationValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04c2fae651014548bff701f5b2ccac45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/VALIDATION_RULES.md
+++ b/Docs/VALIDATION_RULES.md
@@ -1,7 +1,35 @@
 # Validation Rules
 
+## Editor prefab integration validation
+
+Run `Tools/BeaverMania/Validation/Run Prefab Integration Validation` after prefab, ownership, runtime service, or serialized-reference changes.
+
+Menu items:
+
+- `Tools/BeaverMania/Validation/Run Prefab Integration Validation`: full prefab scan.
+- `Tools/BeaverMania/Validation/Validate References`: missing `MonoBehaviour` scripts and detectable missing serialized object references.
+- `Tools/BeaverMania/Validation/Validate Service Ownership`: runtime service duplication, ownership markers, and unapproved service locations.
+
+The validator scans all project prefabs with `AssetDatabase.FindAssets("t:Prefab")` and prints one deterministic Unity console report sorted by rule, prefab path, and detail.
+
+### Rules
+
+- Missing `MonoBehaviour` scripts are errors.
+- Serialized object references are errors when a referenced asset GUID is missing, or when a non-prefab-instance-backed local `fileID` does not exist in the prefab YAML.
+- A component type whose script calls `RuntimeServices.Register` may appear in only one prefab unless this document and the validator allow-list are updated.
+- Runtime service components are allowed only in approved service owner prefabs:
+  - `Assets/Prefabs/Objects/UI/GameMusic.prefab`
+  - `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab`
+- Focus prefabs must keep ownership markers:
+  - `Assets/Prefabs/Objects/UI/GameMusic.prefab`: `RuntimeBootstrapOwner.ownerId=runtime-bootstrap`
+  - `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab`: `PrefabRuntimeHardening`
+  - `Assets/Prefabs/Wasp/LVL1 Wasp.prefab`: `PrefabRuntimeHardening`
+  - `Assets/Prefabs/Scorpion/ScorpionBoss.prefab`: `PrefabRuntimeHardening`
+- Nested prefab instances containing runtime service components outside approved owner prefabs are errors.
+
 ## Required checks
 
+- Run `Tools/BeaverMania/Validation/Run Prefab Integration Validation` before committing prefab integration changes.
 - Run `Tools/Runtime Services/Validate Prefab Registrations` after adding, moving, removing, or variant-overriding any component that calls `RuntimeServices.Register`.
 - Run prefab play-mode smoke tests after changing required refs, tags, layers, animation paths, hitboxes, or UI event wiring.
 - Keep `PrefabRuntimeHardening.requiredComponents` and `requiredObjects` aligned with this documentation.


### PR DESCRIPTION
### Motivation

- Add an editor-side, deterministic prefab scanner to catch integration issues early (missing scripts, broken serialized refs, duplicated runtime service registrations, and ownership/placement drift). 
- Enforce existing runtime service and prefab ownership rules so persistent/scene services remain correctly owned and not duplicated across prefabs.

### Description

- Add `Assets/Scripts/Validation/Editor/PrefabIntegrationValidator.cs` providing menu items under `Tools/BeaverMania/Validation/` and scanning all prefabs via `AssetDatabase.FindAssets("t:Prefab")`.
- Validate missing `MonoBehaviour` scripts, detectable serialized object references with missing asset GUIDs or missing local `fileID`s (with prefab-instance-backed YAML detection), duplicate `RuntimeServices.Register` component types, focus prefab ownership markers, and service components placed outside approved owner prefabs or inside nested prefab instances.
- Emit a single deterministic report sorted by rule/prefab/detail and log to Unity console using `Debug.Log` / `Debug.LogError`.
- Document usage, menu commands, approved owner prefabs, and validation rules in `Docs/VALIDATION_RULES.md`.

### Testing

- Ran `git diff --check` and fixed issues; result passed with no diff-check errors.
- Performed static source checks using small Python scripts to assert presence of menu strings and `AssetDatabase.FindAssets("t:Prefab")` usage; checks passed.
- Executed local YAML inspection scripts during development to sanity-check the missing-`fileID` detection logic; scripts reported prefabs with detectable missing local fileIDs (used to validate conservative detection behavior).
- Unity editor was not available in this environment so editor menu invocation was not executed here; the code is editor-only and committed for validation inside Unity Editor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff16f047d4832ab48b863b73c52ae0)