### PR TITLE
Fix pause menu cursor state handling

### DIFF
--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -60,7 +60,7 @@ public class PauseMenuController : MonoBehaviour
             }
         }
 
-        Player.HideCursor();
+        CursorStateService.GetOrCreate().HideCursor();
         HidePausePanel();
         HideQuestionPanel();
     }
@@ -75,22 +75,26 @@ public class PauseMenuController : MonoBehaviour
         if (ActivePause)
         {
             ShowPausePanel();
-            Player.ShowCursor();
             return;
         }
 
         HidePausePanel();
         HideQuestionPanel();
-        if (Player != null && !Player.isAtTrader)
-        {
-            Player.HideCursor();
-        }
     }
 
     public void ChangeBolean()
     {
-        ActivePause = !ActivePause;
-        SetPaused(ActivePause);
+        var pauseRequested = !ActivePause;
+        var keepCursorVisible = !pauseRequested && IsPlayerInTraderOrDialogueUi();
+
+        if (!SetPaused(pauseRequested))
+        {
+            return;
+        }
+
+        ActivePause = pauseRequested;
+        ApplyCursorState(pauseRequested, keepCursorVisible);
+        Pause();
     }
 
     void HandlePausePressed()
@@ -146,7 +150,7 @@ public class PauseMenuController : MonoBehaviour
         SetPanel(Question, false, this, nameof(Question));
     }
 
-    void SetPaused(bool paused)
+    bool SetPaused(bool paused)
     {
         if (gameFlow == null)
         {
@@ -156,7 +160,37 @@ public class PauseMenuController : MonoBehaviour
         if (!gameFlow.SetPaused(paused))
         {
             ActivePause = false;
+            return false;
         }
+
+        return true;
+    }
+
+    void ApplyCursorState(bool paused, bool keepCursorVisible)
+    {
+        var cursorState = CursorStateService.GetOrCreate();
+        if (paused)
+        {
+            cursorState.ShowCursor();
+            return;
+        }
+
+        if (!keepCursorVisible)
+        {
+            cursorState.HideCursor();
+        }
+    }
+
+    bool IsPlayerInTraderOrDialogueUi()
+    {
+        if (Player != null && Player.isAtTrader)
+        {
+            return true;
+        }
+
+        var currentFlow = gameFlow != null ? gameFlow : GameFlowController.Instance;
+        return currentFlow != null &&
+            (currentFlow.State == GameFlowState.Shop || currentFlow.State == GameFlowState.Dialogue);
     }
 
     static void SetPanel(GameObject panel, bool active, PauseMenuController owner, string fieldName)


### PR DESCRIPTION
### Motivation
- Prevent the pause loop from mutating cursor state every frame and centralize cursor visibility management through `CursorStateService`.
- Ensure resuming gameplay does not hide the cursor when returning to trader/dialogue UI and avoid calling `Player.ShowCursor()`/`Player.HideCursor()` directly from `Pause()`.

### Description
- Replaced the direct `Player.HideCursor()` call in `Start()` with `CursorStateService.GetOrCreate().HideCursor()`. 
- Changed `Pause()` to only apply panel visibility and removed per-frame cursor mutations and direct `Player` cursor calls. 
- Moved pause-related cursor transitions into `ChangeBolean()` which now gates via `SetPaused(...)`, calls new `ApplyCursorState(...)`, and uses `IsPlayerInTraderOrDialogueUi()` to keep cursor visible when appropriate. 
- Added a boolean-returning `SetPaused(bool)` wrapper that uses `GameFlowController.SetPaused()` as the single source of truth for pause/timeScale changes, and added null guards around `Player` checks used to determine trader/dialogue state while preserving public methods `ChangeBolean`, `RestartCheckpointFromMenu`, `MainMenu`, and `Volume` for scene button compatibility.

### Testing
- Ran `git diff --check` which reported no whitespace or diff issues and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3eaf043c832a9c27acf66323bca2)