### PR TITLE
Wire pause menu UI selection

### DIFF
--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 public class PauseMenuController : MonoBehaviour
@@ -14,6 +15,8 @@ public class PauseMenuController : MonoBehaviour
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
     [SerializeField] SettingsController settingsController;
+    [SerializeField] GameObject firstPauseSelection;
+    [SerializeField] GameObject firstQuestionSelection;
 
     protected virtual void OnEnable()
     {
@@ -157,22 +160,22 @@ public class PauseMenuController : MonoBehaviour
 
     public void ShowPausePanel()
     {
-        SetPanel(PauseMenu, true, this, nameof(PauseMenu));
+        SetPanel(PauseMenu, true, firstPauseSelection, this, nameof(PauseMenu));
     }
 
     public void HidePausePanel()
     {
-        SetPanel(PauseMenu, false, this, nameof(PauseMenu));
+        SetPanel(PauseMenu, false, firstPauseSelection, this, nameof(PauseMenu));
     }
 
     public void ShowQuestionPanel()
     {
-        SetPanel(Question, true, this, nameof(Question));
+        SetPanel(Question, true, firstQuestionSelection, this, nameof(Question));
     }
 
     public void HideQuestionPanel()
     {
-        SetPanel(Question, false, this, nameof(Question));
+        SetPanel(Question, false, firstQuestionSelection, this, nameof(Question));
     }
 
     internal void ApplyPauseVisualState(bool paused)
@@ -256,11 +259,22 @@ public class PauseMenuController : MonoBehaviour
              currentFlow.State == GameFlowState.Transitioning);
     }
 
-    static void SetPanel(GameObject panel, bool active, PauseMenuController owner, string fieldName)
+    static void SetPanel(GameObject panel, bool active, GameObject firstSelection, PauseMenuController owner, string fieldName)
     {
         if (panel != null)
         {
+            if (!active)
+            {
+                ClearSelectionIfPanelOwnsIt(panel, owner, fieldName);
+            }
+
             panel.SetActive(active);
+
+            if (active)
+            {
+                SelectPanelObject(firstSelection, owner, fieldName);
+            }
+
             return;
         }
 
@@ -269,5 +283,41 @@ public class PauseMenuController : MonoBehaviour
             "UI panel is null; cannot set active=" + active + ".",
             owner,
             fieldName);
+    }
+
+    static void SelectPanelObject(GameObject selection, PauseMenuController owner, string fieldName)
+    {
+        var eventSystem = EventSystem.current;
+        if (eventSystem == null)
+        {
+            WarnMissingEventSystem(owner, fieldName);
+            return;
+        }
+
+        eventSystem.SetSelectedGameObject(selection);
+    }
+
+    static void ClearSelectionIfPanelOwnsIt(GameObject panel, PauseMenuController owner, string fieldName)
+    {
+        var eventSystem = EventSystem.current;
+        if (eventSystem == null)
+        {
+            WarnMissingEventSystem(owner, fieldName);
+            return;
+        }
+
+        var selected = eventSystem.currentSelectedGameObject;
+        if (selected != null && (selected == panel || selected.transform.IsChildOf(panel.transform)))
+        {
+            eventSystem.SetSelectedGameObject(null);
+        }
+    }
+
+    static void WarnMissingEventSystem(PauseMenuController owner, string fieldName)
+    {
+        BuildSafeLogger.WarnOnce(
+            nameof(PauseMenuController) + ".MissingEventSystem." + fieldName,
+            "EventSystem is missing; UI selection update skipped.",
+            owner);
     }
 }

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -272,7 +272,7 @@ public class PauseMenuController : MonoBehaviour
 
             if (active)
             {
-                SelectPanelObject(firstSelection, owner, fieldName);
+                SelectPanelObject(panel, firstSelection, owner, fieldName);
             }
 
             return;
@@ -285,7 +285,7 @@ public class PauseMenuController : MonoBehaviour
             fieldName);
     }
 
-    static void SelectPanelObject(GameObject selection, PauseMenuController owner, string fieldName)
+    static void SelectPanelObject(GameObject panel, GameObject selection, PauseMenuController owner, string fieldName)
     {
         var eventSystem = EventSystem.current;
         if (eventSystem == null)
@@ -294,7 +294,31 @@ public class PauseMenuController : MonoBehaviour
             return;
         }
 
-        eventSystem.SetSelectedGameObject(selection);
+        eventSystem.SetSelectedGameObject(ResolveSelection(panel, selection));
+    }
+
+    static GameObject ResolveSelection(GameObject panel, GameObject selection)
+    {
+        if (selection != null)
+        {
+            return selection;
+        }
+
+        if (panel == null)
+        {
+            return null;
+        }
+
+        var selectables = panel.GetComponentsInChildren<Selectable>();
+        foreach (var selectable in selectables)
+        {
+            if (selectable != null && selectable.IsInteractable() && selectable.gameObject != panel)
+            {
+                return selectable.gameObject;
+            }
+        }
+
+        return null;
     }
 
     static void ClearSelectionIfPanelOwnsIt(GameObject panel, PauseMenuController owner, string fieldName)


### PR DESCRIPTION
### Motivation
- Ensure pause/question panels can set a default selected UI element when shown and clear selection when hidden only if the selection belongs to that panel.
- Make selection updates safe when no `EventSystem` exists by turning updates into no-ops with a once-only development warning.
- Preserve existing cursor handling via `CursorStateService` and pause state routing via `GameFlowController`.

### Description
- Add `using UnityEngine.EventSystems;` and serialized `GameObject firstPauseSelection` and `firstQuestionSelection` fields.
- Change `ShowPausePanel`/`HidePausePanel` and `ShowQuestionPanel`/`HideQuestionPanel` to pass the first-selection target into `SetPanel` and update `SetPanel` signature to `SetPanel(GameObject panel, bool active, GameObject firstSelection, PauseMenuController owner, string fieldName)`.
- Implement `SelectPanelObject`, `ClearSelectionIfPanelOwnsIt`, and `WarnMissingEventSystem` which use `EventSystem.current` to call `SetSelectedGameObject` and only clear selection when `selected == panel || selected.transform.IsChildOf(panel.transform)`; missing `EventSystem` logs via `BuildSafeLogger.WarnOnce` and is otherwise a no-op.
- No changes to cursor or gameflow routing; cursor calls remain through `CursorStateService` and pause state changes remain via `GameFlowController`.

### Testing
- Ran `git diff --check` which reported no issues.
- Unity editor was not available in the CI environment so compilation/runtime tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d46d2c18832aafb9d0e689ad4064)