### PR TITLE
Reset movement animator state on gameplay block, failure and game-over

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -605,7 +605,11 @@ public class Behaviour : MonoBehaviour, IDamageable
     }
     public void TakeDamage(float Damage) => TakeDamage(new DamageEvent { Amount = Damage, Source = null, Point = transform.position, Type = DamageType.Generic, CanStun = false });
     public void TakeDamage(DamageEvent damageEvent) => Health.TakeDamage(damageEvent.Amount);
-    public void HandleFailure(PlayerFailureReason reason) => Failure.HandleFailure(reason);
+    public void HandleFailure(PlayerFailureReason reason)
+    {
+        ResetMovementRuntimeState();
+        Failure.HandleFailure(reason);
+    }
     public void PlayerMove(Vector3 Direction)
     {
         if (HandleGameplayBlocked())
@@ -809,6 +813,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     public void ActivateLooseMenu()
     {
         //MusicOP.StopMusic();
+        ResetMovementRuntimeState();
         if (!GameFlowController.GetOrCreate().SetGameOver())
         {
             return;
@@ -1042,23 +1047,29 @@ public class Behaviour : MonoBehaviour, IDamageable
             Player.velocity = new Vector3(0f, Player.velocity.y, 0f);
         }
 
+        SetMovementAnimatorIdle();
+    }
+
+    public void SetMovementAnimatorIdle()
+    {
         ClearMovementAnimatorBools();
         PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Aim, false);
         PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Draw, false);
+        PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Crouch, false);
     }
 
     void ClearMovementAnimatorBools()
     {
-        PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Roll, false);
-        PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Run, false);
         PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Walk, false);
+        PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Run, false);
+        PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Midair, false);
+        PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Roll, false);
+        PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Moving, false);
         PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.StrafeForward, false);
         PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.StrafeBack, false);
         PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.StrafeLeft, false);
         PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.StrafeRight, false);
         PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Climb, false);
-        PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Midair, false);
-        PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Moving, false);
     }
 
     void HandleDeathState() => Health.HandleDeathState();


### PR DESCRIPTION
### Motivation
- Ensure animator flags for movement/aim/jump/strafe/roll/crouch are cleared when gameplay is blocked, on failure, or when game-over UI is shown to prevent stale animation states.

### Description
- Call `ResetMovementRuntimeState()` before handling failures and before activating the lose menu to stop movement and animations.
- Add `SetMovementAnimatorIdle()` which clears movement-related animator flags via `PlayerAnimatorParameters` hashed names and also clears `draw`, `aim`, and `crouch` state.
- Route `ResetMovementRuntimeState()` to call `SetMovementAnimatorIdle()` and reorganize `ClearMovementAnimatorBools()` to consistently clear `walk`, `run`, `midair`, `roll`, `moving`, `strafe*`, and `climb` flags.

### Testing
- Ran `git diff --check` and it returned no whitespace errors, success.
- Searched for occurrences of the affected animator parameters with `rg` to verify parameter usage and `PlayerAnimatorParameters` `StringToHash` entries, and all expected matches were found, success.
- Code changes were committed locally and file modifications are limited to `Assets/Scripts/Player/Behaviour.cs`, success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8178806c832ab7dd93df68bedc0a)