### PR TITLE
Unify player failure life handling

### DIFF
--- a/Assets/Scripts/Player/PlayerFailureController.cs
+++ b/Assets/Scripts/Player/PlayerFailureController.cs
@@ -41,47 +41,35 @@ public class PlayerFailureController : MonoBehaviour
             }
         }
 
-        isResolvingFailure = true;
-
-        if (reason == PlayerFailureReason.CompatibilityRestart)
-        {
-            RestartCheckpointForCompatibility();
-            isResolvingFailure = false;
-            return;
-        }
-
-        if (owner.Lives > 1)
-        {
-            owner.Lives--;
-            owner.RestoreHealth();
-            owner.MoveToCheckpoint();
-            ResetRuntimeState();
-            isResolvingFailure = false;
-            return;
-        }
-
-        owner.Lives = 0;
-        owner.ActivateLooseMenu();
-        isResolvingFailure = false;
+        RestartCheckpointForCompatibility();
     }
 
     void RestartCheckpointForCompatibility()
     {
-        if (owner.Lives <= 0)
+        if (isResolvingFailure)
         {
-            owner.Lives = 0;
-            owner.ActivateLooseMenu();
             return;
         }
 
-        owner.RestoreHealth();
-        owner.MoveToCheckpoint();
-        if (owner.Lives > 1)
+        isResolvingFailure = true;
+        try
         {
-            owner.Lives--;
-        }
+            if (owner.Lives > 1)
+            {
+                owner.Lives--;
+                owner.RestoreHealth();
+                owner.MoveToCheckpoint();
+                ResetRuntimeState();
+                return;
+            }
 
-        ResetRuntimeState();
+            owner.Lives = 0;
+            owner.ActivateLooseMenu();
+        }
+        finally
+        {
+            isResolvingFailure = false;
+        }
     }
 
     void ResetRuntimeState()


### PR DESCRIPTION
### Motivation
- Centralize failure handling so compatibility restarts and other failure paths follow the same lives rule: if `owner.Lives > 1` decrement/restore/move/reset, otherwise set lives to `0` and show the lose menu.
- Prevent duplicate or re-entrant failure resolution by ensuring the existing `isResolvingFailure` flag is respected.

### Description
- Route `HandleFailure(...)` calls into a single `RestartCheckpointForCompatibility()` implementation while keeping the public `Behaviour.RestartCheckpoint()` API unchanged.
- Move the `isResolvingFailure` guard into `RestartCheckpointForCompatibility()` and wrap the resolved work in a `try/finally` to guarantee `isResolvingFailure` is cleared.
- Apply the unified life rule: when `owner.Lives > 1` decrement and call `owner.RestoreHealth()`, `owner.MoveToCheckpoint()`, and `ResetRuntimeState()`, otherwise set `owner.Lives = 0` and call `owner.ActivateLooseMenu()`.
- Preserve existing `ResetRuntimeState()` behavior and other public APIs.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3afe0c80832aace9c27ba0722db9)