### PR TITLE
Add SettingsController (persisted UI settings) and integrate with PauseMenu

### DIFF
--- a/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
+++ b/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
@@ -15785,6 +15785,7 @@ GameObject:
   - component: {fileID: 6569126030801917459}
   - component: {fileID: 3664632416280873462}
   - component: {fileID: 2439549891900878302}
+  - component: {fileID: 7314265830149100123}
   - component: {fileID: 8281943336708320071}
   - component: {fileID: 1234567890123456789}
   m_Layer: 5
@@ -16000,6 +16001,23 @@ MonoBehaviour:
   ActivePause: 0
   volumeSlider: {fileID: 8281943336794801012}
   Music: {fileID: 0}
+  settingsController: {fileID: 7314265830149100123}
+--- !u!114 &7314265830149100123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6569126030801917456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 731426583ee745558df549fd9c2a1b84, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  musicSource: {fileID: 0}
+  musicVolumeSlider: {fileID: 8281943336794801012}
+  fullscreenToggle: {fileID: 0}
+  qualityDropdown: {fileID: 0}
 --- !u!114 &8281943336708320071
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Tutorial.unity
+++ b/Assets/Scenes/Tutorial.unity
@@ -14520,6 +14520,24 @@ MonoBehaviour:
   Player: {fileID: 0}
   ActivePause: 0
   volumeSlider: {fileID: 7082506645858404237}
+  Music: {fileID: 0}
+  settingsController: {fileID: 7314265830149100999}
+--- !u!114 &7314265830149100999
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5444702970909479657}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 731426583ee745558df549fd9c2a1b84, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  musicSource: {fileID: 0}
+  musicVolumeSlider: {fileID: 7082506645858404237}
+  fullscreenToggle: {fileID: 0}
+  qualityDropdown: {fileID: 0}
 --- !u!224 &3581325046781199432
 RectTransform:
   m_ObjectHideFlags: 0
@@ -17434,6 +17452,7 @@ GameObject:
   - component: {fileID: 5444702970909479658}
   - component: {fileID: 2485461517859228943}
   - component: {fileID: 3566363148136130855}
+  - component: {fileID: 7314265830149100999}
   - component: {fileID: 7082506645900832702}
   m_Layer: 5
   m_Name: PlayerCanvas

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -13,6 +13,7 @@ public class PauseMenuController : MonoBehaviour
     bool keepCursorVisibleAfterResume;
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
+    [SerializeField] SettingsController settingsController;
 
     protected virtual void OnEnable()
     {
@@ -136,7 +137,19 @@ public class PauseMenuController : MonoBehaviour
 
     public void Volume()
     {
-        if (Player != null && Player.seekMusic && Music != null && volumeSlider != null)
+        if (volumeSlider == null)
+        {
+            return;
+        }
+
+        var adapter = GetSettingsController();
+        if (adapter != null)
+        {
+            adapter.SetMusicVolume(volumeSlider.value);
+            return;
+        }
+
+        if (Player != null && Player.seekMusic && Music != null)
         {
             Music.volume = volumeSlider.value;
         }
@@ -212,6 +225,16 @@ public class PauseMenuController : MonoBehaviour
         var currentFlow = gameFlow != null ? gameFlow : GameFlowController.Instance;
         return currentFlow != null &&
             (currentFlow.State == GameFlowState.Shop || currentFlow.State == GameFlowState.Dialogue);
+    }
+
+    SettingsController GetSettingsController()
+    {
+        if (settingsController == null)
+        {
+            settingsController = GetComponentInChildren<SettingsController>(true);
+        }
+
+        return settingsController;
     }
 
     GameFlowController GetGameFlow()

--- a/Assets/Scripts/UI/SettingsController.cs
+++ b/Assets/Scripts/UI/SettingsController.cs
@@ -1,0 +1,117 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SettingsController : MonoBehaviour
+{
+    public const string MusicVolumeKey = "settings.audio.musicVolume";
+    public const string FullscreenKey = "settings.video.fullscreen";
+    public const string QualityKey = "settings.video.quality";
+
+    [SerializeField] AudioSource musicSource;
+    [SerializeField] Slider musicVolumeSlider;
+    [SerializeField] Toggle fullscreenToggle;
+    [SerializeField] Dropdown qualityDropdown;
+
+    void OnEnable()
+    {
+        LoadAndApplySettings();
+    }
+
+    public void SetMusicVolume(float value)
+    {
+        value = Mathf.Clamp01(value);
+        ApplyMusicVolume(value);
+        PlayerPrefs.SetFloat(MusicVolumeKey, value);
+        PlayerPrefs.Save();
+    }
+
+    public void SetFullscreen(bool enabled)
+    {
+        ApplyFullscreen(enabled);
+        PlayerPrefs.SetInt(FullscreenKey, enabled ? 1 : 0);
+        PlayerPrefs.Save();
+    }
+
+    public void SetQuality(int index)
+    {
+        index = ClampQualityIndex(index);
+        ApplyQuality(index);
+        PlayerPrefs.SetInt(QualityKey, index);
+        PlayerPrefs.Save();
+    }
+
+    void LoadAndApplySettings()
+    {
+        var musicVolume = PlayerPrefs.GetFloat(MusicVolumeKey, GetDefaultMusicVolume());
+        var fullscreen = PlayerPrefs.GetInt(FullscreenKey, Screen.fullScreen ? 1 : 0) == 1;
+        var quality = PlayerPrefs.GetInt(QualityKey, QualitySettings.GetQualityLevel());
+
+        ApplyMusicVolume(musicVolume);
+        ApplyFullscreen(fullscreen);
+        ApplyQuality(quality);
+    }
+
+    void ApplyMusicVolume(float value)
+    {
+        value = Mathf.Clamp01(value);
+        var source = GetMusicSource();
+        if (source != null)
+        {
+            source.volume = value;
+        }
+
+        if (musicVolumeSlider != null)
+        {
+            musicVolumeSlider.SetValueWithoutNotify(value);
+        }
+    }
+
+    void ApplyFullscreen(bool enabled)
+    {
+        Screen.fullScreen = enabled;
+
+        if (fullscreenToggle != null)
+        {
+            fullscreenToggle.SetIsOnWithoutNotify(enabled);
+        }
+    }
+
+    void ApplyQuality(int index)
+    {
+        index = ClampQualityIndex(index);
+        QualitySettings.SetQualityLevel(index, true);
+
+        if (qualityDropdown != null)
+        {
+            qualityDropdown.SetValueWithoutNotify(index);
+        }
+    }
+
+    float GetDefaultMusicVolume()
+    {
+        var source = GetMusicSource();
+        return source != null ? source.volume : 1f;
+    }
+
+    AudioSource GetMusicSource()
+    {
+        if (musicSource != null)
+        {
+            return musicSource;
+        }
+
+        var musicObject = GameObject.FindGameObjectWithTag("Music");
+        if (musicObject == null)
+        {
+            return null;
+        }
+
+        musicSource = musicObject.GetComponent<AudioSource>();
+        return musicSource;
+    }
+
+    static int ClampQualityIndex(int index)
+    {
+        return Mathf.Clamp(index, 0, QualitySettings.names.Length - 1);
+    }
+}

--- a/Assets/Scripts/UI/SettingsController.cs.meta
+++ b/Assets/Scripts/UI/SettingsController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 731426583ee745558df549fd9c2a1b84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
### Motivation
- Provide a lightweight, centralized adapter for persisted UI settings using stable keys for audio/video settings.
- Allow UI to call simple methods (`SetMusicVolume`, `SetFullscreen`, `SetQuality`) and apply saved preferences immediately on enable.

### Description
- Add `Assets/Scripts/UI/SettingsController.cs` implementing stable keys `settings.audio.musicVolume`, `settings.video.fullscreen`, and `settings.video.quality`, loading on `OnEnable`, and calling `PlayerPrefs.Save()` after user-initiated changes.
- `SettingsController` exposes public UI-compatible methods `SetMusicVolume(float)`, `SetFullscreen(bool)`, and `SetQuality(int)` and updates optional `Slider`/`Toggle`/`Dropdown` with `SetValueWithoutNotify`/`SetIsOnWithoutNotify` to avoid callback loops.
- Music volume uses a serialized `AudioSource` if present or finds the `GameObject` tagged `Music` and applies volume safely without creating a persistent audio service.
- Update `PauseMenuController.Volume()` to safely handle missing sliders, attempt to resolve a `SettingsController` adapter via `GetComponentInChildren<SettingsController>(true)`, delegate volume changes to it when present, and fall back to the legacy `Music.volume = volumeSlider.value` behavior.

### Testing
- Ran `git diff --cached --check` to validate staged changes and fix whitespace issues; this check passed.
- Checked for Unity/editor availability with `command -v Unity || command -v unity-editor` and none was found, so editor compile/playmode validation was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c3d7b5f4832ab8ae141c809aec97)