### PR TITLE
Fix player movement input in Behaviour.FixedUpdate

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -1730,80 +1730,41 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
         //Basic movement setup
         {
-            //No Crouch = Regular Movement
-            if (!Input.GetKey(KeyCode.LeftControl))
+            Vector2 input = new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical"));
+
+            if (Input.GetKey(KeyCode.A))
             {
-                HealQue = 3;
-                if (Input.GetKey(KeyCode.W))
-                {
-                    PlayerMove(XZForward);
-                }
-                if (Input.GetKey(KeyCode.S))
-                {
-                    PlayerMove(XZBack);
-                }
-                if (Input.GetKey(KeyCode.D))
-                {
-                    //Otter.Play("Walk Right");
-                    PlayerMove(XZRight);
-                }
-                if (Input.GetKey(KeyCode.A))
-                {
-                    //Otter.Play("Walk Left");
-                    PlayerMove(XZLeft);
-                }
-                if (Input.GetKey(KeyCode.W) && Input.GetKey(KeyCode.D))
-                {
-                    PlayerMove(XZForward + XZRight);
-                }
-                if (Input.GetKey(KeyCode.W) && Input.GetKey(KeyCode.A))
-                {
-                    PlayerMove(XZForward + XZLeft);
-                }
-                if (Input.GetKey(KeyCode.S) && Input.GetKey(KeyCode.D))
-                {
-                    PlayerMove(XZBack + XZRight);
-                }
-                if (Input.GetKey(KeyCode.S) && Input.GetKey(KeyCode.A))
-                {
-                    PlayerMove(XZBack + XZLeft);
-                }
+                input.x -= 1f;
             }
-            //Movement + Crouch = Roll & Evade
-            if (Input.GetKey(KeyCode.LeftControl) && CurrentStamina > 0)
+            if (Input.GetKey(KeyCode.D))
             {
-                HealQue = 3;
-                if (Input.GetKey(KeyCode.W))
+                input.x += 1f;
+            }
+            if (Input.GetKey(KeyCode.S))
+            {
+                input.y -= 1f;
+            }
+            if (Input.GetKey(KeyCode.W))
+            {
+                input.y += 1f;
+            }
+
+            input = Vector2.ClampMagnitude(input, 1f);
+            Vector3 move = XZForward * input.y + XZRight * input.x;
+
+            if (move.sqrMagnitude >= Mathf.Epsilon)
+            {
+                //No Crouch = Regular Movement
+                if (!Input.GetKey(KeyCode.LeftControl))
                 {
-                    PlayerRoll(XZForward);
+                    HealQue = 3;
+                    PlayerMove(move);
                 }
-                if (Input.GetKey(KeyCode.S))
+                //Movement + Crouch = Roll & Evade
+                else if (CurrentStamina > 0)
                 {
-                    PlayerRoll(XZBack);
-                }
-                if (Input.GetKey(KeyCode.D))
-                {
-                    PlayerRoll(XZRight);
-                }
-                if (Input.GetKey(KeyCode.A))
-                {
-                    PlayerRoll(XZLeft);
-                }
-                if (Input.GetKey(KeyCode.W) && Input.GetKey(KeyCode.D))
-                {
-                    PlayerRoll(XZForward + XZRight);
-                }
-                if (Input.GetKey(KeyCode.W) && Input.GetKey(KeyCode.A))
-                {
-                    PlayerRoll(XZForward + XZLeft);
-                }
-                if (Input.GetKey(KeyCode.S) && Input.GetKey(KeyCode.D))
-                {
-                    PlayerRoll(XZBack + XZRight);
-                }
-                if (Input.GetKey(KeyCode.S) && Input.GetKey(KeyCode.A))
-                {
-                    PlayerRoll(XZBack + XZLeft);
+                    HealQue = 3;
+                    PlayerRoll(move);
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Replace scattered per-key movement calls with a single, camera-relative movement vector to avoid duplicate/contradictory movement invocations.
- Ensure exactly one of `PlayerMove(move)` or `PlayerRoll(move)` is invoked per physics tick and skip processing when input is effectively zero.

### Description
- Build a single `Vector2 input` from `Input.GetAxisRaw("Horizontal")`/`Vertical` and additive WASD key adjustments.
- Clamp `input` magnitude to `1f` and compute `move = XZForward * input.y + XZRight * input.x` once.
- Skip movement/roll when `move.sqrMagnitude < Mathf.Epsilon`.
- Invoke exactly one handler: `PlayerMove(move)` when LeftControl is not held, otherwise `PlayerRoll(move)` when `CurrentStamina > 0`, preserving existing `Walk`, `Run`, `steer`, roll speed, stamina, and animator names.

### Testing
- Ran `git diff --check` to validate no whitespace/change conflicts and it passed.
- Verified presence of `Vector2 input`, `Vector3 move`, and single `PlayerMove(move)`/`PlayerRoll(move)` calls via project search and inspected modified lines; checks succeeded.
- No runtime or unit tests were executed in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5cb449b8832ab6333d9ace1e0de7)