### PR TITLE
Move CheckpointService to scene-local owner; add RuntimeServiceOwnerMarker and safe scene-reset

### DIFF
--- a/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
+++ b/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
@@ -29802,7 +29802,6 @@ GameObject:
   - component: {fileID: 4580562239172740852}
   - component: {fileID: 8605846543303424432}
   - component: {fileID: 6562972538239049110}
-  - component: {fileID: 9000000000000000002}
   - component: {fileID: 9000000000000000004}
   - component: {fileID: 9000000000000000005}
   - component: {fileID: 9000000000000000006}
@@ -29846,6 +29845,7 @@ Transform:
   - {fileID: 5087866083122848623}
   - {fileID: 8448209182249481495}
   - {fileID: 8605846543736189813}
+  - {fileID: 9100000000000000002}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -30216,13 +30216,60 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.5, y: 1.227511, z: 0.5}
   m_Center: {x: 0, y: -0.62334055, z: 0}
---- !u!114 &9000000000000000002
+--- !u!1 &9100000000000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9100000000000000002}
+  - component: {fileID: 9100000000000000003}
+  - component: {fileID: 9100000000000000004}
+  m_Layer: 3
+  m_Name: SceneCheckpointService
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9100000000000000002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9100000000000000001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4580562239172740855}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &9100000000000000003
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4580562239172740874}
+  m_GameObject: {fileID: 9100000000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b9f77a6bb764c1ab8ee22d753ceaf0a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  ownerKind: 0
+  destroyOnSceneServiceReset: 0
+--- !u!114 &9100000000000000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9100000000000000001}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d6b88b9371a84b7badcd912c05c0f23a, type: 3}

--- a/Assets/Scripts/Core/RuntimeServiceOwnerMarker.cs
+++ b/Assets/Scripts/Core/RuntimeServiceOwnerMarker.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public enum RuntimeServiceOwnerKind
+{
+    PrefabOwned = 0,
+    FallbackCreated = 1
+}
+
+public sealed class RuntimeServiceOwnerMarker : MonoBehaviour
+{
+    [SerializeField] RuntimeServiceOwnerKind ownerKind;
+    [SerializeField] bool destroyOnSceneServiceReset;
+
+    public RuntimeServiceOwnerKind OwnerKind { get { return ownerKind; } }
+    public bool DestroyOnSceneServiceReset { get { return destroyOnSceneServiceReset; } }
+
+    public void MarkFallbackCreated()
+    {
+        ownerKind = RuntimeServiceOwnerKind.FallbackCreated;
+        destroyOnSceneServiceReset = true;
+    }
+}

--- a/Assets/Scripts/Core/RuntimeServiceOwnerMarker.cs.meta
+++ b/Assets/Scripts/Core/RuntimeServiceOwnerMarker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b9f77a6bb764c1ab8ee22d753ceaf0a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/RuntimeServices.cs
+++ b/Assets/Scripts/Core/RuntimeServices.cs
@@ -87,7 +87,9 @@ public static class RuntimeServices
             "Missing runtime service; creating fallback " + serviceType.Name + ".",
             null,
             serviceType.Name);
-        var service = new GameObject(serviceType.Name).AddComponent<T>();
+        var owner = new GameObject(serviceType.Name);
+        owner.AddComponent<RuntimeServiceOwnerMarker>().MarkFallbackCreated();
+        var service = owner.AddComponent<T>();
         Register(service, lifetime);
         return service;
     }
@@ -221,12 +223,16 @@ public static class RuntimeServices
             var component = registration.Service as Component;
             if (component != null)
             {
-                UnityEngine.Object.Destroy(component.gameObject);
+                var owner = component.GetComponent<RuntimeServiceOwnerMarker>();
+                if (owner != null && owner.DestroyOnSceneServiceReset)
+                {
+                    UnityEngine.Object.Destroy(component.gameObject);
+                }
+
+                continue;
             }
-            else
-            {
-                UnityEngine.Object.Destroy(registration.Service);
-            }
+
+            UnityEngine.Object.Destroy(registration.Service);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Avoid destroying the player root when scene services are cleaned up by moving `CheckpointService` off the player root into a dedicated scene-local owner object. 
- Ensure services created as fallbacks can be distinguished from prefab-owned gameplay objects. 
- Prevent `RuntimeServices.ResetSceneServices()` from blindly destroying gameplay objects during reloads. 

### Description
- Removed `CheckpointService` component from the player root prefab and added a dedicated `SceneCheckpointService` child GameObject that hosts the service instance in `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab`.
- Added `Assets/Scripts/Core/RuntimeServiceOwnerMarker.cs` which defines `RuntimeServiceOwnerMarker` and `RuntimeServiceOwnerKind` to mark owner objects and expose `DestroyOnSceneServiceReset`.
- Updated `RuntimeServices.CreateFallback<T>` to create a service owner GameObject and call `MarkFallbackCreated()` on the marker before adding the service component.
- Updated `RuntimeServices.ResetSceneServices()` to unregister scene services and only destroy the service GameObject when a `RuntimeServiceOwnerMarker` exists and `DestroyOnSceneServiceReset` is true, otherwise skip destruction.

### Testing
- Ran `git diff --check` to validate no whitespace/conflict errors and it succeeded. 
- Ran prefab/placement assertions using a Python script that checks the player prefab no longer contains the original `CheckpointService` component and that `SceneCheckpointService` and the marker GUID are present, and it succeeded. 
- Ran C# brace-balance validation across modified files via Python and `rg` searches for `CheckpointService.GetOrCreate`, `ResetSceneServices`, `ReloadActiveScene`, and marker usages to validate references, and all checks succeeded. 
- Attempted to run `command -v unity || command -v Unity || command -v unity-editor || true` but the Unity editor is not available in this environment so full runtime reload validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3929d534832aac6f23c1501c8b32)