### PR TITLE
Add PlayerCameraReference helper and route Behaviour camera-relative logic through it

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -171,6 +171,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     public string Wallet;
     public GameObject AimIcon;
     public CinemachineFreeLook FreeLook;
+    [SerializeField] PlayerCameraReference cameraReference = new PlayerCameraReference();
     public CinemachineFreeLook CamForTraders;
     public float ChangeSpeech = 1F;
     GameInputReader inputReader;
@@ -181,6 +182,19 @@ public class Behaviour : MonoBehaviour, IDamageable
     PlayerMovementController movementController;
     PlayerFailureController failureController;
 
+    PlayerCameraReference GameplayCamera
+    {
+        get
+        {
+            if (cameraReference == null)
+            {
+                cameraReference = new PlayerCameraReference();
+            }
+
+            cameraReference.Configure(this, FreeLook);
+            return cameraReference;
+        }
+    }
 
     PlayerHealthController Health
     {
@@ -604,8 +618,12 @@ public class Behaviour : MonoBehaviour, IDamageable
         //Strafe
         if (keepLooking == true)
         {
-            Vector3 forwardFace = Camera.main.transform.TransformDirection(Vector3.forward);
-            rotGoal = SafeRotation.LookRotationOrCurrent(new Vector3(forwardFace.x, 0, forwardFace.z), transform.rotation);
+            if (!GameplayCamera.TryGetPlanarBasis(out Vector3 forwardFace, out _))
+            {
+                return;
+            }
+
+            rotGoal = SafeRotation.LookRotationOrCurrent(forwardFace, transform.rotation);
             transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
             Otter.SetBool("walk", false);
             if (Input.GetKey(KeyCode.W))
@@ -695,7 +713,11 @@ public class Behaviour : MonoBehaviour, IDamageable
     [Obsolete]
     public void RotateForward()
     {
-        Vector3 camForward = Camera.main.transform.TransformDirection(Vector3.forward);
+        if (!GameplayCamera.TryGetPlanarBasis(out Vector3 camForward, out _))
+        {
+            return;
+        }
+
         Quaternion direction = SafeRotation.LookRotationOrCurrent(camForward, Spine.rotation);
         if (bowEquipped==false)
         {
@@ -1516,16 +1538,13 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
 
         //Camera vectors setup
-        Vector3 cameraRelativeForward = Camera.main.transform.TransformDirection(Vector3.forward);
-        Vector3 cameraRelativeBack = Camera.main.transform.TransformDirection(Vector3.back);
-        Vector3 cameraRelativeRight = Camera.main.transform.TransformDirection(Vector3.right);
-        Vector3 cameraRelativeLeft = Camera.main.transform.TransformDirection(Vector3.left);
+        if (!GameplayCamera.TryGetPlanarBasis(out Vector3 XZForward, out Vector3 XZRight))
+        {
+            return;
+        }
 
-        //Horizontal camera vectors
-        Vector3 XZForward = new(cameraRelativeForward.x, 0, cameraRelativeForward.z);
-        Vector3 XZBack = new(cameraRelativeBack.x, 0, cameraRelativeBack.z);
-        Vector3 XZRight = new(cameraRelativeRight.x, 0, cameraRelativeRight.z);
-        Vector3 XZLeft = new(cameraRelativeLeft.x, 0, cameraRelativeLeft.z);
+        Vector3 XZBack = -XZForward;
+        Vector3 XZLeft = -XZRight;
 
         //Switch off additional animations if not invoked
         {
@@ -1558,7 +1577,7 @@ public class Behaviour : MonoBehaviour, IDamageable
                 Otter.Play("Aim");
                 if (Input.GetKeyDown(KeyCode.Mouse1))
                 {
-                    rotGoal = SafeRotation.LookRotationOrCurrent(cameraRelativeForward, transform.rotation);
+                    rotGoal = SafeRotation.LookRotationOrCurrent(XZForward, transform.rotation);
                     transform.rotation = rotGoal;
                     Otter.Play("Crouch");
                 }
@@ -1586,7 +1605,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         {
             if (Input.GetKeyDown(KeyCode.Mouse1) && !Input.GetKeyUp(KeyCode.Mouse1))
             {
-                rotGoal = SafeRotation.LookRotationOrCurrent(cameraRelativeForward, transform.rotation);
+                rotGoal = SafeRotation.LookRotationOrCurrent(XZForward, transform.rotation);
                 transform.rotation = rotGoal;
                 if (arrowMunition > 0 &&
                 CurrentStamina > 0)
@@ -1621,7 +1640,7 @@ public class Behaviour : MonoBehaviour, IDamageable
             if (arrowReady == true && Input.GetKeyUp(KeyCode.Mouse1) && CurrentStamina > 0)
             {
                 Sound.ArrowShoot();
-                Instantiate(Arrow, Spine.position + new Vector3(0,1.4f * cameraRelativeForward.normalized.y, 1.4f * cameraRelativeForward.normalized.z), SafeRotation.LookRotationOrCurrent(cameraRelativeForward, transform.rotation)* Quaternion.Euler(90, 0, 0));
+                Instantiate(Arrow, Spine.position + XZForward * 1.4f, SafeRotation.LookRotationOrCurrent(XZForward, transform.rotation) * Quaternion.Euler(90, 0, 0));
                 CurrentStamina -= 30;
                 if (HealthBar != null)
                 {

--- a/Assets/Scripts/Player/PlayerCameraReference.cs
+++ b/Assets/Scripts/Player/PlayerCameraReference.cs
@@ -1,0 +1,156 @@
+using System;
+using Cinemachine;
+using UnityEngine;
+
+[Serializable]
+public sealed class PlayerCameraReference
+{
+    const float MinPlanarSqrMagnitude = 0.0001f;
+
+    enum Source
+    {
+        None,
+        SerializedCamera,
+        FreeLook,
+        BrainCamera,
+        MainCamera
+    }
+
+    [SerializeField] Camera camera;
+
+    [NonSerialized] Behaviour owner;
+    [NonSerialized] CinemachineFreeLook freeLook;
+    [NonSerialized] Transform cachedTransform;
+    [NonSerialized] Camera cachedCamera;
+    [NonSerialized] Source cachedSource;
+
+    public void Configure(Behaviour owner, CinemachineFreeLook freeLook)
+    {
+        this.owner = owner;
+        this.freeLook = freeLook;
+    }
+
+    public bool TryGetPlanarBasis(out Vector3 forward, out Vector3 right)
+    {
+        if (!IsCachedValid() && !TryResolve())
+        {
+            WarnMissingCamera();
+            forward = Vector3.zero;
+            right = Vector3.zero;
+            return false;
+        }
+
+        forward = Flatten(cachedTransform.forward);
+        right = Flatten(cachedTransform.right);
+        if (forward.sqrMagnitude < MinPlanarSqrMagnitude || right.sqrMagnitude < MinPlanarSqrMagnitude)
+        {
+            ClearCache();
+            WarnMissingCamera();
+            forward = Vector3.zero;
+            right = Vector3.zero;
+            return false;
+        }
+
+        forward.Normalize();
+        right.Normalize();
+        return true;
+    }
+
+    bool TryResolve()
+    {
+        if (IsCameraValid(camera))
+        {
+            Cache(camera, Source.SerializedCamera);
+            return true;
+        }
+
+        if (freeLook != null && freeLook.enabled)
+        {
+            var freeLookObject = freeLook.VirtualCameraGameObject;
+            if (freeLookObject != null && freeLookObject.activeInHierarchy)
+            {
+                Cache(freeLookObject.transform, null, Source.FreeLook);
+                return true;
+            }
+        }
+
+        var brain = UnityEngine.Object.FindObjectOfType<CinemachineBrain>();
+        if (brain != null && brain.enabled && brain.gameObject.activeInHierarchy && IsCameraValid(brain.OutputCamera))
+        {
+            Cache(brain.OutputCamera, Source.BrainCamera);
+            return true;
+        }
+
+        if (IsCameraValid(Camera.main))
+        {
+            Cache(Camera.main, Source.MainCamera);
+            return true;
+        }
+
+        ClearCache();
+        return false;
+    }
+
+    bool IsCachedValid()
+    {
+        if (cachedTransform == null)
+        {
+            return false;
+        }
+
+        switch (cachedSource)
+        {
+            case Source.SerializedCamera:
+                return cachedCamera == camera && IsCameraValid(cachedCamera);
+            case Source.FreeLook:
+                return freeLook != null
+                    && freeLook.enabled
+                    && freeLook.VirtualCameraGameObject != null
+                    && cachedTransform == freeLook.VirtualCameraGameObject.transform
+                    && cachedTransform.gameObject.activeInHierarchy;
+            case Source.BrainCamera:
+            case Source.MainCamera:
+                return IsCameraValid(cachedCamera);
+            default:
+                return false;
+        }
+    }
+
+    void Cache(Camera sourceCamera, Source source)
+    {
+        Cache(sourceCamera.transform, sourceCamera, source);
+    }
+
+    void Cache(Transform sourceTransform, Camera sourceCamera, Source source)
+    {
+        cachedTransform = sourceTransform;
+        cachedCamera = sourceCamera;
+        cachedSource = source;
+    }
+
+    void ClearCache()
+    {
+        cachedTransform = null;
+        cachedCamera = null;
+        cachedSource = Source.None;
+    }
+
+    static bool IsCameraValid(Camera candidate)
+    {
+        return candidate != null && candidate.enabled && candidate.gameObject.activeInHierarchy;
+    }
+
+    static Vector3 Flatten(Vector3 vector)
+    {
+        vector.y = 0f;
+        return vector;
+    }
+
+    void WarnMissingCamera()
+    {
+        BuildSafeLogger.WarnOnce(
+            "Behaviour.MissingGameplayCamera",
+            "Behaviour could not resolve an enabled gameplay camera for camera-relative movement or aim.",
+            owner);
+    }
+}

--- a/Assets/Scripts/Player/PlayerCameraReference.cs.meta
+++ b/Assets/Scripts/Player/PlayerCameraReference.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1473077c389d452a8fee039e9fc12978
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Centralize gameplay camera resolution for `Behaviour` to avoid brittle direct `Camera.main` usage and support Cinemachine FreeLook/Brain setups.
- Provide a small non-persistent helper that yields a stable XZ (planar) forward/right basis for movement, strafing and aiming.
- Emit a single once-only warning when no valid gameplay camera can be resolved to aid diagnostics without spamming logs.

### Description
- Add `Assets/Scripts/Player/PlayerCameraReference.cs` as a serializable helper that resolves camera priority: serialized `Camera`, `FreeLook.VirtualCameraGameObject` (when enabled), active `CinemachineBrain.OutputCamera`, then `Camera.main`.
- Cache the resolved camera/transform only while still valid/enabled and re-resolve when null/disabled/scene changes, and expose `bool TryGetPlanarBasis(out Vector3 forward, out Vector3 right)` which returns XZ-flattened, normalized basis vectors and rejects near-zero vectors.
- Integrate the helper into `Behaviour` via a serialized `PlayerCameraReference cameraReference` and `GameplayCamera` accessor, replacing direct `Camera.main` usage in strafing (`PlayerMove`), `RotateForward()`, `FixedUpdate()` camera basis, and stone/bow aim/instantiate paths.
- Use `BuildSafeLogger.WarnOnce("Behaviour.MissingGameplayCamera", ...)` for a single warning when a gameplay camera cannot be resolved.

### Testing
- Ran `git diff --check` which succeeded with no whitespace errors.
- Ran `rg -n "Camera\.main|cameraRelativeForward" Assets/Scripts/Player/Behaviour.cs` which returned no lingering usages of `Camera.main`/old camera variable patterns.
- Ran `command -v unity || command -v unity-editor || command -v Unity || true` which showed no Unity CLI available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff59e19c30832ab97bfdefecb0d9f3)