### PR TITLE
SafeRotation: reject non-finite vectors and guard planar rotation call sites

### DIFF
--- a/Assets/Scripts/Core/SafeRotation.cs
+++ b/Assets/Scripts/Core/SafeRotation.cs
@@ -6,7 +6,7 @@ public static class SafeRotation
 
     public static bool TryLookRotation(Vector3 forward, out Quaternion rotation)
     {
-        if (forward.sqrMagnitude <= MinSqrMagnitude)
+        if (!IsFinite(forward) || forward.sqrMagnitude <= MinSqrMagnitude)
         {
             rotation = Quaternion.identity;
             return false;
@@ -16,10 +16,32 @@ public static class SafeRotation
         return true;
     }
 
+    public static bool TryPlanarLookRotation(Vector3 forward, out Quaternion rotation)
+    {
+        forward.y = 0f;
+        return TryLookRotation(forward, out rotation);
+    }
+
+    public static bool IsFinite(Vector3 vector)
+    {
+        return IsFinite(vector.x) && IsFinite(vector.y) && IsFinite(vector.z);
+    }
+
+    static bool IsFinite(float value)
+    {
+        return !float.IsNaN(value) && !float.IsInfinity(value);
+    }
+
     public static Quaternion LookRotationOrCurrent(Vector3 forward, Quaternion current)
     {
         Quaternion rotation;
         return TryLookRotation(forward, out rotation) ? rotation : current;
+    }
+
+    public static Quaternion PlanarLookRotationOrCurrent(Vector3 forward, Quaternion current)
+    {
+        Quaternion rotation;
+        return TryPlanarLookRotation(forward, out rotation) ? rotation : current;
     }
 
     public static Quaternion LookRotationOrIdentity(Vector3 forward)

--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -388,7 +388,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
     {
         isAttacking = false;
         RBScorpion.velocity = new Vector3(0, RBScorpion.velocity.y, 0);
-        rotGoal = SafeRotation.LookRotationOrCurrent(new Vector3(Distance.x, 0, Distance.z), transform.rotation);
+        rotGoal = SafeRotation.PlanarLookRotationOrCurrent(Distance, transform.rotation);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
         if (transform.rotation != rotGoal)
         {
@@ -406,7 +406,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
     public void Charge(float speed)
     {
         isAttacking = true;
-        rotGoal = SafeRotation.LookRotationOrCurrent(new Vector3(Distance.x, 0, Distance.z), transform.rotation);
+        rotGoal = SafeRotation.PlanarLookRotationOrCurrent(Distance, transform.rotation);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
         RBScorpion.velocity = new Vector3(Distance.x, 0, Distance.z).normalized * speed + new Vector3(0, RBScorpion.velocity.y, 0);
 
@@ -421,13 +421,13 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         Scorpion.SetBool("Walk", false);
         Scorpion.SetBool("Backwards", false);
         Scorpion.SetBool("Attack", true);
-        rotGoal = SafeRotation.LookRotationOrCurrent(new Vector3(Distance.x, 0, Distance.z), transform.rotation);
+        rotGoal = SafeRotation.PlanarLookRotationOrCurrent(Distance, transform.rotation);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
     }
     private void Reverse()
     {
         isAttacking = true;
-        rotGoal = SafeRotation.LookRotationOrCurrent(new Vector3(Distance.x, 0, Distance.z), transform.rotation);
+        rotGoal = SafeRotation.PlanarLookRotationOrCurrent(Distance, transform.rotation);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
         RBScorpion.velocity = new Vector3(-Distance.x, 0, -Distance.z).normalized * 5 + new Vector3(0, RBScorpion.velocity.y, 0);
         Scorpion.SetBool("Walk", false);

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -467,8 +467,11 @@ public class Behaviour : MonoBehaviour, IDamageable
         {
             Plattering = "Get off me ya nasty bastards!";
             ChangeSpeech = 3;
-            var ParryDirection = new Vector3((OBJ.transform.position - transform.position).x, 0, (OBJ.transform.position - transform.position).z);
-            transform.rotation = SafeRotation.LookRotationOrCurrent(ParryDirection, transform.rotation);
+            Vector3 ParryDirection = OBJ.transform.position - transform.position;
+            if (SafeRotation.TryPlanarLookRotation(ParryDirection, out Quaternion parryRotation))
+            {
+                transform.rotation = parryRotation;
+            }
         }
         if (OBJ.gameObject.CompareTag("Strike"))
         {
@@ -610,12 +613,19 @@ public class Behaviour : MonoBehaviour, IDamageable
             return;
         }
 
+        if (!SafeRotation.IsFinite(Direction))
+        {
+            return;
+        }
+
         movementInvoked = true;
         //Regular walk
         if (keepLooking==false)
         {
-            rotGoal = SafeRotation.LookRotationOrCurrent(Direction, transform.rotation);
-            transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            if (SafeRotation.TryLookRotation(Direction, out rotGoal))
+            {
+                transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            }
             PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Walk, true);
         }
         //Strafe
@@ -626,8 +636,10 @@ public class Behaviour : MonoBehaviour, IDamageable
                 return;
             }
 
-            rotGoal = SafeRotation.LookRotationOrCurrent(forwardFace, transform.rotation);
-            transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            if (SafeRotation.TryLookRotation(forwardFace, out rotGoal))
+            {
+                transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            }
             PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Walk, false);
             if (Input.GetKey(KeyCode.W))
             {
@@ -694,8 +706,15 @@ public class Behaviour : MonoBehaviour, IDamageable
             return;
         }
 
-        rotGoal = SafeRotation.LookRotationOrCurrent(new Vector3(Direction.x, 0, Direction.z), transform.rotation);
-        transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.11f);
+        if (!SafeRotation.IsFinite(Direction))
+        {
+            return;
+        }
+
+        if (SafeRotation.TryPlanarLookRotation(Direction, out rotGoal))
+        {
+            transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.11f);
+        }
         //Evading Roll action
         {
             if (Input.GetKey(KeyCode.LeftControl) && CurrentStamina > 0 && grounded == true)
@@ -738,7 +757,11 @@ public class Behaviour : MonoBehaviour, IDamageable
             return;
         }
 
-        Quaternion direction = SafeRotation.LookRotationOrCurrent(camForward, Spine.rotation);
+        if (!SafeRotation.TryLookRotation(camForward, out Quaternion direction))
+        {
+            return;
+        }
+
         if (bowEquipped==false)
         {
             Spine.rotation = direction;
@@ -1766,8 +1789,10 @@ public class Behaviour : MonoBehaviour, IDamageable
                 Otter.Play("Aim");
                 if (Input.GetKeyDown(KeyCode.Mouse1))
                 {
-                    rotGoal = SafeRotation.LookRotationOrCurrent(XZForward, transform.rotation);
-                    transform.rotation = rotGoal;
+                    if (SafeRotation.TryPlanarLookRotation(XZForward, out rotGoal))
+                    {
+                        transform.rotation = rotGoal;
+                    }
                     Otter.Play("Crouch");
                 }
                 keepLooking = true;
@@ -1794,8 +1819,10 @@ public class Behaviour : MonoBehaviour, IDamageable
         {
             if (Input.GetKeyDown(KeyCode.Mouse1) && !Input.GetKeyUp(KeyCode.Mouse1))
             {
-                rotGoal = SafeRotation.LookRotationOrCurrent(XZForward, transform.rotation);
-                transform.rotation = rotGoal;
+                if (SafeRotation.TryPlanarLookRotation(XZForward, out rotGoal))
+                {
+                    transform.rotation = rotGoal;
+                }
                 if (arrowMunition > 0 &&
                 CurrentStamina > 0)
                 {
@@ -1828,8 +1855,13 @@ public class Behaviour : MonoBehaviour, IDamageable
             }
             if (arrowReady == true && Input.GetKeyUp(KeyCode.Mouse1) && CurrentStamina > 0)
             {
+                if (!SafeRotation.TryPlanarLookRotation(XZForward, out Quaternion arrowRotation))
+                {
+                    return;
+                }
+
                 Sound.ArrowShoot();
-                Instantiate(Arrow, Spine.position + XZForward * 1.4f, SafeRotation.LookRotationOrCurrent(XZForward, transform.rotation) * Quaternion.Euler(90, 0, 0));
+                Instantiate(Arrow, Spine.position + XZForward * 1.4f, arrowRotation * Quaternion.Euler(90, 0, 0));
                 CurrentStamina -= 30;
                 if (HealthBar != null)
                 {
@@ -1926,8 +1958,10 @@ public class Behaviour : MonoBehaviour, IDamageable
             {
                 if (isParried == false)
                 {
-                    rotGoal = SafeRotation.LookRotationOrCurrent(new Vector3(Player.velocity.x, 0, Player.velocity.z), transform.rotation);
-                    transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.5f);
+                    if (SafeRotation.TryPlanarLookRotation(Player.velocity, out rotGoal))
+                    {
+                        transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.5f);
+                    }
                 }
                 PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Moving, true);
                 SlideEffect.enableEmission = true;


### PR DESCRIPTION
### Motivation
- Prevent invalid input (NaN/Inf/zero) from reaching `Quaternion.LookRotation` and causing runtime rotation failures during gameplay. 
- Patch call sites that construct raw planar vectors so rotations are validated centrally without adding per-frame failure logs.

### Description
- Add finite-value checks and planar helpers to `SafeRotation`: `IsFinite`, `TryPlanarLookRotation`, and `PlanarLookRotationOrCurrent`, and update `TryLookRotation` to reject non-finite vectors. 
- Replace ad-hoc planar `new Vector3(..., 0, ...)` usages with the safe planar helper at player and NPC sites, including `Player` parry, `PlayerMove`, `PlayerRoll`, `RotateForward` (spine), stone/bow aim branches, arrow instantiation, and neutral-moving rotation. 
- Replace `ScorpionScript` planar rotation constructions with `SafeRotation.PlanarLookRotationOrCurrent(Distance, ...)`. 
- Preserve existing `Quaternion.Slerp` interpolation factors and avoid introducing per-frame rotation warning logs (camera-missing warnings remain driven by existing `PlayerCameraReference.WarnMissingCamera` behavior).

### Testing
- Ran `git diff --check` to ensure no whitespace/errors; succeeded. 
- Ran repository searches (`rg`) for legacy planar `LookRotationOrCurrent(new Vector3(..., 0, ...)` patterns to confirm replacements; succeeded. 
- Changes committed locally (`Guard planar rotation call sites`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6623dc48832abc73a66dce2ea5e9)