### PR TITLE
Guard ObjectiveUI and UpdatePlattering against nulls and OOB access

### DIFF
--- a/Assets/Scripts/Player/ObjectiveUI.cs
+++ b/Assets/Scripts/Player/ObjectiveUI.cs
@@ -12,7 +12,19 @@ public class ObjectiveUI: MonoBehaviour
     public void Update()
     {
         Player = transform.GetComponent<Behaviour>();
-        i = currentPoint.GetComponent<WayPoint>().i;
+
+        if (currentPoint == null || Objective == null)
+        {
+            return;
+        }
+
+        i = currentPoint.i;
+
+        if (i < 0 || i >= Objective.Length)
+        {
+            return;
+        }
+
         Instruction = Objective[i];
 
     }

--- a/Assets/Scripts/UI/UpdatePlattering.cs
+++ b/Assets/Scripts/UI/UpdatePlattering.cs
@@ -11,6 +11,11 @@ public class UpdatePlattering : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        if (Player == null || PlatetringText == null)
+        {
+            return;
+        }
+
         PlatetringText.text = Player.Plattering;
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent runtime exceptions and reduce per-frame overhead in UI scripts by guarding null references and invalid objective indices while preserving public fields.

### Description
- In `ObjectiveUI.Update`, early-return if `currentPoint` or `Objective` is null.
- Use the cached `currentPoint.i` instead of calling `GetComponent<WayPoint>()` every frame.
- Validate `i` is within `0..Objective.Length-1` before assigning `Instruction`.
- In `UpdatePlattering.Update`, early-return if `Player` or `PlatetringText` is null and leave displayed strings unchanged.

### Testing
- Ran `git diff --check` and it returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ac925548832a9de7e66abaaa65c6)