### PR TITLE
Validate runtime bootstrap owner services

### DIFF
--- a/Assets/Editor/RuntimeServicePrefabValidator.cs
+++ b/Assets/Editor/RuntimeServicePrefabValidator.cs
@@ -9,14 +9,6 @@ public static class RuntimeServicePrefabValidator
     const string RegisterCall = "RuntimeServices.Register";
     const string GameMusicPrefabPath = "Assets/Prefabs/Objects/UI/GameMusic.prefab";
 
-    static readonly System.Type[] PersistentServiceTypes =
-    {
-        typeof(SceneTransitionService),
-        typeof(CursorStateService),
-        typeof(GameFlowController),
-        typeof(GameInputReader)
-    };
-
     [MenuItem(MenuPath)]
     public static void ValidatePrefabRegistrationsMenu()
     {
@@ -27,6 +19,7 @@ public static class RuntimeServicePrefabValidator
     {
         var prefabPathsByType = new Dictionary<System.Type, List<string>>();
         var prefabPathsByOwnerId = new Dictionary<string, List<string>>();
+        var ownerServiceErrors = new List<string>();
         var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { "Assets" });
 
         foreach (var prefabGuid in prefabGuids)
@@ -40,7 +33,14 @@ public static class RuntimeServicePrefabValidator
 
             foreach (var owner in prefab.GetComponentsInChildren<RuntimeBootstrapOwner>(true))
             {
-                if (owner == null || string.IsNullOrEmpty(owner.OwnerId))
+                if (owner == null)
+                {
+                    continue;
+                }
+
+                ValidateOwnedServices(prefabPath, owner, ownerServiceErrors);
+
+                if (string.IsNullOrEmpty(owner.OwnerId))
                 {
                     continue;
                 }
@@ -111,23 +111,80 @@ public static class RuntimeServicePrefabValidator
                 + gameMusicService.Key.FullName + "\n" + GameMusicPrefabPath);
         }
 
+        foreach (var ownerServiceError in ownerServiceErrors)
+        {
+            Debug.LogError(ownerServiceError);
+        }
+
         if (persistentServicePrefabCounts.Length != 1)
         {
             Debug.LogError("Persistent runtime service components must be isolated to exactly one prefab.\n"
                 + string.Join("\n", persistentServicePrefabCounts));
         }
 
-        if (duplicateTypes.Length > 0 || duplicateOwnerIds.Length > 0 || gameMusicPersistentServices.Length > 0 || persistentServicePrefabCounts.Length != 1)
+        if (duplicateTypes.Length > 0 || duplicateOwnerIds.Length > 0 || gameMusicPersistentServices.Length > 0 || ownerServiceErrors.Count > 0 || persistentServicePrefabCounts.Length != 1)
         {
             return false;
         }
 
         if (logSuccess)
         {
-            Debug.Log("Runtime service prefab validation passed: no duplicate RuntimeServices.Register component types or RuntimeBootstrapOwner ownerIds found.");
+            Debug.Log("Runtime service prefab validation passed: no duplicate RuntimeServices.Register component types, RuntimeBootstrapOwner ownerIds, or owner service mismatches found.");
         }
 
         return true;
+    }
+
+    static void ValidateOwnedServices(string prefabPath, RuntimeBootstrapOwner owner, List<string> errors)
+    {
+        var ownedServices = owner.OwnedServices ?? new Component[0];
+        var actualServices = owner.GetComponentsInChildren<MonoBehaviour>(true)
+            .Where(component => component != null && component != owner && RegistersRuntimeService(component))
+            .Cast<Component>()
+            .ToArray();
+
+        var ownedServiceSet = new HashSet<Component>(ownedServices.Where(service => service != null));
+        var actualServiceSet = new HashSet<Component>(actualServices);
+        var ownedServiceTypes = new HashSet<System.Type>();
+
+        for (var i = 0; i < ownedServices.Length; i++)
+        {
+            var ownedService = ownedServices[i];
+            if (ownedService == null)
+            {
+                errors.Add(prefabPath + "\nRuntimeBootstrapOwner " + OwnerLabel(owner) + " ownedServices contains a null entry at index " + i + ".");
+                continue;
+            }
+
+            if (!ownedServiceTypes.Add(ownedService.GetType()))
+            {
+                errors.Add(prefabPath + "\nRuntimeBootstrapOwner " + OwnerLabel(owner) + " has duplicate owned service component type: " + ownedService.GetType().FullName + ".");
+            }
+
+            if (!actualServiceSet.Contains(ownedService))
+            {
+                errors.Add(prefabPath + "\nRuntimeBootstrapOwner " + OwnerLabel(owner) + " references a service that is not an actual registered component under the owner: " + ownedService.GetType().FullName + ".");
+            }
+
+            ServiceLifetime serviceLifetime;
+            if (RuntimeServices.TryGetDeclaredLifetime(ownedService.GetType(), out serviceLifetime) && serviceLifetime != owner.Lifetime)
+            {
+                errors.Add(prefabPath + "\nRuntimeBootstrapOwner " + OwnerLabel(owner) + " lifetime " + owner.Lifetime + " does not match owned service " + ownedService.GetType().FullName + " lifetime " + serviceLifetime + ".");
+            }
+        }
+
+        foreach (var actualService in actualServices)
+        {
+            if (!ownedServiceSet.Contains(actualService))
+            {
+                errors.Add(prefabPath + "\nRuntimeBootstrapOwner " + OwnerLabel(owner) + " ownedServices is missing actual registered component: " + actualService.GetType().FullName + ".");
+            }
+        }
+    }
+
+    static string OwnerLabel(RuntimeBootstrapOwner owner)
+    {
+        return string.IsNullOrEmpty(owner.OwnerId) ? owner.name : owner.OwnerId;
     }
 
     static bool RegistersRuntimeService(MonoBehaviour component)
@@ -138,6 +195,7 @@ public static class RuntimeServicePrefabValidator
 
     static bool IsPersistentServiceType(System.Type type)
     {
-        return PersistentServiceTypes.Contains(type);
+        ServiceLifetime lifetime;
+        return RuntimeServices.TryGetDeclaredLifetime(type, out lifetime) && lifetime == ServiceLifetime.Persistent;
     }
 }

--- a/Assets/Scripts/Core/RuntimeServices.cs
+++ b/Assets/Scripts/Core/RuntimeServices.cs
@@ -107,6 +107,28 @@ public static class RuntimeServices
         return new InvalidOperationException(message);
     }
 
+    public static bool TryGetDeclaredLifetime(Type serviceType, out ServiceLifetime lifetime)
+    {
+        if (serviceType == typeof(SceneTransitionService)
+            || serviceType == typeof(CursorStateService)
+            || serviceType == typeof(GameFlowController)
+            || serviceType == typeof(GameInputReader)
+            || serviceType == typeof(DebugBootstrapper))
+        {
+            lifetime = ServiceLifetime.Persistent;
+            return true;
+        }
+
+        if (serviceType == typeof(CheckpointService))
+        {
+            lifetime = ServiceLifetime.Scene;
+            return true;
+        }
+
+        lifetime = default(ServiceLifetime);
+        return false;
+    }
+
     public static bool Register<T>(T service, ServiceLifetime lifetime) where T : UnityEngine.Object
     {
         if (service == null)

--- a/Assets/Scripts/Runtime/RuntimeBootstrapOwner.cs
+++ b/Assets/Scripts/Runtime/RuntimeBootstrapOwner.cs
@@ -16,6 +16,8 @@ public sealed class RuntimeBootstrapOwner : MonoBehaviour
 
     void Awake()
     {
+        ValidateOwnedServices();
+
         if (lifetime == ServiceLifetime.Persistent)
         {
             DontDestroyOnLoad(gameObject);
@@ -31,6 +33,51 @@ public sealed class RuntimeBootstrapOwner : MonoBehaviour
         {
             OwnersById.Remove(ownerId);
         }
+    }
+
+    void ValidateOwnedServices()
+    {
+        if (ownedServices == null)
+        {
+            return;
+        }
+
+        var serviceTypes = new HashSet<System.Type>();
+        for (var i = 0; i < ownedServices.Length; i++)
+        {
+            var service = ownedServices[i];
+            if (service == null)
+            {
+                Debug.LogError("RuntimeBootstrapOwner ownedServices contains a null entry at index " + i + ".", this);
+                continue;
+            }
+
+            var serviceType = service.GetType();
+            if (!serviceTypes.Add(serviceType))
+            {
+                Debug.LogError("Duplicate owned runtime service component type found under owner " + OwnerLabel() + ": " + serviceType.FullName + ".", this);
+            }
+
+            ServiceLifetime serviceLifetime;
+            if (!RuntimeServices.TryGetDeclaredLifetime(serviceType, out serviceLifetime))
+            {
+                continue;
+            }
+
+            if (lifetime == ServiceLifetime.Persistent && serviceLifetime == ServiceLifetime.Scene)
+            {
+                Debug.LogError("Persistent RuntimeBootstrapOwner " + OwnerLabel() + " contains scene-lifetime-only service: " + serviceType.FullName + ".", service);
+            }
+            else if (lifetime == ServiceLifetime.Scene && serviceLifetime == ServiceLifetime.Persistent)
+            {
+                Debug.LogError("Scene RuntimeBootstrapOwner " + OwnerLabel() + " contains persistent service: " + serviceType.FullName + ".", service);
+            }
+        }
+    }
+
+    string OwnerLabel()
+    {
+        return string.IsNullOrEmpty(ownerId) ? name : ownerId;
     }
 
     void ValidateUniqueOwnerId()
@@ -54,6 +101,8 @@ public sealed class RuntimeBootstrapOwner : MonoBehaviour
 #if UNITY_EDITOR
     void OnValidate()
     {
+        ValidateOwnedServiceTypesOnly();
+
         if (string.IsNullOrEmpty(ownerId))
         {
             return;
@@ -65,6 +114,29 @@ public sealed class RuntimeBootstrapOwner : MonoBehaviour
             {
                 Debug.LogError("Duplicate RuntimeBootstrapOwner ownerId found: " + ownerId + ".", this);
                 return;
+            }
+        }
+    }
+
+    void ValidateOwnedServiceTypesOnly()
+    {
+        if (ownedServices == null)
+        {
+            return;
+        }
+
+        var serviceTypes = new HashSet<System.Type>();
+        foreach (var service in ownedServices)
+        {
+            if (service == null)
+            {
+                continue;
+            }
+
+            var serviceType = service.GetType();
+            if (!serviceTypes.Add(serviceType))
+            {
+                Debug.LogError("Duplicate owned runtime service component type found under owner " + OwnerLabel() + ": " + serviceType.FullName + ".", this);
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Ensure `RuntimeBootstrapOwner.OwnedServices` entries are validated at runtime and edit-time to catch nulls, duplicate component types, and lifetime mismatches.
- Surface prefab-time mismatches between declared `OwnedServices` and actual components so prefab registration is accurate.
- Preserve existing service registration paths so components that self-register in their own `Awake()` are not changed.

### Description
- Add `ValidateOwnedServices()` called from `RuntimeBootstrapOwner.Awake()` to error on null `ownedServices` entries, duplicate service component types under the same owner, and lifetime mismatches using `RuntimeServices.TryGetDeclaredLifetime`.
- Add editor-time `ValidateOwnedServiceTypesOnly()` invoked from `OnValidate()` to detect duplicate owned service component types in the inspector.
- Add `RuntimeServices.TryGetDeclaredLifetime(Type, out ServiceLifetime)` to declare known service lifetimes used by validation logic.
- Update `RuntimeServicePrefabValidator` to validate each `RuntimeBootstrapOwner.OwnedServices` against actual `RuntimeServices.Register`-calling components on the prefab and report missing/stale entries, duplicates, and lifetime mismatches, and to use `TryGetDeclaredLifetime` in `IsPersistentServiceType`.

### Testing
- Ran `git diff --check` with no issues reported.
- Unity Editor tests were not run because the Unity CLI was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff41cd1fe8832aae8797c716c4ab66)