### PR TITLE
Fix UI guards, stop duplicate HUD render, add load/music/lives safety

### DIFF
--- a/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
+++ b/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
@@ -15786,7 +15786,6 @@ GameObject:
   - component: {fileID: 3664632416280873462}
   - component: {fileID: 2439549891900878302}
   - component: {fileID: 7314265830149100123}
-  - component: {fileID: 8281943336708320071}
   - component: {fileID: 1234567890123456789}
   m_Layer: 5
   m_Name: PlayerCanvas
@@ -16018,30 +16017,6 @@ MonoBehaviour:
   musicVolumeSlider: {fileID: 8281943336794801012}
   fullscreenToggle: {fileID: 0}
   qualityDropdown: {fileID: 0}
---- !u!114 &8281943336708320071
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6569126030801917456}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 66e3189e81ab2eb41ae0a551e8ad811e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Player: {fileID: 0}
-  PlayerObjective: {fileID: 0}
-  ObjectiveText: {fileID: 9220225752409644998}
-  DisplayText: {fileID: 3664632416460160701}
-  StaminaText: {fileID: 702658506274280216}
-  LogCountText: {fileID: 3664632415969327218}
-  HealingDisplay: {fileID: 3664632415368234109}
-  CurrencyCount: {fileID: 8281943336737566932}
-  SeedCount: {fileID: 509081396571889018}
-  GobletCount: {fileID: 8281943335477456013}
-  AppleCount: {fileID: 189672765652707343}
-  ArrowMunition: {fileID: 8722552630855434181}
 --- !u!114 &1234567890123456789
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/ObjectiveUI.cs
+++ b/Assets/Scripts/Player/ObjectiveUI.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class ObjectiveUI: MonoBehaviour
@@ -8,25 +6,27 @@ public class ObjectiveUI: MonoBehaviour
     public string[] Objective;
     public int i;
     public WayPoint currentPoint;
-   public string Instruction;
+    public string Instruction;
+
     public void Update()
     {
-        Player = transform.GetComponent<Behaviour>();
+        if (Player == null)
+        {
+            Player = GetComponent<Behaviour>();
+        }
 
-        if (currentPoint == null || Objective == null)
+        if (Player == null || currentPoint == null || Objective == null || Objective.Length == 0)
         {
             return;
         }
 
         i = currentPoint.i;
-
         if (i < 0 || i >= Objective.Length)
         {
             return;
         }
 
-        Instruction = Objective[i];
-
+        Instruction = Objective[i] ?? string.Empty;
     }
 
     //public void OnTriggerStay(Collider GameObjective) 
@@ -45,7 +45,12 @@ public class ObjectiveUI: MonoBehaviour
     //}
     public void UpdateObjective()
     {
-        i++;
+        if (Objective == null || Objective.Length == 0)
+        {
+            return;
+        }
+
+        i = Mathf.Min(i + 1, Objective.Length - 1);
     }
 
 }

--- a/Assets/Scripts/Player/PlayerFailureController.cs
+++ b/Assets/Scripts/Player/PlayerFailureController.cs
@@ -75,7 +75,7 @@ public class PlayerFailureController : MonoBehaviour
 
     void RestartCheckpointForCompatibility()
     {
-        if (owner.Lives <= 1)
+        if (owner.Lives <= 0)
         {
             owner.Lives = 0;
             owner.ActivateLooseMenu();

--- a/Assets/Scripts/SceneScripts/LoadingScreenController.cs
+++ b/Assets/Scripts/SceneScripts/LoadingScreenController.cs
@@ -7,6 +7,7 @@ public class LoadingScreenController : MonoBehaviour
     public Slider loadingBar; // Reference to a loading progress bar (if applicable)
     public float fillSpeed = 0.5f; // Speed at which the loading bar fills (adjust as needed)
 
+    private static string activeLoadScene;
     private bool isLoading;
 
     void Start()
@@ -18,14 +19,23 @@ public class LoadingScreenController : MonoBehaviour
         }
     }
 
-    public void LoadScene(string sceneName)
+    void OnDestroy()
     {
         if (isLoading)
+        {
+            activeLoadScene = null;
+        }
+    }
+
+    public void LoadScene(string sceneName)
+    {
+        if (string.IsNullOrWhiteSpace(sceneName) || isLoading || !string.IsNullOrEmpty(activeLoadScene))
         {
             return;
         }
 
         isLoading = true;
+        activeLoadScene = sceneName;
 
         // Activate the loading screen canvas
         if (loadingScreen != null)
@@ -44,6 +54,7 @@ public class LoadingScreenController : MonoBehaviour
         if (operation == null)
         {
             isLoading = false;
+            activeLoadScene = null;
 
             if (loadingScreen != null)
             {
@@ -93,5 +104,6 @@ public class LoadingScreenController : MonoBehaviour
         }
 
         isLoading = false;
+        activeLoadScene = null;
     }
 }

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -18,7 +18,6 @@ public sealed class DebugReference : MonoBehaviour
     public TextMeshProUGUI ArrowMunition;
 
     HudPresenter presenter;
-    bool presenterOwnsUpdate = true;
 
     private void Start()
     {
@@ -29,7 +28,6 @@ public sealed class DebugReference : MonoBehaviour
         }
 
         presenter.Bind(Player, PlayerObjective, CheckpointService.GetOrCreate());
-        presenterOwnsUpdate = presenter.isActiveAndEnabled;
         presenter.ObjectiveText = ObjectiveText;
         presenter.DisplayText = DisplayText;
         presenter.StaminaText = StaminaText;
@@ -42,17 +40,4 @@ public sealed class DebugReference : MonoBehaviour
         presenter.ArrowMunition = ArrowMunition;
     }
 
-    private void Update()
-    {
-        if (presenter == null)
-        {
-            return;
-        }
-
-        presenterOwnsUpdate = presenter.isActiveAndEnabled;
-        if (!presenterOwnsUpdate)
-        {
-            presenter.RenderNow();
-        }
-    }
 }

--- a/Assets/Scripts/UI/MusicPlaylist.cs
+++ b/Assets/Scripts/UI/MusicPlaylist.cs
@@ -30,7 +30,7 @@ public class MusicPlaylist : MonoBehaviour
             BuildSafeLogger.ErrorOnce("MusicPlaylist.MissingAudioSource", "No AudioSource component found on the GameObject.", this, missingField: nameof(MusicSource));
             return;
         }
-        if (MusicClip.Length == 0)
+        if (MusicClip == null || MusicClip.Length == 0)
         {
             BuildSafeLogger.ErrorOnce("MusicPlaylist.NoMusicClips", "No music clips assigned in the MusicClip array.", this, missingField: nameof(MusicClip));
             return;
@@ -65,6 +65,13 @@ public class MusicPlaylist : MonoBehaviour
     {
         while (true)
         {
+            if (MusicSource == null || MusicClip == null || MusicClip.Length == 0)
+            {
+                yield break;
+            }
+
+            currentSong = Mathf.Clamp(currentSong, 0, MusicClip.Length - 1);
+
             if (currentSong != previousSong)
             {
                 PlayCurrentSong();
@@ -84,7 +91,19 @@ public class MusicPlaylist : MonoBehaviour
 
     private void PlayCurrentSong()
     {
-        MusicSource.clip = MusicClip[currentSong];
+        if (MusicSource == null || MusicClip == null || MusicClip.Length == 0)
+        {
+            return;
+        }
+
+        currentSong = Mathf.Clamp(currentSong, 0, MusicClip.Length - 1);
+        var clip = MusicClip[currentSong];
+        if (clip == null)
+        {
+            return;
+        }
+
+        MusicSource.clip = clip;
         MusicSource.Play();
     }
 
@@ -110,6 +129,11 @@ public class MusicPlaylist : MonoBehaviour
 
     public void ChangeSong(int newSongIndex)
     {
+        if (MusicSource == null)
+        {
+            MusicSource = GetComponent<AudioSource>();
+        }
+
         if (MusicSource == null || MusicClip == null || MusicClip.Length == 0)
         {
             return;

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -76,7 +76,7 @@ public class PauseMenuController : MonoBehaviour
 
     public void Pause()
     {
-        ApplyPauseVisualState(ActivePause);
+        // Legacy animation/UI hook. Pause panel state is applied only when pause state changes.
     }
 
     public void ChangeBolean()

--- a/Assets/Scripts/UI/UpdatePlattering.cs
+++ b/Assets/Scripts/UI/UpdatePlattering.cs
@@ -1,21 +1,27 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 using TMPro;
-using UnityEngine.UI;
+using UnityEngine;
+
 public class UpdatePlattering : MonoBehaviour
 {
     public Behaviour Player;
     public TextMeshProUGUI PlatetringText;
 
-    // Update is called once per frame
     void Update()
     {
+        if (Player == null)
+        {
+            var playerObject = GameObject.FindGameObjectWithTag("Player");
+            if (playerObject != null)
+            {
+                Player = playerObject.GetComponent<Behaviour>();
+            }
+        }
+
         if (Player == null || PlatetringText == null)
         {
             return;
         }
 
-        PlatetringText.text = Player.Plattering;
+        PlatetringText.text = Player.Plattering ?? string.Empty;
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent per-frame UI mutations and null-reference crashes in several HUD components.
- Avoid duplicate HUD rendering caused by both `DebugReference` and `HudPresenter` updating the UI.
- Prevent concurrent/duplicate scene loads and make `MusicPlaylist` resilient to missing clips/components.
- Correct lives handling for compatibility restart so players only lose when lives are already exhausted.

### Description
- Make `PauseMenuController.Pause()` a no-op to stop per-frame pause panel mutation and keep pause UI changes driven by state transitions (`Assets/Scripts/UI/PauseMenuController.cs`).
- Add null guards, player resolution, safe clamping and string fallbacks in `ObjectiveUI` and `UpdatePlattering` to avoid NREs (`Assets/Scripts/Player/ObjectiveUI.cs`, `Assets/Scripts/UI/UpdatePlattering.cs`).
- Remove runtime duplicate-render path from `DebugReference` (drop conditional `RenderNow` update) and remove the duplicate `DebugReference` component from `PlayerCanvas` prefab to stop double HUD rendering (`Assets/Scripts/UI/DebugReference.cs`, `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`).
- Add static `activeLoadScene`, early-return guard, and `OnDestroy`/reset handling to `LoadingScreenController` to prevent duplicate scene loads (`Assets/Scripts/SceneScripts/LoadingScreenController.cs`).
- Harden `MusicPlaylist` with `[RequireComponent(typeof(AudioSource))]` usage and additional null/length checks, clamping and safe early-exits in the playlist loop and `PlayCurrentSong`/`ChangeSong` (`Assets/Scripts/UI/MusicPlaylist.cs`).
- Fix `RestartCheckpointForCompatibility()` so it triggers the lose menu only when `owner.Lives <= 0`, otherwise decrement and restart as intended (`Assets/Scripts/Player/PlayerFailureController.cs`).

### Testing
- Ran `git diff --check` and it reported no whitespace/errors, test passed.
- Verified absence of the duplicate `DebugReference` prefab GUID and absence of `ApplyPauseVisualState(ActivePause)` / runtime `RenderNow` usage with `rg`, checks passed.
- Unity editor/playmode tests were not run because Unity is not available in PATH in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ddf9b918832abd805e6e6abbf829)