### PR TITLE
Codex/opt UI audio

### DIFF
--- a/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
+++ b/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
@@ -15786,7 +15786,6 @@ GameObject:
   - component: {fileID: 3664632416280873462}
   - component: {fileID: 2439549891900878302}
   - component: {fileID: 7314265830149100123}
-  - component: {fileID: 8281943336708320071}
   - component: {fileID: 1234567890123456789}
   m_Layer: 5
   m_Name: PlayerCanvas
@@ -16018,30 +16017,6 @@ MonoBehaviour:
   musicVolumeSlider: {fileID: 8281943336794801012}
   fullscreenToggle: {fileID: 0}
   qualityDropdown: {fileID: 0}
---- !u!114 &8281943336708320071
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6569126030801917456}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 66e3189e81ab2eb41ae0a551e8ad811e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Player: {fileID: 0}
-  PlayerObjective: {fileID: 0}
-  ObjectiveText: {fileID: 9220225752409644998}
-  DisplayText: {fileID: 3664632416460160701}
-  StaminaText: {fileID: 702658506274280216}
-  LogCountText: {fileID: 3664632415969327218}
-  HealingDisplay: {fileID: 3664632415368234109}
-  CurrencyCount: {fileID: 8281943336737566932}
-  SeedCount: {fileID: 509081396571889018}
-  GobletCount: {fileID: 8281943335477456013}
-  AppleCount: {fileID: 189672765652707343}
-  ArrowMunition: {fileID: 8722552630855434181}
 --- !u!114 &1234567890123456789
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
+++ b/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
@@ -15785,6 +15785,7 @@ GameObject:
   - component: {fileID: 6569126030801917459}
   - component: {fileID: 3664632416280873462}
   - component: {fileID: 2439549891900878302}
+  - component: {fileID: 7314265830149100123}
   - component: {fileID: 8281943336708320071}
   - component: {fileID: 1234567890123456789}
   m_Layer: 5
@@ -16000,6 +16001,23 @@ MonoBehaviour:
   ActivePause: 0
   volumeSlider: {fileID: 8281943336794801012}
   Music: {fileID: 0}
+  settingsController: {fileID: 7314265830149100123}
+--- !u!114 &7314265830149100123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6569126030801917456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 731426583ee745558df549fd9c2a1b84, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  musicSource: {fileID: 0}
+  musicVolumeSlider: {fileID: 8281943336794801012}
+  fullscreenToggle: {fileID: 0}
+  qualityDropdown: {fileID: 0}
 --- !u!114 &8281943336708320071
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -74188,6 +74188,10 @@ GameObject:
   m_Component:
   - component: {fileID: 709278988}
   - component: {fileID: 709278987}
+  - component: {fileID: 709278991}
+  - component: {fileID: 709278990}
+  - component: {fileID: 709278989}
+  - component: {fileID: 709278992}
   m_Layer: 0
   m_Name: GameMaster
   m_TagString: GM
@@ -74207,7 +74211,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e29b6dacd5af9c045a26df095e303a9f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  lastCheckPointPos: {x: 1312.508, y: 38.965, z: 182.5264}
 --- !u!4 &709278988
 Transform:
   m_ObjectHideFlags: 0
@@ -74223,6 +74226,54 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 481
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &709278989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709278986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9c64e666ce0249b09bc64c4b77ce67d8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &709278990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709278986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9df28112db774dffa98adda7788af9e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &709278991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709278986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b95fb80eea43429e8636de54a40675ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &709278992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709278986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ceed2cbf5f3d470f81d4370ba7bdfa0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &709337413
 GameObject:
   m_ObjectHideFlags: 0
@@ -187063,7 +187114,7 @@ Camera:
   m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 35.864223
+  m_FocalLength: 26.95244
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -187072,7 +187123,7 @@ Camera:
     height: 1
   near clip plane: 0.001
   far clip plane: 5000
-  field of view: 37
+  field of view: 48
   orthographic: 0
   orthographic size: 10
   m_Depth: 0
@@ -187097,7 +187148,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1662287251}
-  m_LocalRotation: {x: 0.021738043, y: 0.9317651, z: -0.04510556, w: 0.3595927}
+  m_LocalRotation: {x: 0.019751614, y: 0.932, z: -0.039958555, w: 0.35970724}
   m_LocalPosition: {x: 1315.8147, y: 41.67188, z: 188.29756}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -215951,8 +216002,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 592d20127b1745f4886d153a7ff036d6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  OBJ: {fileID: 0}
-  Player: {fileID: 0}
+  OBJ: {fileID: 1917606087}
+  Player: {fileID: 6441267853562444145}
 --- !u!4 &1917606089
 Transform:
   m_ObjectHideFlags: 0
@@ -242379,7 +242430,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e29b6dacd5af9c045a26df095e303a9f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  lastCheckPointPos: {x: 0, y: 0, z: 0}
 --- !u!1 &434338289962217090
 GameObject:
   m_ObjectHideFlags: 0
@@ -303300,11 +303350,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 520611400682036544, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 3.212773
+      value: 3.21
       objectReference: {fileID: 0}
     - target: {fileID: 520611400682036544, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -6.000001
+      value: -6
       objectReference: {fileID: 0}
     - target: {fileID: 848579588544079351, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_IsActive
@@ -303720,11 +303770,11 @@ PrefabInstance:
       objectReference: {fileID: 8849613805985902112}
     - target: {fileID: 4606268706475194607, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 3.212773
+      value: 3.21
       objectReference: {fileID: 0}
     - target: {fileID: 4606268706475194607, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -6.000001
+      value: -6
       objectReference: {fileID: 0}
     - target: {fileID: 4716460299031841400, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -303756,15 +303806,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268527766832, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 2.524567
+      value: 2.677525
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268527766832, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.935392
+      value: -5.876797
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139202, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 37
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -303780,23 +303830,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9991061
+      value: 0.99950993
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.042220898
+      value: 0.03123235
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0021049676
+      value: 0.0021058617
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000088951776
+      value: -0.00006580422
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268832731778, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 37
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268832731789, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -303844,27 +303894,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269152501947, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 37
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269713821992, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 2.524567
+      value: 2.677525
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269713821992, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.935392
+      value: -5.876797
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269788669586, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 2.524567
+      value: 2.677525
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269788669586, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.935392
+      value: -5.876797
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045682, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 37
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -303880,19 +303930,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9982625
+      value: 0.9985726
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.058885537
+      value: 0.05337105
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0021031797
+      value: 0.0021038654
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00012406427
+      value: -0.00011244416
       objectReference: {fileID: 0}
     - target: {fileID: 5972254857217462357, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -303932,11 +303982,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6644894321090993483, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 3.212773
+      value: 3.21
       objectReference: {fileID: 0}
     - target: {fileID: 6644894321090993483, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -6.000001
+      value: -6
       objectReference: {fileID: 0}
     - target: {fileID: 6726411282374825627, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_Enabled

--- a/Assets/Scenes/Tutorial.unity
+++ b/Assets/Scenes/Tutorial.unity
@@ -14520,6 +14520,24 @@ MonoBehaviour:
   Player: {fileID: 0}
   ActivePause: 0
   volumeSlider: {fileID: 7082506645858404237}
+  Music: {fileID: 0}
+  settingsController: {fileID: 7314265830149100999}
+--- !u!114 &7314265830149100999
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5444702970909479657}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 731426583ee745558df549fd9c2a1b84, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  musicSource: {fileID: 0}
+  musicVolumeSlider: {fileID: 7082506645858404237}
+  fullscreenToggle: {fileID: 0}
+  qualityDropdown: {fileID: 0}
 --- !u!224 &3581325046781199432
 RectTransform:
   m_ObjectHideFlags: 0
@@ -17434,6 +17452,7 @@ GameObject:
   - component: {fileID: 5444702970909479658}
   - component: {fileID: 2485461517859228943}
   - component: {fileID: 3566363148136130855}
+  - component: {fileID: 7314265830149100999}
   - component: {fileID: 7082506645900832702}
   m_Layer: 5
   m_Name: PlayerCanvas

--- a/Assets/Scripts/Core/CursorStateService.cs
+++ b/Assets/Scripts/Core/CursorStateService.cs
@@ -1,9 +1,13 @@
+using System;
+using System.Collections;
 using UnityEngine;
 
 [DefaultExecutionOrder(-1000)]
 public class CursorStateService : MonoBehaviour
 {
     public static CursorStateService Instance { get; private set; }
+
+    int cursorStateVersion;
 
     public static CursorStateService GetOrCreate()
     {
@@ -42,11 +46,49 @@ public class CursorStateService : MonoBehaviour
 
     public void ShowCursor()
     {
+        cursorStateVersion++;
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
     }
 
     public void HideCursor()
+    {
+        cursorStateVersion++;
+        ApplyGameplayCursorState();
+    }
+
+    public void RestoreGameplayCursorAfterUiClose(Func<bool> canRestore = null)
+    {
+        StartCoroutine(RestoreGameplayCursorAfterUiCloseCoroutine(cursorStateVersion, canRestore));
+    }
+
+    IEnumerator RestoreGameplayCursorAfterUiCloseCoroutine(int requestVersion, Func<bool> canRestore)
+    {
+        yield return null;
+        yield return new WaitForEndOfFrame();
+
+        if (requestVersion != cursorStateVersion ||
+            !CanRestoreGameplayCursor(canRestore))
+        {
+            yield break;
+        }
+
+        cursorStateVersion++;
+        ApplyGameplayCursorState();
+    }
+
+    static bool CanRestoreGameplayCursor(Func<bool> canRestore)
+    {
+        if (canRestore != null && !canRestore())
+        {
+            return false;
+        }
+
+        var flow = GameFlowController.Instance;
+        return flow == null || flow.State == GameFlowState.Playing;
+    }
+
+    static void ApplyGameplayCursorState()
     {
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;

--- a/Assets/Scripts/NPC/Beaver/Trader.cs
+++ b/Assets/Scripts/NPC/Beaver/Trader.cs
@@ -70,11 +70,35 @@ public class Trader : MonoBehaviour
         TradeText.SetActive(false);
         DialoguePanel.SetActive(false);
         Shop.SetActive(false);
+        RestoreGameplayAfterInteractionUiClosed();
     }
 
     public void CloseShop()
     {
+        skipPressed = true;
         Shop.SetActive(false);
+        RestoreGameplayAfterInteractionUiClosed();
+    }
+
+    public bool IsShopOpen()
+    {
+        return Shop != null && Shop.activeInHierarchy;
+    }
+
+    public void RestoreGameplayAfterDialogueCancelled()
+    {
+        if (!IsShopOpen())
+        {
+            RestoreGameplayAfterInteractionUiClosed();
+        }
+    }
+
+    void RestoreGameplayAfterInteractionUiClosed()
+    {
+        if (Player != null)
+        {
+            Player.ExitTraderInteraction();
+        }
     }
 
     public void Honey()

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -810,6 +810,8 @@ public class Behaviour : MonoBehaviour, IDamageable
     }
     public void ShowCursor() => Interaction.ShowCursor();
     public void HideCursor() => Interaction.HideCursor();
+    public void ExitTraderInteraction() => Interaction.ExitTrader();
+    public void RestoreGameplayCursorAfterUiClose() => Interaction.RestoreGameplayCursorAfterUiClose();
     public void ActivateLooseMenu()
     {
         //MusicOP.StopMusic();

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -814,7 +814,8 @@ public class Behaviour : MonoBehaviour, IDamageable
     {
         //MusicOP.StopMusic();
         ResetMovementRuntimeState();
-        if (!GameFlowController.GetOrCreate().SetGameOver())
+        var gameFlow = GameFlowController.GetOrCreate();
+        if (gameFlow.State != GameFlowState.GameOver && !gameFlow.SetGameOver())
         {
             return;
         }

--- a/Assets/Scripts/Player/BossHandler.cs
+++ b/Assets/Scripts/Player/BossHandler.cs
@@ -51,8 +51,8 @@ public class BossHandler : MonoBehaviour
     {
         ChatCollider.SetActive(false);
         player.isAtTrader = false;
-        player.HideCursor();
         BossPanel.SetActive(false);
+        player.RestoreGameplayCursorAfterUiClose();
         Boss.isAttacking = true;
         BossBar.SetActive(true);
         player.TryConfigureFreeLookForBoss(6f, 300f, 2f, player.Root);

--- a/Assets/Scripts/Player/ObjectiveUI.cs
+++ b/Assets/Scripts/Player/ObjectiveUI.cs
@@ -12,7 +12,19 @@ public class ObjectiveUI: MonoBehaviour
     public void Update()
     {
         Player = transform.GetComponent<Behaviour>();
-        i = currentPoint.GetComponent<WayPoint>().i;
+
+        if (currentPoint == null || Objective == null)
+        {
+            return;
+        }
+
+        i = currentPoint.i;
+
+        if (i < 0 || i >= Objective.Length)
+        {
+            return;
+        }
+
         Instruction = Objective[i];
 
     }

--- a/Assets/Scripts/Player/ObjectiveUI.cs
+++ b/Assets/Scripts/Player/ObjectiveUI.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class ObjectiveUI: MonoBehaviour
@@ -8,25 +6,27 @@ public class ObjectiveUI: MonoBehaviour
     public string[] Objective;
     public int i;
     public WayPoint currentPoint;
-   public string Instruction;
+    public string Instruction;
+
     public void Update()
     {
-        Player = transform.GetComponent<Behaviour>();
+        if (Player == null)
+        {
+            Player = GetComponent<Behaviour>();
+        }
 
-        if (currentPoint == null || Objective == null)
+        if (Player == null || currentPoint == null || Objective == null || Objective.Length == 0)
         {
             return;
         }
 
         i = currentPoint.i;
-
         if (i < 0 || i >= Objective.Length)
         {
             return;
         }
 
-        Instruction = Objective[i];
-
+        Instruction = Objective[i] ?? string.Empty;
     }
 
     //public void OnTriggerStay(Collider GameObjective) 
@@ -45,7 +45,12 @@ public class ObjectiveUI: MonoBehaviour
     //}
     public void UpdateObjective()
     {
-        i++;
+        if (Objective == null || Objective.Length == 0)
+        {
+            return;
+        }
+
+        i = Mathf.Min(i + 1, Objective.Length - 1);
     }
 
 }

--- a/Assets/Scripts/Player/PlayerFailureController.cs
+++ b/Assets/Scripts/Player/PlayerFailureController.cs
@@ -75,7 +75,7 @@ public class PlayerFailureController : MonoBehaviour
 
     void RestartCheckpointForCompatibility()
     {
-        if (owner.Lives <= 1)
+        if (owner.Lives <= 0)
         {
             owner.Lives = 0;
             owner.ActivateLooseMenu();

--- a/Assets/Scripts/Player/PlayerFailureController.cs
+++ b/Assets/Scripts/Player/PlayerFailureController.cs
@@ -75,9 +75,9 @@ public class PlayerFailureController : MonoBehaviour
 
     void RestartCheckpointForCompatibility()
     {
-        if (owner.Lives <= 0)
+        if (owner.Lives <= 1)
         {
-            owner.Lives = 0;
+            owner.Lives = Mathf.Max(owner.Lives, 1);
             owner.ActivateLooseMenu();
             return;
         }

--- a/Assets/Scripts/Player/PlayerFailureController.cs
+++ b/Assets/Scripts/Player/PlayerFailureController.cs
@@ -75,20 +75,16 @@ public class PlayerFailureController : MonoBehaviour
 
     void RestartCheckpointForCompatibility()
     {
-        if (owner.Lives <= 0)
+        if (owner.Lives <= 1)
         {
             owner.Lives = 0;
             owner.ActivateLooseMenu();
             return;
         }
 
+        owner.Lives--;
         owner.RestoreHealth();
         owner.MoveToCheckpoint();
-        if (owner.Lives > 1)
-        {
-            owner.Lives--;
-        }
-
         ResetRuntimeState();
     }
 

--- a/Assets/Scripts/Player/PlayerInteractionController.cs
+++ b/Assets/Scripts/Player/PlayerInteractionController.cs
@@ -28,6 +28,11 @@ public class PlayerInteractionController : MonoBehaviour
         }
     }
 
+    public void RestoreGameplayCursorAfterUiClose()
+    {
+        CursorStateService.GetOrCreate().RestoreGameplayCursorAfterUiClose(CanRestoreGameplayCursor);
+    }
+
     public void EnterTrader(Collider trader)
     {
         var skip = trader.gameObject.GetComponent<Trader>().skipPressed;
@@ -48,11 +53,24 @@ public class PlayerInteractionController : MonoBehaviour
     public void ExitTrader()
     {
         owner.isAtTrader = false;
-        GameFlowController.GetOrCreate().SetPlaying();
+        var gameFlow = GameFlowController.GetOrCreate();
+        if (gameFlow.State == GameFlowState.Playing ||
+            gameFlow.State == GameFlowState.Shop ||
+            gameFlow.State == GameFlowState.Dialogue)
+        {
+            gameFlow.SetPlaying();
+        }
+
         owner.TrySetTraderCameraEnabled(false);
         owner.TrySetTraderCameraLookAt(null);
         owner.TrySetFreeLookEnabled(true);
         owner.TryRotateFreeLookLookAtTowardRoot();
+        RestoreGameplayCursorAfterUiClose();
+    }
+
+    bool CanRestoreGameplayCursor()
+    {
+        return owner != null && !owner.isAtTrader;
     }
 
     GameInputReader GetInputReader()

--- a/Assets/Scripts/Player/PlayerState.cs.meta
+++ b/Assets/Scripts/Player/PlayerState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8496c89b7348f2342b3f1af1bf0650a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SceneScripts/DoNotDestroy.cs
+++ b/Assets/Scripts/SceneScripts/DoNotDestroy.cs
@@ -11,6 +11,12 @@ public class DoNotDestroy : MonoBehaviour
 
     private void Awake()
     {
+        var musicPlaylist = GetComponent<MusicPlaylist>();
+        if (musicPlaylist != null)
+        {
+            musicPlaylist.WarnIfDuplicateMusicObjectExists();
+        }
+
         var serviceType = GetType();
         if (PersistentTypes.Contains(serviceType))
         {

--- a/Assets/Scripts/SceneScripts/LoadingScreenController.cs
+++ b/Assets/Scripts/SceneScripts/LoadingScreenController.cs
@@ -7,6 +7,8 @@ public class LoadingScreenController : MonoBehaviour
     public Slider loadingBar; // Reference to a loading progress bar (if applicable)
     public float fillSpeed = 0.5f; // Speed at which the loading bar fills (adjust as needed)
 
+    private bool isLoading;
+
     void Start()
     {
         // Disable the loading screen canvas on Start
@@ -18,6 +20,13 @@ public class LoadingScreenController : MonoBehaviour
 
     public void LoadScene(string sceneName)
     {
+        if (isLoading)
+        {
+            return;
+        }
+
+        isLoading = true;
+
         // Activate the loading screen canvas
         if (loadingScreen != null)
         {
@@ -34,6 +43,20 @@ public class LoadingScreenController : MonoBehaviour
         AsyncOperation operation = SceneTransitionService.LoadSceneAsync(sceneName);
         if (operation == null)
         {
+            isLoading = false;
+
+            if (loadingScreen != null)
+            {
+                loadingScreen.SetActive(false);
+            }
+
+            BuildSafeLogger.WarnOnce(
+                nameof(LoadingScreenController) + ".LoadSceneAsyncNull." + sceneName,
+                "Scene load request did not start: " + sceneName + ".",
+                this,
+                null,
+                null,
+                nameof(LoadScene));
             yield break;
         }
 
@@ -68,5 +91,7 @@ public class LoadingScreenController : MonoBehaviour
 
             yield return null; // Wait for the next frame
         }
+
+        isLoading = false;
     }
 }

--- a/Assets/Scripts/SceneScripts/LoadingScreenController.cs
+++ b/Assets/Scripts/SceneScripts/LoadingScreenController.cs
@@ -7,6 +7,7 @@ public class LoadingScreenController : MonoBehaviour
     public Slider loadingBar; // Reference to a loading progress bar (if applicable)
     public float fillSpeed = 0.5f; // Speed at which the loading bar fills (adjust as needed)
 
+    private static string activeLoadScene;
     private bool isLoading;
 
     void Start()
@@ -18,14 +19,23 @@ public class LoadingScreenController : MonoBehaviour
         }
     }
 
-    public void LoadScene(string sceneName)
+    void OnDestroy()
     {
         if (isLoading)
+        {
+            activeLoadScene = null;
+        }
+    }
+
+    public void LoadScene(string sceneName)
+    {
+        if (string.IsNullOrWhiteSpace(sceneName) || isLoading || !string.IsNullOrEmpty(activeLoadScene))
         {
             return;
         }
 
         isLoading = true;
+        activeLoadScene = sceneName;
 
         // Activate the loading screen canvas
         if (loadingScreen != null)
@@ -44,6 +54,7 @@ public class LoadingScreenController : MonoBehaviour
         if (operation == null)
         {
             isLoading = false;
+            activeLoadScene = null;
 
             if (loadingScreen != null)
             {
@@ -93,5 +104,6 @@ public class LoadingScreenController : MonoBehaviour
         }
 
         isLoading = false;
+        activeLoadScene = null;
     }
 }

--- a/Assets/Scripts/SceneScripts/MainMenu.cs
+++ b/Assets/Scripts/SceneScripts/MainMenu.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class MainMenu : MonoBehaviour
 {
+    private bool playRequested;
+
     //double Timer=57;
     //Behavior Ottis;
     //Start is called before the first frame update
@@ -17,6 +19,12 @@ public class MainMenu : MonoBehaviour
     //}
     public void PlayGame()
     {
+        if (playRequested)
+        {
+            return;
+        }
+
+        playRequested = true;
         SceneTransitionService.LoadLevel1();
     }
     public void QuitGame()

--- a/Assets/Scripts/SceneScripts/RestartGameLooseMenu.cs
+++ b/Assets/Scripts/SceneScripts/RestartGameLooseMenu.cs
@@ -6,12 +6,18 @@ public sealed class RestartGameLooseMenu : MonoBehaviour
 
     public void ResetartGame()
     {
+        ResolveLoseMenuController();
         if (loseMenuController != null)
         {
             loseMenuController.RestartGame();
-            return;
         }
+    }
 
-        SceneTransitionService.ReloadActiveScene();
+    void ResolveLoseMenuController()
+    {
+        if (loseMenuController == null)
+        {
+            loseMenuController = GetComponentInParent<LoseMenuController>();
+        }
     }
 }

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -18,7 +18,6 @@ public sealed class DebugReference : MonoBehaviour
     public TextMeshProUGUI ArrowMunition;
 
     HudPresenter presenter;
-    bool presenterOwnsUpdate = true;
 
     private void Start()
     {
@@ -29,7 +28,6 @@ public sealed class DebugReference : MonoBehaviour
         }
 
         presenter.Bind(Player, PlayerObjective, CheckpointService.GetOrCreate());
-        presenterOwnsUpdate = presenter.isActiveAndEnabled;
         presenter.ObjectiveText = ObjectiveText;
         presenter.DisplayText = DisplayText;
         presenter.StaminaText = StaminaText;
@@ -42,17 +40,4 @@ public sealed class DebugReference : MonoBehaviour
         presenter.ArrowMunition = ArrowMunition;
     }
 
-    private void Update()
-    {
-        if (presenter == null)
-        {
-            return;
-        }
-
-        presenterOwnsUpdate = presenter.isActiveAndEnabled;
-        if (!presenterOwnsUpdate)
-        {
-            presenter.RenderNow();
-        }
-    }
 }

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -18,6 +18,7 @@ public sealed class DebugReference : MonoBehaviour
     public TextMeshProUGUI ArrowMunition;
 
     HudPresenter presenter;
+    bool presenterOwnsUpdate = true;
 
     private void Start()
     {
@@ -28,6 +29,7 @@ public sealed class DebugReference : MonoBehaviour
         }
 
         presenter.Bind(Player, PlayerObjective, CheckpointService.GetOrCreate());
+        presenterOwnsUpdate = presenter.isActiveAndEnabled;
         presenter.ObjectiveText = ObjectiveText;
         presenter.DisplayText = DisplayText;
         presenter.StaminaText = StaminaText;
@@ -42,7 +44,13 @@ public sealed class DebugReference : MonoBehaviour
 
     private void Update()
     {
-        if (presenter != null)
+        if (presenter == null)
+        {
+            return;
+        }
+
+        presenterOwnsUpdate = presenter.isActiveAndEnabled;
+        if (!presenterOwnsUpdate)
         {
             presenter.RenderNow();
         }

--- a/Assets/Scripts/UI/Dialogue.cs
+++ b/Assets/Scripts/UI/Dialogue.cs
@@ -52,6 +52,18 @@ public class Dialogue : MonoBehaviour
         index = 0;
     }
 
+    void OnDisable()
+    {
+        if (Merchant != null)
+        {
+            Merchant.RestoreGameplayAfterDialogueCancelled();
+        }
+        else if (Player != null && Player.isAtTrader)
+        {
+            Player.ExitTraderInteraction();
+        }
+    }
+
     // Update is called once per frame
     public void Continue()
     {

--- a/Assets/Scripts/UI/LoseMenuController.cs
+++ b/Assets/Scripts/UI/LoseMenuController.cs
@@ -11,6 +11,12 @@ public sealed class LoseMenuController : MonoBehaviour
 
     public void ShowLosePanel()
     {
+        if (!TrySetGameOver())
+        {
+            return;
+        }
+
+        CursorStateService.GetOrCreate().ShowCursor();
         SetPanel(true);
     }
 
@@ -34,11 +40,30 @@ public sealed class LoseMenuController : MonoBehaviour
         SceneTransitionService.LoadMenu();
     }
 
+    bool TrySetGameOver()
+    {
+        var gameFlow = GameFlowController.GetOrCreate();
+        if (gameFlow.State == GameFlowState.GameOver)
+        {
+            return true;
+        }
+
+        if (gameFlow.State == GameFlowState.Transitioning)
+        {
+            return false;
+        }
+
+        return gameFlow.SetGameOver();
+    }
+
     void SetPanel(bool active)
     {
         if (LosePanel != null)
         {
-            LosePanel.SetActive(active);
+            if (LosePanel.activeSelf != active)
+            {
+                LosePanel.SetActive(active);
+            }
             return;
         }
 

--- a/Assets/Scripts/UI/MusicPlaylist.cs
+++ b/Assets/Scripts/UI/MusicPlaylist.cs
@@ -2,8 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(AudioSource))]
 public class MusicPlaylist : MonoBehaviour
 {
+    // GameMusic.prefab persists music only; it is not a runtime bootstrap owner.
     public AudioSource MusicSource;
     [SerializeField] AudioClip[] MusicClip;
     private int currentSong = 0;
@@ -68,16 +70,31 @@ public class MusicPlaylist : MonoBehaviour
 
     public void StopMusic()
     {
+        if (MusicSource == null)
+        {
+            return;
+        }
+
         MusicSource.Pause();
     }
 
     public void ResumeMusic()
     {
+        if (MusicSource == null)
+        {
+            return;
+        }
+
         MusicSource.Play();
     }
 
     public void ChangeSong(int newSongIndex)
     {
+        if (MusicSource == null || MusicClip == null || MusicClip.Length == 0)
+        {
+            return;
+        }
+
         if (newSongIndex >= 0 && newSongIndex < MusicClip.Length)
         {
             currentSong = newSongIndex;

--- a/Assets/Scripts/UI/MusicPlaylist.cs
+++ b/Assets/Scripts/UI/MusicPlaylist.cs
@@ -30,7 +30,7 @@ public class MusicPlaylist : MonoBehaviour
             BuildSafeLogger.ErrorOnce("MusicPlaylist.MissingAudioSource", "No AudioSource component found on the GameObject.", this, missingField: nameof(MusicSource));
             return;
         }
-        if (MusicClip.Length == 0)
+        if (MusicClip == null || MusicClip.Length == 0)
         {
             BuildSafeLogger.ErrorOnce("MusicPlaylist.NoMusicClips", "No music clips assigned in the MusicClip array.", this, missingField: nameof(MusicClip));
             return;
@@ -65,6 +65,13 @@ public class MusicPlaylist : MonoBehaviour
     {
         while (true)
         {
+            if (MusicSource == null || MusicClip == null || MusicClip.Length == 0)
+            {
+                yield break;
+            }
+
+            currentSong = Mathf.Clamp(currentSong, 0, MusicClip.Length - 1);
+
             if (currentSong != previousSong)
             {
                 PlayCurrentSong();
@@ -84,7 +91,19 @@ public class MusicPlaylist : MonoBehaviour
 
     private void PlayCurrentSong()
     {
-        MusicSource.clip = MusicClip[currentSong];
+        if (MusicSource == null || MusicClip == null || MusicClip.Length == 0)
+        {
+            return;
+        }
+
+        currentSong = Mathf.Clamp(currentSong, 0, MusicClip.Length - 1);
+        var clip = MusicClip[currentSong];
+        if (clip == null)
+        {
+            return;
+        }
+
+        MusicSource.clip = clip;
         MusicSource.Play();
     }
 
@@ -110,6 +129,11 @@ public class MusicPlaylist : MonoBehaviour
 
     public void ChangeSong(int newSongIndex)
     {
+        if (MusicSource == null)
+        {
+            MusicSource = GetComponent<AudioSource>();
+        }
+
         if (MusicSource == null || MusicClip == null || MusicClip.Length == 0)
         {
             return;

--- a/Assets/Scripts/UI/MusicPlaylist.cs
+++ b/Assets/Scripts/UI/MusicPlaylist.cs
@@ -11,9 +11,12 @@ public class MusicPlaylist : MonoBehaviour
     private int currentSong = 0;
     private int previousSong = -1;
     private Coroutine playlistCoroutine;
+    private const string MusicTag = "Music";
 
     private void Start()
     {
+        WarnIfDuplicateMusicObjectExists();
+
         if (MusicSource == null)
         {
             MusicSource = GetComponent<AudioSource>();
@@ -30,6 +33,20 @@ public class MusicPlaylist : MonoBehaviour
             return;
         }
         StartPlaylist();
+    }
+
+    private void WarnIfDuplicateMusicObjectExists()
+    {
+        var musicObjects = GameObject.FindGameObjectsWithTag(MusicTag);
+        for (var i = 0; i < musicObjects.Length; i++)
+        {
+            var musicObject = musicObjects[i];
+            if (musicObject != null && musicObject != gameObject && musicObject.activeInHierarchy)
+            {
+                BuildSafeLogger.WarnOnce("MusicPlaylist.DuplicateActiveMusic", "Another active object tagged Music exists: " + musicObject.name, this, missingTag: MusicTag);
+                return;
+            }
+        }
     }
 
     private void StartPlaylist()

--- a/Assets/Scripts/UI/MusicPlaylist.cs
+++ b/Assets/Scripts/UI/MusicPlaylist.cs
@@ -13,10 +13,13 @@ public class MusicPlaylist : MonoBehaviour
     private Coroutine playlistCoroutine;
     private const string MusicTag = "Music";
 
-    private void Start()
+    private void Awake()
     {
         WarnIfDuplicateMusicObjectExists();
+    }
 
+    private void Start()
+    {
         if (MusicSource == null)
         {
             MusicSource = GetComponent<AudioSource>();
@@ -35,7 +38,7 @@ public class MusicPlaylist : MonoBehaviour
         StartPlaylist();
     }
 
-    private void WarnIfDuplicateMusicObjectExists()
+    internal void WarnIfDuplicateMusicObjectExists()
     {
         var musicObjects = GameObject.FindGameObjectsWithTag(MusicTag);
         for (var i = 0; i < musicObjects.Length; i++)

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -10,6 +10,7 @@ public class PauseMenuController : MonoBehaviour
 
     GameFlowController gameFlow;
     GameInputReader inputReader;
+    bool keepCursorVisibleAfterResume;
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
 
@@ -67,25 +68,31 @@ public class PauseMenuController : MonoBehaviour
 
     protected virtual void Update()
     {
-        Pause();
     }
 
     public void Pause()
     {
-        if (ActivePause)
-        {
-            ShowPausePanel();
-            return;
-        }
-
-        HidePausePanel();
-        HideQuestionPanel();
+        ApplyPauseVisualState(ActivePause);
     }
 
     public void ChangeBolean()
     {
-        var pauseRequested = !ActivePause;
-        var keepCursorVisible = !pauseRequested && IsPlayerInTraderOrDialogueUi();
+        var currentFlow = GetGameFlow();
+        if (IsPauseToggleBlocked(currentFlow))
+        {
+            return;
+        }
+
+        var pauseRequested = currentFlow != null
+            ? currentFlow.State != GameFlowState.Paused
+            : !ActivePause;
+        var keepCursorVisible = !pauseRequested &&
+            (keepCursorVisibleAfterResume || IsPlayerInTraderOrDialogueUi());
+
+        if (pauseRequested)
+        {
+            keepCursorVisibleAfterResume = IsPlayerInTraderOrDialogueUi();
+        }
 
         if (!SetPaused(pauseRequested))
         {
@@ -94,7 +101,12 @@ public class PauseMenuController : MonoBehaviour
 
         ActivePause = pauseRequested;
         ApplyCursorState(pauseRequested, keepCursorVisible);
-        Pause();
+        ApplyPauseVisualState(pauseRequested);
+
+        if (!pauseRequested)
+        {
+            keepCursorVisibleAfterResume = false;
+        }
     }
 
     void HandlePausePressed()
@@ -150,14 +162,23 @@ public class PauseMenuController : MonoBehaviour
         SetPanel(Question, false, this, nameof(Question));
     }
 
-    bool SetPaused(bool paused)
+    internal void ApplyPauseVisualState(bool paused)
     {
-        if (gameFlow == null)
+        if (paused)
         {
-            gameFlow = GameFlowController.GetOrCreate();
+            ShowPausePanel();
+            return;
         }
 
-        if (!gameFlow.SetPaused(paused))
+        HidePausePanel();
+        HideQuestionPanel();
+    }
+
+    bool SetPaused(bool paused)
+    {
+        gameFlow = GetGameFlow();
+
+        if (gameFlow == null || !gameFlow.SetPaused(paused))
         {
             ActivePause = false;
             return false;
@@ -191,6 +212,25 @@ public class PauseMenuController : MonoBehaviour
         var currentFlow = gameFlow != null ? gameFlow : GameFlowController.Instance;
         return currentFlow != null &&
             (currentFlow.State == GameFlowState.Shop || currentFlow.State == GameFlowState.Dialogue);
+    }
+
+    GameFlowController GetGameFlow()
+    {
+        if (gameFlow == null)
+        {
+            gameFlow = GameFlowController.Instance != null
+                ? GameFlowController.Instance
+                : GameFlowController.GetOrCreate();
+        }
+
+        return gameFlow;
+    }
+
+    static bool IsPauseToggleBlocked(GameFlowController currentFlow)
+    {
+        return currentFlow != null &&
+            (currentFlow.State == GameFlowState.GameOver ||
+             currentFlow.State == GameFlowState.Transitioning);
     }
 
     static void SetPanel(GameObject panel, bool active, PauseMenuController owner, string fieldName)

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -13,6 +13,7 @@ public class PauseMenuController : MonoBehaviour
     bool keepCursorVisibleAfterResume;
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
+    [SerializeField] SettingsController settingsController;
 
     protected virtual void OnEnable()
     {
@@ -136,7 +137,19 @@ public class PauseMenuController : MonoBehaviour
 
     public void Volume()
     {
-        if (Player != null && Player.seekMusic && Music != null && volumeSlider != null)
+        if (volumeSlider == null)
+        {
+            return;
+        }
+
+        var adapter = GetSettingsController();
+        if (adapter != null)
+        {
+            adapter.SetMusicVolume(volumeSlider.value);
+            return;
+        }
+
+        if (Player != null && Player.seekMusic && Music != null)
         {
             Music.volume = volumeSlider.value;
         }
@@ -212,6 +225,16 @@ public class PauseMenuController : MonoBehaviour
         var currentFlow = gameFlow != null ? gameFlow : GameFlowController.Instance;
         return currentFlow != null &&
             (currentFlow.State == GameFlowState.Shop || currentFlow.State == GameFlowState.Dialogue);
+    }
+
+    SettingsController GetSettingsController()
+    {
+        if (settingsController == null)
+        {
+            settingsController = GetComponentInChildren<SettingsController>(true);
+        }
+
+        return settingsController;
     }
 
     GameFlowController GetGameFlow()

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 public class PauseMenuController : MonoBehaviour
@@ -14,6 +15,8 @@ public class PauseMenuController : MonoBehaviour
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
     [SerializeField] SettingsController settingsController;
+    [SerializeField] GameObject firstPauseSelection;
+    [SerializeField] GameObject firstQuestionSelection;
 
     protected virtual void OnEnable()
     {
@@ -157,22 +160,22 @@ public class PauseMenuController : MonoBehaviour
 
     public void ShowPausePanel()
     {
-        SetPanel(PauseMenu, true, this, nameof(PauseMenu));
+        SetPanel(PauseMenu, true, firstPauseSelection, this, nameof(PauseMenu));
     }
 
     public void HidePausePanel()
     {
-        SetPanel(PauseMenu, false, this, nameof(PauseMenu));
+        SetPanel(PauseMenu, false, firstPauseSelection, this, nameof(PauseMenu));
     }
 
     public void ShowQuestionPanel()
     {
-        SetPanel(Question, true, this, nameof(Question));
+        SetPanel(Question, true, firstQuestionSelection, this, nameof(Question));
     }
 
     public void HideQuestionPanel()
     {
-        SetPanel(Question, false, this, nameof(Question));
+        SetPanel(Question, false, firstQuestionSelection, this, nameof(Question));
     }
 
     internal void ApplyPauseVisualState(bool paused)
@@ -256,11 +259,22 @@ public class PauseMenuController : MonoBehaviour
              currentFlow.State == GameFlowState.Transitioning);
     }
 
-    static void SetPanel(GameObject panel, bool active, PauseMenuController owner, string fieldName)
+    static void SetPanel(GameObject panel, bool active, GameObject firstSelection, PauseMenuController owner, string fieldName)
     {
         if (panel != null)
         {
+            if (!active)
+            {
+                ClearSelectionIfPanelOwnsIt(panel, owner, fieldName);
+            }
+
             panel.SetActive(active);
+
+            if (active)
+            {
+                SelectPanelObject(firstSelection, owner, fieldName);
+            }
+
             return;
         }
 
@@ -269,5 +283,41 @@ public class PauseMenuController : MonoBehaviour
             "UI panel is null; cannot set active=" + active + ".",
             owner,
             fieldName);
+    }
+
+    static void SelectPanelObject(GameObject selection, PauseMenuController owner, string fieldName)
+    {
+        var eventSystem = EventSystem.current;
+        if (eventSystem == null)
+        {
+            WarnMissingEventSystem(owner, fieldName);
+            return;
+        }
+
+        eventSystem.SetSelectedGameObject(selection);
+    }
+
+    static void ClearSelectionIfPanelOwnsIt(GameObject panel, PauseMenuController owner, string fieldName)
+    {
+        var eventSystem = EventSystem.current;
+        if (eventSystem == null)
+        {
+            WarnMissingEventSystem(owner, fieldName);
+            return;
+        }
+
+        var selected = eventSystem.currentSelectedGameObject;
+        if (selected != null && (selected == panel || selected.transform.IsChildOf(panel.transform)))
+        {
+            eventSystem.SetSelectedGameObject(null);
+        }
+    }
+
+    static void WarnMissingEventSystem(PauseMenuController owner, string fieldName)
+    {
+        BuildSafeLogger.WarnOnce(
+            nameof(PauseMenuController) + ".MissingEventSystem." + fieldName,
+            "EventSystem is missing; UI selection update skipped.",
+            owner);
     }
 }

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -272,7 +272,7 @@ public class PauseMenuController : MonoBehaviour
 
             if (active)
             {
-                SelectPanelObject(firstSelection, owner, fieldName);
+                SelectPanelObject(panel, firstSelection, owner, fieldName);
             }
 
             return;
@@ -285,7 +285,7 @@ public class PauseMenuController : MonoBehaviour
             fieldName);
     }
 
-    static void SelectPanelObject(GameObject selection, PauseMenuController owner, string fieldName)
+    static void SelectPanelObject(GameObject panel, GameObject selection, PauseMenuController owner, string fieldName)
     {
         var eventSystem = EventSystem.current;
         if (eventSystem == null)
@@ -294,7 +294,31 @@ public class PauseMenuController : MonoBehaviour
             return;
         }
 
-        eventSystem.SetSelectedGameObject(selection);
+        eventSystem.SetSelectedGameObject(ResolveSelection(panel, selection));
+    }
+
+    static GameObject ResolveSelection(GameObject panel, GameObject selection)
+    {
+        if (selection != null)
+        {
+            return selection;
+        }
+
+        if (panel == null)
+        {
+            return null;
+        }
+
+        var selectables = panel.GetComponentsInChildren<Selectable>();
+        foreach (var selectable in selectables)
+        {
+            if (selectable != null && selectable.IsInteractable() && selectable.gameObject != panel)
+            {
+                return selectable.gameObject;
+            }
+        }
+
+        return null;
     }
 
     static void ClearSelectionIfPanelOwnsIt(GameObject panel, PauseMenuController owner, string fieldName)

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -76,7 +76,7 @@ public class PauseMenuController : MonoBehaviour
 
     public void Pause()
     {
-        ApplyPauseVisualState(ActivePause);
+        // Legacy animation/UI hook. Pause panel state is applied only when pause state changes.
     }
 
     public void ChangeBolean()

--- a/Assets/Scripts/UI/SettingsController.cs
+++ b/Assets/Scripts/UI/SettingsController.cs
@@ -1,0 +1,117 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SettingsController : MonoBehaviour
+{
+    public const string MusicVolumeKey = "settings.audio.musicVolume";
+    public const string FullscreenKey = "settings.video.fullscreen";
+    public const string QualityKey = "settings.video.quality";
+
+    [SerializeField] AudioSource musicSource;
+    [SerializeField] Slider musicVolumeSlider;
+    [SerializeField] Toggle fullscreenToggle;
+    [SerializeField] Dropdown qualityDropdown;
+
+    void OnEnable()
+    {
+        LoadAndApplySettings();
+    }
+
+    public void SetMusicVolume(float value)
+    {
+        value = Mathf.Clamp01(value);
+        ApplyMusicVolume(value);
+        PlayerPrefs.SetFloat(MusicVolumeKey, value);
+        PlayerPrefs.Save();
+    }
+
+    public void SetFullscreen(bool enabled)
+    {
+        ApplyFullscreen(enabled);
+        PlayerPrefs.SetInt(FullscreenKey, enabled ? 1 : 0);
+        PlayerPrefs.Save();
+    }
+
+    public void SetQuality(int index)
+    {
+        index = ClampQualityIndex(index);
+        ApplyQuality(index);
+        PlayerPrefs.SetInt(QualityKey, index);
+        PlayerPrefs.Save();
+    }
+
+    void LoadAndApplySettings()
+    {
+        var musicVolume = PlayerPrefs.GetFloat(MusicVolumeKey, GetDefaultMusicVolume());
+        var fullscreen = PlayerPrefs.GetInt(FullscreenKey, Screen.fullScreen ? 1 : 0) == 1;
+        var quality = PlayerPrefs.GetInt(QualityKey, QualitySettings.GetQualityLevel());
+
+        ApplyMusicVolume(musicVolume);
+        ApplyFullscreen(fullscreen);
+        ApplyQuality(quality);
+    }
+
+    void ApplyMusicVolume(float value)
+    {
+        value = Mathf.Clamp01(value);
+        var source = GetMusicSource();
+        if (source != null)
+        {
+            source.volume = value;
+        }
+
+        if (musicVolumeSlider != null)
+        {
+            musicVolumeSlider.SetValueWithoutNotify(value);
+        }
+    }
+
+    void ApplyFullscreen(bool enabled)
+    {
+        Screen.fullScreen = enabled;
+
+        if (fullscreenToggle != null)
+        {
+            fullscreenToggle.SetIsOnWithoutNotify(enabled);
+        }
+    }
+
+    void ApplyQuality(int index)
+    {
+        index = ClampQualityIndex(index);
+        QualitySettings.SetQualityLevel(index, true);
+
+        if (qualityDropdown != null)
+        {
+            qualityDropdown.SetValueWithoutNotify(index);
+        }
+    }
+
+    float GetDefaultMusicVolume()
+    {
+        var source = GetMusicSource();
+        return source != null ? source.volume : 1f;
+    }
+
+    AudioSource GetMusicSource()
+    {
+        if (musicSource != null)
+        {
+            return musicSource;
+        }
+
+        var musicObject = GameObject.FindGameObjectWithTag("Music");
+        if (musicObject == null)
+        {
+            return null;
+        }
+
+        musicSource = musicObject.GetComponent<AudioSource>();
+        return musicSource;
+    }
+
+    static int ClampQualityIndex(int index)
+    {
+        return Mathf.Clamp(index, 0, QualitySettings.names.Length - 1);
+    }
+}

--- a/Assets/Scripts/UI/SettingsController.cs.meta
+++ b/Assets/Scripts/UI/SettingsController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 731426583ee745558df549fd9c2a1b84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/UpdatePlattering.cs
+++ b/Assets/Scripts/UI/UpdatePlattering.cs
@@ -11,6 +11,11 @@ public class UpdatePlattering : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        if (Player == null || PlatetringText == null)
+        {
+            return;
+        }
+
         PlatetringText.text = Player.Plattering;
     }
 }

--- a/Assets/Scripts/UI/UpdatePlattering.cs
+++ b/Assets/Scripts/UI/UpdatePlattering.cs
@@ -1,21 +1,27 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 using TMPro;
-using UnityEngine.UI;
+using UnityEngine;
+
 public class UpdatePlattering : MonoBehaviour
 {
     public Behaviour Player;
     public TextMeshProUGUI PlatetringText;
 
-    // Update is called once per frame
     void Update()
     {
+        if (Player == null)
+        {
+            var playerObject = GameObject.FindGameObjectWithTag("Player");
+            if (playerObject != null)
+            {
+                Player = playerObject.GetComponent<Behaviour>();
+            }
+        }
+
         if (Player == null || PlatetringText == null)
         {
             return;
         }
 
-        PlatetringText.text = Player.Plattering;
+        PlatetringText.text = Player.Plattering ?? string.Empty;
     }
 }


### PR DESCRIPTION
## Summary

- Stabilized pause/menu state transitions:
  - Pause toggles are now edge-triggered instead of mutating panels every frame.
  - Pause is blocked during game-over and scene-transition states.
  - Cursor visibility/locking is routed through runtime cursor services.
  - Pause/question panels now support safe UI selection/focus fallback.

- Hardened lose/game-over flow:
  - Lose panel activation is idempotent.
  - Game-over state is coordinated with `GameFlowController`.
  - Restart/menu actions continue routing through `SceneTransitionService`.
  - Legacy typo callback `ResetartGame()` remains compatible.

- Reduced duplicate HUD/runtime text ownership:
  - `DebugReference` now acts as a binding adapter for `HudPresenter` instead of rendering separately.
  - Objective/plattering UI writers now guard missing player/text/objective refs and out-of-range objective indexes.

- Improved loading/menu safety:
  - Main menu Play is duplicate-click guarded.
  - Loading screen blocks duplicate/empty scene loads.
  - Failed async scene starts reset loading state and hide the loading overlay safely.

- Clarified music ownership:
  - `MusicPlaylist` now explicitly requires an `AudioSource`.
  - Playlist playback handles missing sources/clips/null clips safely.
  - Duplicate active music objects are diagnosed without adding new runtime bootstrap ownership.
  - `GameMusic.prefab` remains music-only with existing persistence.

- Added lightweight settings persistence:
  - New `SettingsController` persists music volume, fullscreen, and quality via `PlayerPrefs`.
  - Pause volume slider delegates through settings when available.
  - PlayerCanvas/Tutorial UI wiring now references the settings controller.

## Testing

- Not run in this pass; PR message generated from branch diff/log review.

## References
 
- Pause/menu changes are in PauseMenuController, including no-op legacy Update()/Pause(), state-derived toggling, settings delegation, cursor handling, transition/game-over blocking, and UI focus fallback. 
- Lose/game-over routing is handled by LoseMenuController, Behaviour, PlayerFailureController, and RestartGameLooseMenu. 
- HUD/text hardening is in DebugReference, ObjectiveUI, and UpdatePlattering. 
- Loading/menu safety is in MainMenu and LoadingScreenController. 
- Music ownership and duplicate diagnostics are in MusicPlaylist, DoNotDestroy, and GameMusic.prefab. 
- Settings persistence and prefab/scene wiring are in SettingsController, PlayerCanvas.prefab, and Tutorial.unity. 

## Commands used
```
git status --short && git branch --show-current && git log --oneline --decorate -n 12 && git diff --stat main...HEAD || git diff --stat origin/main...HEAD
git status --short; git branch -a --format='%(refname:short)'; git log --oneline --decorate --max-count=30
git diff --stat 2aa67a5c..HEAD; git diff --name-only 2aa67a5c..HEAD
nl -ba Assets/Scripts/UI/PauseMenuController.cs | sed -n '1,260p'
nl -ba Assets/Scripts/UI/LoseMenuController.cs | sed -n '1,180p'
nl -ba Assets/Scripts/UI/MusicPlaylist.cs | sed -n '1,180p'
nl -ba Assets/Scripts/UI/SettingsController.cs | sed -n '1,240p'
nl -ba Assets/Prefabs/Objects/UI/PlayerCanvas.prefab | sed -n '15780,15800p'
nl -ba Assets/Scenes/Tutorial.unity | sed -n '14515,14530p'
```