### PR TITLE
Avoid duplicate HUD rendering

### DIFF
--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -18,6 +18,7 @@ public sealed class DebugReference : MonoBehaviour
     public TextMeshProUGUI ArrowMunition;
 
     HudPresenter presenter;
+    bool presenterOwnsUpdate = true;
 
     private void Start()
     {
@@ -28,6 +29,7 @@ public sealed class DebugReference : MonoBehaviour
         }
 
         presenter.Bind(Player, PlayerObjective, CheckpointService.GetOrCreate());
+        presenterOwnsUpdate = presenter.isActiveAndEnabled;
         presenter.ObjectiveText = ObjectiveText;
         presenter.DisplayText = DisplayText;
         presenter.StaminaText = StaminaText;
@@ -42,7 +44,13 @@ public sealed class DebugReference : MonoBehaviour
 
     private void Update()
     {
-        if (presenter != null)
+        if (presenter == null)
+        {
+            return;
+        }
+
+        presenterOwnsUpdate = presenter.isActiveAndEnabled;
+        if (!presenterOwnsUpdate)
         {
             presenter.RenderNow();
         }


### PR DESCRIPTION
### Motivation
- Prevent DebugReference from redundantly calling `HudPresenter.RenderNow()` when a `HudPresenter` is enabled and already self-updating, while preserving serialized field names for prefab compatibility.

### Description
- Add private flag `presenterOwnsUpdate` to track whether the presenter is active and enabled.
- Set `presenterOwnsUpdate = presenter.isActiveAndEnabled` after `presenter.Bind(...)` in `Start()`.
- In `Update()`, skip calling `presenter.RenderNow()` when `presenterOwnsUpdate` is true and only call `RenderNow()` when the presenter is not self-updating.
- Preserve all public serialized fields and adapter binding behavior in `DebugReference` to maintain prefab compatibility.

### Testing
- Ran `git diff --check`, which completed with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a4dfa5e8832aba708ba0e34b3080)