### PR TITLE
Make FreeLook/CamForTraders optional and add safe camera helpers

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -560,9 +560,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
         if (OBJ.gameObject.CompareTag("House"))
         {
-            FreeLook.m_Orbits[0].m_Radius = 1f;
-            FreeLook.m_Orbits[1].m_Radius = 2f;
-            FreeLook.m_Orbits[2].m_Radius =1f;
+            TrySetFreeLookOrbits(FreeLook, 1f, 2f, 1f);
         }
         if (OBJ.gameObject.CompareTag("What Is this?"))
         {
@@ -592,9 +590,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
         if (OBJ.gameObject.CompareTag("House"))
         {
-            FreeLook.m_Orbits[0].m_Radius = 4;
-            FreeLook.m_Orbits[1].m_Radius = 6;
-            FreeLook.m_Orbits[2].m_Radius = 5;
+            TrySetFreeLookOrbits(FreeLook, 4f, 6f, 5f);
             //FreeLook.m_Lens.FieldOfView = 25;
         }
         if (OBJ.gameObject.CompareTag("Scorpion"))
@@ -1019,8 +1015,6 @@ public class Behaviour : MonoBehaviour, IDamageable
             RuntimeReferenceValidator.Require(MunitionDisplay, this, nameof(MunitionDisplay)) &
             RuntimeReferenceValidator.Require(LooseScreen, this, nameof(LooseScreen)) &
             RuntimeReferenceValidator.Require(AimIcon, this, nameof(AimIcon)) &
-            RuntimeReferenceValidator.Require(FreeLook, this, nameof(FreeLook)) &
-            RuntimeReferenceValidator.Require(CamForTraders, this, nameof(CamForTraders)) &
             RuntimeReferenceValidator.Require(HologramedBridge, this, nameof(HologramedBridge)) &
             RuntimeReferenceValidator.Require(appleOBJ, this, nameof(appleOBJ)) &
             RuntimeReferenceValidator.Require(gobletOBJ, this, nameof(gobletOBJ));
@@ -1041,7 +1035,59 @@ public class Behaviour : MonoBehaviour, IDamageable
             }
         }
 
+        WarnMissingCameraReference(FreeLook, nameof(FreeLook));
+        WarnMissingCameraReference(CamForTraders, nameof(CamForTraders));
+
         return valid;
+    }
+
+    bool TrySetFreeLookOrbits(CinemachineFreeLook cam, float top, float mid, float bottom)
+    {
+        if (!WarnMissingCameraReference(cam, nameof(FreeLook)))
+        {
+            return false;
+        }
+
+        if (cam.m_Orbits == null || cam.m_Orbits.Length < 3)
+        {
+            BuildSafeLogger.WarnOnce(
+                nameof(Behaviour) + ".InvalidFreeLookOrbits",
+                "FreeLook camera does not have the expected three orbit rigs.",
+                this,
+                nameof(FreeLook));
+            return false;
+        }
+
+        cam.m_Orbits[0].m_Radius = top;
+        cam.m_Orbits[1].m_Radius = mid;
+        cam.m_Orbits[2].m_Radius = bottom;
+        return true;
+    }
+
+    bool TrySetTraderCameraEnabled(bool enabled)
+    {
+        if (!WarnMissingCameraReference(CamForTraders, nameof(CamForTraders)))
+        {
+            return false;
+        }
+
+        CamForTraders.enabled = enabled;
+        return true;
+    }
+
+    bool WarnMissingCameraReference(CinemachineFreeLook cam, string fieldName)
+    {
+        if (cam != null)
+        {
+            return true;
+        }
+
+        BuildSafeLogger.WarnOnce(
+            nameof(Behaviour) + ".MissingCameraReference." + fieldName,
+            fieldName + " is not assigned; camera-specific behaviour will be skipped.",
+            this,
+            fieldName);
+        return false;
     }
 
     public void Start()
@@ -1060,7 +1106,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         Failure.Initialize(this);
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
-        CamForTraders.enabled = false;
+        TrySetTraderCameraEnabled(false);
         if (PopUpEffect != null && Root != null)
         {
             Instantiate(PopUpEffect, Root.position, Quaternion.identity);
@@ -1127,9 +1173,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         {
             Bow[i].SetActive(false);
         }
-        FreeLook.m_Orbits[0].m_Radius = 4;
-        FreeLook.m_Orbits[1].m_Radius = 6;
-        FreeLook.m_Orbits[2].m_Radius = 5;
+        TrySetFreeLookOrbits(FreeLook, 4f, 6f, 5f);
     }
     [System.Obsolete]
     public void Update()
@@ -1228,7 +1272,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         Health.ClampStaminaAndParry();
         //Crouch action - Place Logs
         {
-            if (Input.GetKey(KeyCode.LeftControl)&& FreeLook.m_Lens.FieldOfView<20)
+            if (FreeLook != null && Input.GetKey(KeyCode.LeftControl) && FreeLook.m_Lens.FieldOfView < 20)
             {
                 FreeLook.m_LookAt = Face;
             }

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -1064,7 +1064,74 @@ public class Behaviour : MonoBehaviour, IDamageable
         return true;
     }
 
-    bool TrySetTraderCameraEnabled(bool enabled)
+    public bool TrySetFreeLookEnabled(bool enabled)
+    {
+        if (!WarnMissingCameraReference(FreeLook, nameof(FreeLook)))
+        {
+            return false;
+        }
+
+        FreeLook.enabled = enabled;
+        return true;
+    }
+
+    public bool TrySetFreeLookLookAt(Transform lookAt)
+    {
+        if (!WarnMissingCameraReference(FreeLook, nameof(FreeLook)))
+        {
+            return false;
+        }
+
+        FreeLook.m_LookAt = lookAt;
+        return true;
+    }
+
+    public bool TryConfigureFreeLookForBoss(float middleOrbitRadius, float xAxisMaxSpeed, float yAxisMaxSpeed, Transform lookAt)
+    {
+        if (!WarnMissingCameraReference(FreeLook, nameof(FreeLook)))
+        {
+            return false;
+        }
+
+        if (FreeLook.m_Orbits == null || FreeLook.m_Orbits.Length < 2)
+        {
+            BuildSafeLogger.WarnOnce(
+                nameof(Behaviour) + ".InvalidFreeLookBossOrbit",
+                "FreeLook camera does not have the expected middle orbit rig; boss camera changes will be skipped.",
+                this,
+                nameof(FreeLook));
+            return false;
+        }
+
+        FreeLook.m_Orbits[1].m_Radius = middleOrbitRadius;
+        FreeLook.m_XAxis.m_MaxSpeed = xAxisMaxSpeed;
+        FreeLook.m_YAxis.m_MaxSpeed = yAxisMaxSpeed;
+        FreeLook.m_LookAt = lookAt;
+        return true;
+    }
+
+    public bool TryRotateFreeLookLookAtTowardRoot()
+    {
+        if (!WarnMissingCameraReference(FreeLook, nameof(FreeLook)))
+        {
+            return false;
+        }
+
+        if (FreeLook.m_LookAt == null)
+        {
+            BuildSafeLogger.WarnOnce(
+                nameof(Behaviour) + ".MissingFreeLookLookAt",
+                "FreeLook camera does not have a LookAt target; camera rotation reset will be skipped.",
+                this,
+                nameof(FreeLook));
+            return false;
+        }
+
+        FreeLook.m_LookAt.rotation = Quaternion.Slerp(transform.rotation, SafeRotation.LookRotationOrCurrent(Root.position, transform.rotation), 0.5f);
+        return true;
+    }
+
+    public bool TrySetTraderCameraEnabled(bool enabled)
     {
         if (!WarnMissingCameraReference(CamForTraders, nameof(CamForTraders)))
         {
@@ -1072,6 +1139,17 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
 
         CamForTraders.enabled = enabled;
+        return true;
+    }
+
+    public bool TrySetTraderCameraLookAt(Transform lookAt)
+    {
+        if (!WarnMissingCameraReference(CamForTraders, nameof(CamForTraders)))
+        {
+            return false;
+        }
+
+        CamForTraders.m_LookAt = lookAt;
         return true;
     }
 
@@ -1274,7 +1352,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         {
             if (FreeLook != null && Input.GetKey(KeyCode.LeftControl) && FreeLook.m_Lens.FieldOfView < 20)
             {
-                FreeLook.m_LookAt = Face;
+                TrySetFreeLookLookAt(Face);
             }
 
             if (Input.GetKey(KeyCode.LeftControl) && grounded == true && Rolling == false && !Input.GetKey(KeyCode.Space))

--- a/Assets/Scripts/Player/BossHandler.cs
+++ b/Assets/Scripts/Player/BossHandler.cs
@@ -55,10 +55,7 @@ public class BossHandler : MonoBehaviour
         BossPanel.SetActive(false);
         Boss.isAttacking = true;
         BossBar.SetActive(true);
-        player.FreeLook.m_Orbits[1].m_Radius = 6;
-        player.FreeLook.m_XAxis.m_MaxSpeed = 300;
-        player.FreeLook.m_YAxis.m_MaxSpeed = 2;
-        player.FreeLook.m_LookAt = player.Root;
+        player.TryConfigureFreeLookForBoss(6f, 300f, 2f, player.Root);
     }
     public void OnTriggerStay(Collider OBJ)
     {
@@ -68,10 +65,7 @@ public class BossHandler : MonoBehaviour
             player.isAtTrader = true;
             Boss.isAttacking = false;
             BossPanel.SetActive(true);
-            player.FreeLook.m_Orbits[1].m_Radius = 15;
-            player.FreeLook.m_XAxis.m_MaxSpeed = 0;
-            player.FreeLook.m_YAxis.m_MaxSpeed = 0;
-            player.FreeLook.m_LookAt = Boss.transform;   
+            player.TryConfigureFreeLookForBoss(15f, 0f, 0f, Boss.transform);
         }
     }
     [System.Obsolete("Scorpion boss damage is applied by BossHitbox components on prefab hitbox colliders.")]

--- a/Assets/Scripts/Player/PlayerInteractionController.cs
+++ b/Assets/Scripts/Player/PlayerInteractionController.cs
@@ -19,7 +19,7 @@ public class PlayerInteractionController : MonoBehaviour
 
     public void HideCursor()
     {
-        owner.FreeLook.m_LookAt = owner.Root;
+        owner.TrySetFreeLookLookAt(owner.Root);
         CursorStateService.GetOrCreate().HideCursor();
         var gameFlow = GameFlowController.Instance;
         if (gameFlow == null || gameFlow.State == GameFlowState.Playing)
@@ -36,9 +36,9 @@ public class PlayerInteractionController : MonoBehaviour
             ShowCursor();
             owner.isAtTrader = true;
             GameFlowController.GetOrCreate().SetShop();
-            owner.FreeLook.enabled = false;
-            owner.CamForTraders.enabled = true;
-            owner.CamForTraders.m_LookAt = trader.transform;
+            owner.TrySetFreeLookEnabled(false);
+            owner.TrySetTraderCameraEnabled(true);
+            owner.TrySetTraderCameraLookAt(trader.transform);
             return;
         }
 
@@ -49,10 +49,10 @@ public class PlayerInteractionController : MonoBehaviour
     {
         owner.isAtTrader = false;
         GameFlowController.GetOrCreate().SetPlaying();
-        owner.CamForTraders.enabled = false;
-        owner.CamForTraders.m_LookAt = null;
-        owner.FreeLook.enabled = true;
-        owner.FreeLook.m_LookAt.rotation = Quaternion.Slerp(owner.transform.rotation, SafeRotation.LookRotationOrCurrent(owner.Root.position, owner.transform.rotation), 0.5f);
+        owner.TrySetTraderCameraEnabled(false);
+        owner.TrySetTraderCameraLookAt(null);
+        owner.TrySetFreeLookEnabled(true);
+        owner.TryRotateFreeLookLookAtTowardRoot();
     }
 
     GameInputReader GetInputReader()


### PR DESCRIPTION
### Motivation
- Keep serialized `FreeLook`/`CamForTraders` fields for prefab compatibility while avoiding startup-fatal failures when those camera refs are not assigned. 

### Description
- Stop requiring `FreeLook` and `CamForTraders` in `ValidateStartReferences()` and emit a warning via `BuildSafeLogger.WarnOnce` using a new `WarnMissingCameraReference` helper instead. 
- Add `TrySetFreeLookOrbits(CinemachineFreeLook cam, float top, float mid, float bottom)` and `TrySetTraderCameraEnabled(bool enabled)` helper methods and replace direct `FreeLook.m_Orbits[...]` and `CamForTraders.enabled = ...` assignments with those helpers. 
- Add null-guards around `FreeLook` usage (e.g. `FreeLook.m_Lens.FieldOfView` / `FreeLook.m_LookAt`) to avoid NREs when camera is absent. 
- Preserve the public serialized fields `FreeLook` and `CamForTraders` to maintain prefab compatibility. 

### Testing
- Ran `git diff --check` which produced no issues. 
- No local C#/Unity build or unit tests executed because no solution/project files were available in the workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5fd2242c832a93af30e9dce2d59c)