### PR TITLE
Serialize Player.cameraReference on allowed prefabs

### DIFF
--- a/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
+++ b/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
@@ -30113,6 +30113,8 @@ MonoBehaviour:
   GM: {fileID: 0}
   AimIcon: {fileID: 0}
   FreeLook: {fileID: 5012679269152501947}
+  cameraReference:
+    camera: {fileID: 0}
   CamForTraders: {fileID: 9047202634484327852}
   ChangeSpeech: 1
 --- !u!114 &4580562239172740873

--- a/Assets/Prefabs/OtterPlayer/Player Updated.prefab
+++ b/Assets/Prefabs/OtterPlayer/Player Updated.prefab
@@ -66838,6 +66838,8 @@ MonoBehaviour:
   GM: {fileID: 0}
   AimIcon: {fileID: 0}
   FreeLook: {fileID: 1427810939599441655}
+  cameraReference:
+    camera: {fileID: 0}
   CamForTraders: {fileID: 3156488547051756512}
   ChangeSpeech: 1
 --- !u!114 &157913311816747088


### PR DESCRIPTION
### Motivation
- Persist the `PlayerCameraReference.camera` serialized field on player prefabs so camera-resolution logic can use an explicit serialized camera while avoiding adding runtime service components.

### Description
- Added `cameraReference:
  camera: {fileID: 0}` under the `FreeLook` field in `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` and `Assets/Prefabs/OtterPlayer/Player Updated.prefab` to expose the existing `PlayerCameraReference` helper without converting it to a `MonoBehaviour` or touching runtime services.

### Testing
- Ran `git diff --check`, `git diff --name-only`, verified no edits to `Assets/Scenes/Level 1.unity` or `Assets/Scenes/Menu.unity`, and scanned diffs for forbidden tokens (runtime service, input, cursor, scene transition, game flow, checkpoint); all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff85191738832abcc2e310fb3c6b0b)