### PR TITLE
Guard scene startup flow changes

### DIFF
--- a/Assets/Scripts/Core/GameFlowController.cs
+++ b/Assets/Scripts/Core/GameFlowController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 [DefaultExecutionOrder(-1000)]
 public class GameFlowController : MonoBehaviour
@@ -47,6 +48,31 @@ public class GameFlowController : MonoBehaviour
         State = GameFlowState.Playing;
         Time.timeScale = 1f;
         SetGameplayInput();
+    }
+
+    public bool TrySetPlayingFromSceneStartup(string ownerName)
+    {
+        if (!IsGameplayScene(SceneManager.GetActiveScene().name))
+        {
+            return false;
+        }
+
+        if (State == GameFlowState.Transitioning ||
+            State == GameFlowState.Paused ||
+            State == GameFlowState.GameOver)
+        {
+            return false;
+        }
+
+        SetPlaying();
+        return true;
+    }
+
+    public void SetMainMenu()
+    {
+        State = GameFlowState.MainMenu;
+        Time.timeScale = 1f;
+        SetUiInput();
     }
 
     public bool SetPaused(bool paused)
@@ -107,6 +133,11 @@ public class GameFlowController : MonoBehaviour
         State = GameFlowState.Transitioning;
         Time.timeScale = 1f;
         SetInputDisabled();
+    }
+
+    static bool IsGameplayScene(string sceneName)
+    {
+        return sceneName == SceneNames.Level1;
     }
 
     void SetGameplayInput()

--- a/Assets/Scripts/Core/SceneTransitionService.cs
+++ b/Assets/Scripts/Core/SceneTransitionService.cs
@@ -250,7 +250,7 @@ public class SceneTransitionService : MonoBehaviour
             if (isMenu)
             {
                 CursorStateService.GetOrCreate().ShowCursor();
-                GameInputReader.GetOrCreate().EnableUiInput();
+                GameFlowController.GetOrCreate().SetMainMenu();
             }
             else
             {

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -969,7 +969,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
 
         inputReader = GameInputReader.GetOrCreate();
-        GameFlowController.GetOrCreate().SetPlaying();
+        GameFlowController.GetOrCreate().TrySetPlayingFromSceneStartup(nameof(Behaviour));
         Inventory.Initialize(this);
         Interaction.Initialize(this, inputReader);
         Combat.Initialize(this);

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -36,7 +36,7 @@ public class PauseMenuController : MonoBehaviour
         }
 
         gameFlow = GameFlowController.GetOrCreate();
-        gameFlow.SetPlaying();
+        gameFlow.TrySetPlayingFromSceneStartup(nameof(PauseMenuController));
         Player = playerObject.GetComponent<Behaviour>();
         if (!RuntimeReferenceValidator.Require(Player, this, nameof(Player)) ||
             !RuntimeReferenceValidator.Require(PauseMenu, this, nameof(PauseMenu)) ||


### PR DESCRIPTION
### Motivation
- Prevent scene-local `Start()` methods from unconditionally stomping runtime flow by removing direct `SetPlaying()` calls where possible.
- Make `SceneTransitionService.CompleteLoad()` authoritative for setting menu/gameplay runtime flow and provide a guarded compatibility helper for legacy scene entry.

### Description
- Add `TrySetPlayingFromSceneStartup(string ownerName)` to `GameFlowController` which only calls `SetPlaying()` when `IsGameplayScene(...)` and the current `State` is not `Transitioning`, `Paused`, or `GameOver`, and add `SetMainMenu()` and `IsGameplayScene(...)` helpers.
- Replace direct `SetPlaying()` calls in `Behaviour.Start()` and `PauseMenuController.Start()` with `TrySetPlayingFromSceneStartup(...)` to avoid state stomps on scene startup.
- Make `SceneTransitionService.CompleteLoad()` call `SetMainMenu()` for the menu scene and `SetPlaying()` for non-menu scenes so scene loads determine the intended runtime flow.
- Preserve existing public APIs and scene button methods; changes are backward-compatible fallbacks for legacy startup code.

### Testing
- Ran `git diff --check` which completed with no issues.
- Verified code changes with `rg -n "Start\(\)|SetPlaying\(\)|TrySetPlayingFromSceneStartup|SetMainMenu|CompleteLoad"` and confirmed the replaced call sites.
- Committed changes and validated `git status --short` / `git diff --stat` to ensure only the 4 intended files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4087c27c832aa23f4b5c905d0bdf)