### PR TITLE
Guard player camera consumers and invalidate cached camera on scene load

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Cinemachine;
 using Cinemachine.Utility;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class Behaviour : MonoBehaviour, IDamageable
 {
@@ -1169,6 +1170,22 @@ public class Behaviour : MonoBehaviour, IDamageable
         return false;
     }
 
+    void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+        GameplayCamera.Invalidate();
+    }
+
+    void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        GameplayCamera.Invalidate();
+    }
+
     public void Start()
     {
         if (!ValidateStartReferences())
@@ -1725,10 +1742,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
 
         //Camera vectors setup
-        if (!GameplayCamera.TryGetPlanarBasis(out Vector3 XZForward, out Vector3 XZRight))
-        {
-            return;
-        }
+        bool hasGameplayCamera = GameplayCamera.TryGetPlanarBasis(out Vector3 XZForward, out Vector3 XZRight);
 
         //Switch off additional animations if not invoked
         {
@@ -1739,7 +1753,7 @@ public class Behaviour : MonoBehaviour, IDamageable
             //keepLooking = false;
         }
         //Stoning action
-        if (bowEquipped == false)
+        if (hasGameplayCamera && bowEquipped == false)
         {
             if (Input.GetKey(KeyCode.Mouse1)
                 && CurrentStamina > 0
@@ -1776,7 +1790,7 @@ public class Behaviour : MonoBehaviour, IDamageable
             }
         }
         //Bow action       
-        if (bowEquipped == true)
+        if (hasGameplayCamera && bowEquipped == true)
         {
             if (Input.GetKeyDown(KeyCode.Mouse1) && !Input.GetKeyUp(KeyCode.Mouse1))
             {
@@ -1845,6 +1859,7 @@ public class Behaviour : MonoBehaviour, IDamageable
             }
         }
         //Basic movement setup
+        if (hasGameplayCamera)
         {
             Vector2 input = Vector2.ClampMagnitude(new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical")), 1f);
             Vector3 move = (XZForward * input.y + XZRight * input.x).normalized;

--- a/Assets/Scripts/Player/PlayerCameraReference.cs
+++ b/Assets/Scripts/Player/PlayerCameraReference.cs
@@ -30,6 +30,11 @@ public sealed class PlayerCameraReference
         this.freeLook = freeLook;
     }
 
+    public void Invalidate()
+    {
+        ClearCache();
+    }
+
     public bool TryGetPlanarBasis(out Vector3 forward, out Vector3 right)
     {
         if (!IsCachedValid() && !TryResolve())


### PR DESCRIPTION
### Motivation
- Ensure camera-relative movement and aiming safely handle missing or stale gameplay cameras after scene loads or camera changes.
- Avoid crashing or incorrect rotation when `Camera.main` or Cinemachine virtual cameras are not available.

### Description
- Add `OnEnable`/`OnDisable` and `OnSceneLoaded` handlers to call `GameplayCamera.Invalidate()` so cached camera references are cleared when scenes change.
- Expose `PlayerCameraReference.Invalidate()` which clears the internal camera/transform cache. 
- Replace the early `return` from `FixedUpdate` on missing camera with a guarded `hasGameplayCamera` boolean and skip only camera-dependent sections (aiming, bow, and horizontal movement) when no valid camera is resolved.
- Add `using UnityEngine.SceneManagement;` to `Behaviour.cs` and keep existing Cinemachine resolution/order logic intact.

### Testing
- Ran `git diff --check` with no issues detected (passed). 
- Ran `rg "Camera\.main\.transform\.TransformDirection|TransformDirection\(" Assets/Scripts/Player/Behaviour.cs` to verify no direct Camera.main TransformDirection usages remain in the targeted file (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff64c9ea58832aa8d727cae624dfa7)