### PR TITLE
Fix gameplay camera basis resolution

### DIFF
--- a/Assets/Scripts/Player/PlayerCameraReference.cs
+++ b/Assets/Scripts/Player/PlayerCameraReference.cs
@@ -45,8 +45,9 @@ public sealed class PlayerCameraReference
             return false;
         }
 
-        forward = Flatten(cachedTransform.forward);
-        right = Flatten(cachedTransform.right);
+        Quaternion basisRotation = GetCachedBasisRotation();
+        forward = Flatten(basisRotation * Vector3.forward);
+        right = Flatten(basisRotation * Vector3.right);
         if (forward.sqrMagnitude < MinPlanarSqrMagnitude || right.sqrMagnitude < MinPlanarSqrMagnitude)
         {
             ClearCache();
@@ -75,19 +76,15 @@ public sealed class PlayerCameraReference
             return true;
         }
 
-        if (freeLook != null && freeLook.enabled)
-        {
-            var freeLookObject = freeLook.VirtualCameraGameObject;
-            if (freeLookObject != null && freeLookObject.activeInHierarchy)
-            {
-                Cache(freeLookObject.transform, null, Source.FreeLook);
-                return true;
-            }
-        }
-
         if (IsCameraValid(Camera.main))
         {
             Cache(Camera.main, Source.MainCamera);
+            return true;
+        }
+
+        if (IsFreeLookValid())
+        {
+            Cache(freeLook.VirtualCameraGameObject.transform, null, Source.FreeLook);
             return true;
         }
 
@@ -108,11 +105,9 @@ public sealed class PlayerCameraReference
                 return cachedCamera == camera && IsCameraValid(cachedCamera);
             case Source.FreeLook:
                 return !TryGetBrainOutputCamera(out _)
-                    && freeLook != null
-                    && freeLook.enabled
-                    && freeLook.VirtualCameraGameObject != null
-                    && cachedTransform == freeLook.VirtualCameraGameObject.transform
-                    && cachedTransform.gameObject.activeInHierarchy;
+                    && !IsCameraValid(Camera.main)
+                    && IsFreeLookValid()
+                    && cachedTransform == freeLook.VirtualCameraGameObject.transform;
             case Source.BrainCamera:
             case Source.MainCamera:
                 return IsCameraValid(cachedCamera);
@@ -138,6 +133,24 @@ public sealed class PlayerCameraReference
         cachedTransform = null;
         cachedCamera = null;
         cachedSource = Source.None;
+    }
+
+    Quaternion GetCachedBasisRotation()
+    {
+        if (cachedSource == Source.FreeLook && freeLook != null)
+        {
+            return freeLook.State.FinalOrientation;
+        }
+
+        return cachedTransform.rotation;
+    }
+
+    bool IsFreeLookValid()
+    {
+        return freeLook != null
+            && freeLook.enabled
+            && freeLook.VirtualCameraGameObject != null
+            && freeLook.VirtualCameraGameObject.activeInHierarchy;
     }
 
     static bool TryGetBrainOutputCamera(out Camera outputCamera)


### PR DESCRIPTION
### Motivation
- Resolve a high-priority bug where an unassigned serialized camera caused the code to use the FreeLook virtual-camera GameObject transform as the gameplay basis, producing camera-relative movement that did not match the rendered view. 
- Prefer the actually rendered camera orientation for movement/aim calculations and only fall back to FreeLook state when no rendered camera is available.

### Description
- Change camera resolution order in `PlayerCameraReference.TryResolve()` to prefer `CinemachineBrain.OutputCamera` and `Camera.main` before falling back to a `CinemachineFreeLook` virtual camera. 
- Replace direct use of `cachedTransform.forward/right` in `TryGetPlanarBasis()` with a resolved basis rotation via `GetCachedBasisRotation()`, and derive planar axes from that rotation so FreeLook fallback uses its `State.FinalOrientation` instead of the vcam GameObject transform. 
- Add helper `GetCachedBasisRotation()` and `IsFreeLookValid()` and tighten `IsCachedValid()` logic so a cached FreeLook basis is invalidated when a rendered brain or main camera becomes available. 
- Keep existing camera validity checks (`IsCameraValid`) and warning path (`WarnMissingCamera`) intact.

### Testing
- Ran `git diff --check` to validate no whitespace/merge conflicts and it completed with no errors. 
- Performed static inspection of the modified file `Assets/Scripts/Player/PlayerCameraReference.cs` to confirm the resolution order and new helpers are present and referenced; no compile-time errors were reported by local checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff91ee82bc832a8a83eabaa4a327d3)