### PR TITLE
Guard duplicate scene load requests

### DIFF
--- a/Assets/Scripts/SceneScripts/LoadingScreenController.cs
+++ b/Assets/Scripts/SceneScripts/LoadingScreenController.cs
@@ -7,6 +7,8 @@ public class LoadingScreenController : MonoBehaviour
     public Slider loadingBar; // Reference to a loading progress bar (if applicable)
     public float fillSpeed = 0.5f; // Speed at which the loading bar fills (adjust as needed)
 
+    private bool isLoading;
+
     void Start()
     {
         // Disable the loading screen canvas on Start
@@ -18,6 +20,13 @@ public class LoadingScreenController : MonoBehaviour
 
     public void LoadScene(string sceneName)
     {
+        if (isLoading)
+        {
+            return;
+        }
+
+        isLoading = true;
+
         // Activate the loading screen canvas
         if (loadingScreen != null)
         {
@@ -34,6 +43,20 @@ public class LoadingScreenController : MonoBehaviour
         AsyncOperation operation = SceneTransitionService.LoadSceneAsync(sceneName);
         if (operation == null)
         {
+            isLoading = false;
+
+            if (loadingScreen != null)
+            {
+                loadingScreen.SetActive(false);
+            }
+
+            BuildSafeLogger.WarnOnce(
+                nameof(LoadingScreenController) + ".LoadSceneAsyncNull." + sceneName,
+                "Scene load request did not start: " + sceneName + ".",
+                this,
+                null,
+                null,
+                nameof(LoadScene));
             yield break;
         }
 
@@ -68,5 +91,7 @@ public class LoadingScreenController : MonoBehaviour
 
             yield return null; // Wait for the next frame
         }
+
+        isLoading = false;
     }
 }

--- a/Assets/Scripts/SceneScripts/MainMenu.cs
+++ b/Assets/Scripts/SceneScripts/MainMenu.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class MainMenu : MonoBehaviour
 {
+    private bool playRequested;
+
     //double Timer=57;
     //Behavior Ottis;
     //Start is called before the first frame update
@@ -17,6 +19,12 @@ public class MainMenu : MonoBehaviour
     //}
     public void PlayGame()
     {
+        if (playRequested)
+        {
+            return;
+        }
+
+        playRequested = true;
         SceneTransitionService.LoadLevel1();
     }
     public void QuitGame()


### PR DESCRIPTION
### Motivation
- Prevent duplicate scene-load actions from rapid repeated clicks that can cause inconsistent UX or multiple transition attempts.
- Ensure `LoadingScreenController` recovers cleanly when `SceneTransitionService.LoadSceneAsync` returns `null` so the UI isn't left stuck.
- Preserve existing public APIs and UX entry points (`PlayGame`, `QuitGame`, `LoadScene`) so external callers remain unchanged.

### Description
- Added `private bool playRequested` to `MainMenu` and a guard inside `PlayGame()` to ignore duplicate requests while preserving `public PlayGame()` and `public QuitGame()` signatures.
- Added `private bool isLoading` to `LoadingScreenController` and an early return in `LoadScene(string)` when a load is already in progress, and set `isLoading = true` when starting a load.
- In `LoadSceneAsync(string)` reset `isLoading` and hide the loading screen if `SceneTransitionService.LoadSceneAsync(sceneName)` returns `null`, and log a safe warning with `BuildSafeLogger.WarnOnce` referencing `nameof(LoadScene)`.
- Ensure `isLoading = false` is set after the async loop completes so subsequent loads are allowed, and do not modify `Assets/Scenes/Menu.unity`.

### Testing
- Ran `git diff --check` to validate whitespace and basic diffs, which completed with no reported issues.
- Ran `git diff --name-only` to confirm the changed files (`Assets/Scripts/SceneScripts/MainMenu.cs` and `Assets/Scripts/SceneScripts/LoadingScreenController.cs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00bae4f0b0832ab4dfd11f8efbe433)