### PR TITLE
Guard RotateForward against null Spine

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -725,6 +725,11 @@ public class Behaviour : MonoBehaviour, IDamageable
     [Obsolete]
     public void RotateForward()
     {
+        if (Spine == null)
+        {
+            return;
+        }
+
         if (!CanProcessPlayerGameplay())
         {
             ResetBlockedGameplayInputState();


### PR DESCRIPTION
### Motivation
- Prevent a null-reference during `RotateForward()` when `Spine` is missing while preserving existing bow-aim offset and method signature.

### Description
- Add an early-return guard at the top of `RotateForward()`: `if (Spine == null) return;` so `Spine.rotation` is not modified when absent.

### Testing
- Ran `git diff --check` and an `rg` search for `RotateForward`, `Spine == null`, and `TryGetPlanarBasis`, all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5e075e2c832a9b268bc4b7a6e473)