### PR TITLE
Guard wasp spawner ticking on validation

### DIFF
--- a/Assets/Scripts/Objects/Hive/WaspSpawner.cs
+++ b/Assets/Scripts/Objects/Hive/WaspSpawner.cs
@@ -5,9 +5,10 @@ using UnityEngine;
 public class WaspSpawner : MonoBehaviour, IRuntimeResettable
 {
     public GameObject Wasp;
-    public GameObject Hive;
+    [SerializeField] GameObject Hive;
     public Behaviour Player;
     Transform playerTransform;
+    private bool initialized;
     public Vector3 Distance;
     [SerializeField] float SpawnDistance;
     public int WaspCounter=3;
@@ -26,17 +27,28 @@ public class WaspSpawner : MonoBehaviour, IRuntimeResettable
     { 
         Counter=WaspCounter;
         RealClock = SpawnClock;
-        if (PlayerReference.TryGetPlayer(out Player))
+        if (Hive == null)
+        {
+            Hive = gameObject;
+        }
+
+        if (Player == null)
+        {
+            PlayerReference.TryGetPlayer(out Player);
+        }
+
+        if (Player != null)
         {
             playerTransform = Player.transform;
         }
 
-        if (!ValidateReferences())
+        bool validReferences = ValidateReferences();
+        if (validReferences && playerTransform != null)
         {
-            return;
+            CaptureRuntimeState();
         }
 
-        CaptureRuntimeState();
+        initialized = validReferences && playerTransform != null;
     }
 
     void CaptureRuntimeState()
@@ -76,6 +88,11 @@ public class WaspSpawner : MonoBehaviour, IRuntimeResettable
 
     public void Update()
     {
+        if (!initialized)
+        {
+            return;
+        }
+
          Distance = playerTransform.position - gameObject.transform.position;
 
         if (Mathf.Abs(Distance.magnitude) < SpawnDistance )

--- a/Docs/VALIDATION_RULES.md
+++ b/Docs/VALIDATION_RULES.md
@@ -44,6 +44,7 @@ The validator scans all project prefabs with `AssetDatabase.FindAssets("t:Prefab
 ## Reference validation
 
 - Required refs: non-null serialized components/objects needed for startup, gameplay, damage, input, UI navigation, spawning, or scene transition.
+- Failed required-reference validation must prevent ticking behavior.
 - Optional refs: null-safe, feature-gated, scene-provided, or cosmetic refs.
 - `PrefabRuntimeHardening` should cover required refs that can be validated on `Awake` without scene dependencies.
 - Do not add validation for refs intentionally resolved from the active scene.


### PR DESCRIPTION
### Motivation
- Prevent `WaspSpawner` from running `Update()` when required serialized references or the player `Transform` are not resolved to avoid null-access and unintended runtime behaviour.
- Prefer an explicit serialized/local owner for `Hive` while preserving `PlayerReference.TryGetPlayer()` as a compatibility fallback for player resolution.
- Make required-reference validation a gate for ticking behaviour and document the rule in validation docs.

### Description
- Add a private `initialized` flag and set it at the end of `Start()` to `ValidateReferences() && playerTransform != null`.
- Change `Hive` to a serialized/local owner (`[SerializeField] GameObject Hive`) and fallback to `Hive = gameObject` in `Start()` when null.
- Prefer a serialized `Player` first, then call `PlayerReference.TryGetPlayer(out Player)` as a fallback, assign `playerTransform` when available, and compute `validReferences = ValidateReferences()`.
- Early-return from `Update()` when `initialized` is `false` to stop ticking behaviour when validation failed.
- Add the rule `Failed required-reference validation must prevent ticking behavior.` to `Docs/VALIDATION_RULES.md`.

### Testing
- Ran `git diff --check` which reported no whitespace/format issues and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff1cba1b1c832ab18177ad5488704f)