### PR TITLE
Harden runtime service resolution

### DIFF
--- a/Assets/Scripts/Core/CheckpointService.cs
+++ b/Assets/Scripts/Core/CheckpointService.cs
@@ -9,6 +9,12 @@ public sealed class CheckpointService : MonoBehaviour
 
     public static CheckpointService GetOrCreate()
     {
+        CheckpointService service;
+        if (RuntimeServices.TryGetOrFind(ServiceLifetime.Scene, out service))
+        {
+            return service;
+        }
+
         return RuntimeServices.GetOrCreate<CheckpointService>(ServiceLifetime.Scene);
     }
 

--- a/Assets/Scripts/Core/CursorStateService.cs
+++ b/Assets/Scripts/Core/CursorStateService.cs
@@ -7,7 +7,7 @@ public class CursorStateService : MonoBehaviour
 
     public static CursorStateService GetOrCreate()
     {
-        return RuntimeServices.GetOrCreate<CursorStateService>(ServiceLifetime.Persistent);
+        return RuntimeServices.GetRequired<CursorStateService>(ServiceLifetime.Persistent);
     }
 
     private void Awake()

--- a/Assets/Scripts/Core/GameFlowController.cs
+++ b/Assets/Scripts/Core/GameFlowController.cs
@@ -9,7 +9,7 @@ public class GameFlowController : MonoBehaviour
 
     public static GameFlowController GetOrCreate()
     {
-        return RuntimeServices.GetOrCreate<GameFlowController>(ServiceLifetime.Persistent);
+        return RuntimeServices.GetRequired<GameFlowController>(ServiceLifetime.Persistent);
     }
 
     private void Awake()

--- a/Assets/Scripts/Core/RuntimeServices.cs
+++ b/Assets/Scripts/Core/RuntimeServices.cs
@@ -31,30 +31,78 @@ public static class RuntimeServices
         return false;
     }
 
-    public static T GetOrCreate<T>(ServiceLifetime lifetime) where T : Component
+    public static bool TryGetOrFind<T>(ServiceLifetime lifetime, out T service) where T : Component
     {
-        var serviceType = typeof(T);
-        T service;
         if (TryGet(out service))
         {
-            return service;
+            return true;
         }
 
         service = UnityEngine.Object.FindObjectOfType<T>();
         if (service != null)
         {
             Register(service, lifetime);
+            return true;
+        }
+
+        return false;
+    }
+
+    public static T GetRequired<T>(ServiceLifetime lifetime) where T : Component
+    {
+        T service;
+        if (TryGetOrFind(lifetime, out service))
+        {
             return service;
         }
 
+        throw MissingService<T>(lifetime, false);
+    }
+
+    public static T GetOrCreate<T>(ServiceLifetime lifetime) where T : Component
+    {
+        T service;
+        if (TryGetOrFind(lifetime, out service))
+        {
+            return service;
+        }
+
+        if (lifetime == ServiceLifetime.Persistent)
+        {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            return CreateFallback<T>(lifetime);
+#else
+            throw MissingService<T>(lifetime, true);
+#endif
+        }
+
+        return CreateFallback<T>(lifetime);
+    }
+
+    private static T CreateFallback<T>(ServiceLifetime lifetime) where T : Component
+    {
+        var serviceType = typeof(T);
         BuildSafeLogger.WarnOnce(
             serviceType.FullName + ".MissingService",
             "Missing runtime service; creating fallback " + serviceType.Name + ".",
             null,
             serviceType.Name);
-        service = new GameObject(serviceType.Name).AddComponent<T>();
+        var service = new GameObject(serviceType.Name).AddComponent<T>();
         Register(service, lifetime);
         return service;
+    }
+
+    private static InvalidOperationException MissingService<T>(ServiceLifetime lifetime, bool blockedFallback) where T : Component
+    {
+        var serviceType = typeof(T);
+        var message = "Missing " + lifetime + " runtime service: " + serviceType.Name + ". Add it to the scene/bootstrap before use.";
+        if (blockedFallback)
+        {
+            message += " Release builds do not create fallback persistent services.";
+        }
+
+        Debug.LogError(message);
+        return new InvalidOperationException(message);
     }
 
     public static bool Register<T>(T service, ServiceLifetime lifetime) where T : UnityEngine.Object

--- a/Assets/Scripts/Core/SceneTransitionService.cs
+++ b/Assets/Scripts/Core/SceneTransitionService.cs
@@ -15,7 +15,7 @@ public class SceneTransitionService : MonoBehaviour
 
     public static SceneTransitionService GetOrCreate()
     {
-        return RuntimeServices.GetOrCreate<SceneTransitionService>(ServiceLifetime.Persistent);
+        return RuntimeServices.GetRequired<SceneTransitionService>(ServiceLifetime.Persistent);
     }
 
     public static void LoadMenu()

--- a/Assets/Scripts/Input/GameInputReader.cs
+++ b/Assets/Scripts/Input/GameInputReader.cs
@@ -30,7 +30,7 @@ public class GameInputReader : MonoBehaviour
 
     public static GameInputReader GetOrCreate()
     {
-        return RuntimeServices.GetOrCreate<GameInputReader>(ServiceLifetime.Persistent);
+        return RuntimeServices.GetRequired<GameInputReader>(ServiceLifetime.Persistent);
     }
 
     internal void EnableGameplayInput()


### PR DESCRIPTION
### Motivation
- Split service resolution so callers can choose no-create lookups vs creation and avoid silently spawning persistent singletons in release builds.
- Ensure missing persistent services fail loudly while allowing editor/development fallback for convenience.

### Description
- Added `TryGetOrFind<T>(ServiceLifetime, out T)` to perform no-create resolution (registered lookup + scene `FindObjectOfType`) and `GetRequired<T>(ServiceLifetime)` which throws if missing.
- Changed `GetOrCreate<T>(ServiceLifetime)` to use `TryGetOrFind` and to block creating fallback persistent services in release builds, with editor/development fallback gated by `#if UNITY_EDITOR || DEVELOPMENT_BUILD`.
- Introduced `CreateFallback<T>` to centralize fallback creation and `MissingService<T>` to log an explicit error and throw an `InvalidOperationException` when creation is blocked.
- Updated public wrappers to preserve existing names: `SceneTransitionService.GetOrCreate`, `GameFlowController.GetOrCreate`, `CursorStateService.GetOrCreate`, and `GameInputReader.GetOrCreate` now call `RuntimeServices.GetRequired<...>(ServiceLifetime.Persistent)` to surface missing persistent services immediately.
- Kept scene-scoped behavior for `CheckpointService.GetOrCreate` by first using `TryGetOrFind(ServiceLifetime.Scene, out ...)` and falling back to `GetOrCreate<CheckpointService>(ServiceLifetime.Scene)` for explicit scene creation.

### Testing
- Ran `git diff --check` and it produced no issues (passed).
- Ran `if rg "RuntimeServices\.GetOrCreate<.*ServiceLifetime\.Persistent" Assets/Scripts -n; then exit 1; else exit 0; fi` to verify no remaining persistent `GetOrCreate` callsites and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff383751f0832ab523131ea5f6821c)