### PR TITLE
Fix gameplay camera basis fallback

### DIFF
--- a/Assets/Scripts/Player/PlayerCameraReference.cs
+++ b/Assets/Scripts/Player/PlayerCameraReference.cs
@@ -11,7 +11,7 @@ public sealed class PlayerCameraReference
     {
         None,
         SerializedCamera,
-        FreeLook,
+        FreeLookState,
         BrainCamera,
         MainCamera
     }
@@ -45,8 +45,9 @@ public sealed class PlayerCameraReference
             return false;
         }
 
-        forward = Flatten(cachedTransform.forward);
-        right = Flatten(cachedTransform.right);
+        var basisRotation = GetBasisRotation();
+        forward = Flatten(basisRotation * Vector3.forward);
+        right = Flatten(basisRotation * Vector3.right);
         if (forward.sqrMagnitude < MinPlanarSqrMagnitude || right.sqrMagnitude < MinPlanarSqrMagnitude)
         {
             ClearCache();
@@ -75,19 +76,15 @@ public sealed class PlayerCameraReference
             return true;
         }
 
-        if (freeLook != null && freeLook.enabled)
-        {
-            var freeLookObject = freeLook.VirtualCameraGameObject;
-            if (freeLookObject != null && freeLookObject.activeInHierarchy)
-            {
-                Cache(freeLookObject.transform, null, Source.FreeLook);
-                return true;
-            }
-        }
-
         if (IsCameraValid(Camera.main))
         {
             Cache(Camera.main, Source.MainCamera);
+            return true;
+        }
+
+        if (IsFreeLookValid())
+        {
+            Cache(freeLook.transform, null, Source.FreeLookState);
             return true;
         }
 
@@ -106,13 +103,11 @@ public sealed class PlayerCameraReference
         {
             case Source.SerializedCamera:
                 return cachedCamera == camera && IsCameraValid(cachedCamera);
-            case Source.FreeLook:
+            case Source.FreeLookState:
                 return !TryGetBrainOutputCamera(out _)
-                    && freeLook != null
-                    && freeLook.enabled
-                    && freeLook.VirtualCameraGameObject != null
-                    && cachedTransform == freeLook.VirtualCameraGameObject.transform
-                    && cachedTransform.gameObject.activeInHierarchy;
+                    && !IsCameraValid(Camera.main)
+                    && IsFreeLookValid()
+                    && cachedTransform == freeLook.transform;
             case Source.BrainCamera:
             case Source.MainCamera:
                 return IsCameraValid(cachedCamera);
@@ -138,6 +133,21 @@ public sealed class PlayerCameraReference
         cachedTransform = null;
         cachedCamera = null;
         cachedSource = Source.None;
+    }
+
+    Quaternion GetBasisRotation()
+    {
+        if (cachedSource == Source.FreeLookState && IsFreeLookValid())
+        {
+            return freeLook.State.FinalOrientation;
+        }
+
+        return cachedTransform.rotation;
+    }
+
+    bool IsFreeLookValid()
+    {
+        return freeLook != null && freeLook.enabled && freeLook.gameObject.activeInHierarchy;
     }
 
     static bool TryGetBrainOutputCamera(out Camera outputCamera)


### PR DESCRIPTION
### Motivation

- Fix a high-priority case where an unassigned serialized camera caused the code to pick a CineMachine FreeLook virtual-camera GameObject transform as the movement/aim basis instead of the actually rendered camera, which made player controls become relative to a prefab/default vcam transform.
- Ensure the gameplay basis uses the rendered output camera when available and otherwise uses the FreeLook runtime state orientation so movement/aim align with what the player sees.

### Description

- Reordered camera resolution to prefer a serialized camera, then the Cinemachine brain `OutputCamera`, then `Camera.main`, and only then fall back to FreeLook state; this prevents using a non-rendered vcam transform as the gameplay basis.
- Replaced the FreeLook virtual-camera GameObject transform fallback with the FreeLook runtime `State.FinalOrientation` for basis rotation and added `GetBasisRotation()` to compute the planar forward/right from that rotation.
- Tightened FreeLook caching/validation and added `IsFreeLookValid()` and a `FreeLookState` enum entry so the cached FreeLook fallback is invalidated when a rendered brain/main camera becomes available.

### Testing

- Ran `git diff --check` which reported no problems and committed the change.
- No Unity editor or .NET CLI was available in the environment, so Unity play-mode or runtime validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff90d10f34832a95c70426656bf44b)