### PR TITLE
Add script hierarchy folder metadata

### DIFF
--- a/Assets/Scripts/AI.meta
+++ b/Assets/Scripts/AI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 791ae3207c5e1fca942c0ca7a7b1d96b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/HIERARCHY_GUIDE.md
+++ b/Docs/HIERARCHY_GUIDE.md
@@ -31,6 +31,14 @@ See also: [Hierarchy and Reference Checklist](HierarchyAndReferenceChecklist.md)
 - `_Sockets` — stable attachment/spawn/IK/weapon/camera anchors.
 - `_Debug` — debug-only helpers and validation markers.
 
+
+## Additive script folder rules
+
+- `Assets/Scripts/AI` is reserved for new AI-specific scripts; do not move existing scripts into it as part of hierarchy cleanup.
+- `Assets/Scripts/Runtime` is reserved for new runtime-ownership helpers only.
+- `Assets/Scripts/Validation/Editor` is reserved for new validation and editor-only tooling only.
+- Folder additions are additive: create the folder and Unity `.meta` file, then leave existing scripts in place unless a migration is explicitly scoped.
+
 ## Reference rules
 
 - Prefer serialized refs, typed components, interfaces, and `TryGetComponent` over tags or hierarchy names.


### PR DESCRIPTION
### Motivation
- Reserve additive script folders for future organized additions without moving existing scripts.
- Allow new runtime ownership helpers and editor validation tooling to have clear, documented locations.

### Description
- Add Unity folder metadata file `Assets/Scripts/AI.meta` to create the `Assets/Scripts/AI` folder.
- Ensure `Assets/Scripts/Runtime` and `Assets/Scripts/Validation/Editor` exist and are documented as reserved locations for runtime and editor validation tooling respectively.
- Update `Docs/HIERARCHY_GUIDE.md` to include the “Additive script folder rules” describing placement rules and the requirement to leave existing scripts unmoved.

### Testing
- Ran `git diff --check` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff2142d694832a8b4c3f1a08082f06)