### PR TITLE
Reduce redundant frame updates

### DIFF
--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -87,7 +87,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         Physics.IgnoreLayerCollision(10, 10);
 
         CurrentHealth = MaxHealth;
-        Explosion.SetActive(false);
+        SetActiveIfChanged(Explosion, false);
         feedback?.ResetFeedback();
         paceUp = chargeSpeed + 2;
         resetCharge = chargeClock;
@@ -167,7 +167,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         {
             foreach (var animatorBool in initialAnimatorBools)
             {
-                Scorpion.SetBool(animatorBool.Key, animatorBool.Value);
+                SetAnimatorBoolIfChanged(Scorpion, animatorBool.Key, animatorBool.Value);
             }
         }
 
@@ -176,14 +176,14 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
             Explosion.transform.SetParent(initialExplosionParent);
             Explosion.transform.localPosition = initialExplosionLocalPosition;
             Explosion.transform.localRotation = initialExplosionLocalRotation;
-            Explosion.SetActive(initialExplosionActive);
+            SetActiveIfChanged(Explosion, initialExplosionActive);
         }
 
         feedback?.ResetFeedback();
 
         if (StunEffect != null)
         {
-            StunEffect.SetActive(false);
+            SetActiveIfChanged(StunEffect, false);
         }
 
         if (BossHealth != null)
@@ -200,6 +200,27 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         }
 
         spawnedOnDeath.Clear();
+    }
+
+    void SetScorpionBool(string param, bool value)
+    {
+        SetAnimatorBoolIfChanged(Scorpion, param, value);
+    }
+
+    static void SetActiveIfChanged(GameObject target, bool active)
+    {
+        if (target != null && target.activeSelf != active)
+        {
+            target.SetActive(active);
+        }
+    }
+
+    static void SetAnimatorBoolIfChanged(Animator animator, string param, bool value)
+    {
+        if (animator != null && animator.GetBool(param) != value)
+        {
+            animator.SetBool(param, value);
+        }
     }
 
     bool ValidateReferences()
@@ -377,9 +398,9 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
     private void Idle()
     {
         isAttacking = false;
-        Scorpion.SetBool("Walk", false);
-        Scorpion.SetBool("Backwards", false);
-        Scorpion.SetBool("Attack", false);
+        SetScorpionBool("Walk", false);
+        SetScorpionBool("Backwards", false);
+        SetScorpionBool("Attack", false);
         RBScorpion.velocity = new Vector3(0, RBScorpion.velocity.y, 0);
         rotGoal = transform.rotation;
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
@@ -392,15 +413,15 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
         if (transform.rotation != rotGoal)
         {
-            Scorpion.SetBool("Walk", true);
-            Scorpion.SetBool("Backwards", false);
-            Scorpion.SetBool("Attack", false);
+            SetScorpionBool("Walk", true);
+            SetScorpionBool("Backwards", false);
+            SetScorpionBool("Attack", false);
         }
         else
         {
-            Scorpion.SetBool("Walk", false);
-            Scorpion.SetBool("Backwards", false);
-            Scorpion.SetBool("Attack", false);
+            SetScorpionBool("Walk", false);
+            SetScorpionBool("Backwards", false);
+            SetScorpionBool("Attack", false);
         }
     }
     public void Charge(float speed)
@@ -410,17 +431,17 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
         RBScorpion.velocity = new Vector3(Distance.x, 0, Distance.z).normalized * speed + new Vector3(0, RBScorpion.velocity.y, 0);
 
-        Scorpion.SetBool("Walk", true);
-        Scorpion.SetBool("Backwards", false);
-        Scorpion.SetBool("Attack", false);
+        SetScorpionBool("Walk", true);
+        SetScorpionBool("Backwards", false);
+        SetScorpionBool("Attack", false);
     }
     private void StopAndAttack()
     {
         isAttacking = true;
         RBScorpion.velocity = new Vector3(0, RBScorpion.velocity.y, 0);
-        Scorpion.SetBool("Walk", false);
-        Scorpion.SetBool("Backwards", false);
-        Scorpion.SetBool("Attack", true);
+        SetScorpionBool("Walk", false);
+        SetScorpionBool("Backwards", false);
+        SetScorpionBool("Attack", true);
         rotGoal = SafeRotation.PlanarLookRotationOrCurrent(Distance, transform.rotation);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
     }
@@ -430,9 +451,9 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         rotGoal = SafeRotation.PlanarLookRotationOrCurrent(Distance, transform.rotation);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
         RBScorpion.velocity = new Vector3(-Distance.x, 0, -Distance.z).normalized * 5 + new Vector3(0, RBScorpion.velocity.y, 0);
-        Scorpion.SetBool("Walk", false);
-        Scorpion.SetBool("Backwards", true);
-        Scorpion.SetBool("Attack", false);
+        SetScorpionBool("Walk", false);
+        SetScorpionBool("Backwards", true);
+        SetScorpionBool("Attack", false);
     }
 
     public void TakeDamage(int Damage) => TakeDamage(new DamageEvent { Amount = Damage, Source = null, Point = transform.position, Type = DamageType.Generic, CanStun = false });
@@ -467,19 +488,19 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
     private void Stunned()
     {
         isAttacking = false;
-        Scorpion.SetBool("Backwards", false);
-        Scorpion.SetBool("Walk", false);
-        Scorpion.SetBool("Attack", false);
-        Scorpion.SetBool("Stunned", true);
-        StunEffect.SetActive(true);
+        SetScorpionBool("Backwards", false);
+        SetScorpionBool("Walk", false);
+        SetScorpionBool("Attack", false);
+        SetScorpionBool("Stunned", true);
+        SetActiveIfChanged(StunEffect, true);
     }
     private void Recovered()
     {
         isAttacking = false;
-        Scorpion.SetBool("Stunned", false);
+        SetScorpionBool("Stunned", false);
         combo = 0;
         StunnedClock = initialStun;
-        StunEffect.SetActive(false);
+        SetActiveIfChanged(StunEffect, false);
     }
     private void Death()
     {
@@ -493,7 +514,7 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         feedback?.EmitDeath();
         if (Explosion != null)
         {
-            Explosion.SetActive(true);
+            SetActiveIfChanged(Explosion, true);
             Explosion.transform.parent = null;
         }
 

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -183,7 +183,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         {
             foreach (var animatorBool in initialAnimatorBools)
             {
-                SetAnimatorBoolIfChanged(animatorBool.Key, animatorBool.Value);
+                SetWaspBool(animatorBool.Key, animatorBool.Value);
             }
         }
 

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -183,7 +183,8 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         {
             foreach (var animatorBool in initialAnimatorBools)
             {
-                SetWaspBool(animatorBool.Key, animatorBool.Value);
+                // Restore cached bools through the guarded setter with the Wasp animator.
+                SetAnimatorBoolIfChanged(Wasp, animatorBool.Key, animatorBool.Value);
             }
         }
 

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -110,10 +110,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         SetState(WaspState.Patrol);
         RandoMovement();
         NPC.velocity = Vector3.forward;
-        if (BuzzSource != null)
-        {
-            BuzzSource.SetActive(true);
-        }
+        SetBuzzActive(true);
         CaptureRuntimeState();
     }
 
@@ -186,7 +183,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         {
             foreach (var animatorBool in initialAnimatorBools)
             {
-                Wasp.SetBool(animatorBool.Key, animatorBool.Value);
+                SetAnimatorBoolIfChanged(animatorBool.Key, animatorBool.Value);
             }
         }
 
@@ -197,10 +194,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
 
         feedback?.ResetFeedback();
 
-        if (BuzzSource != null)
-        {
-            BuzzSource.SetActive(true);
-        }
+        SetBuzzActive(true);
 
         for (int i = spawnedOnDeath.Count - 1; i >= 0; i--)
         {
@@ -211,6 +205,32 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         }
 
         spawnedOnDeath.Clear();
+    }
+
+    void SetBuzzActive(bool active)
+    {
+        SetActiveIfChanged(BuzzSource, active);
+    }
+
+    void SetWaspBool(string param, bool value)
+    {
+        SetAnimatorBoolIfChanged(Wasp, param, value);
+    }
+
+    static void SetActiveIfChanged(GameObject target, bool active)
+    {
+        if (target != null && target.activeSelf != active)
+        {
+            target.SetActive(active);
+        }
+    }
+
+    static void SetAnimatorBoolIfChanged(Animator animator, string param, bool value)
+    {
+        if (animator != null && animator.GetBool(param) != value)
+        {
+            animator.SetBool(param, value);
+        }
     }
 
     bool ValidateReferences()
@@ -303,7 +323,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
 
         if (PlayerDistance > 6)
         {
-            Wasp.SetBool("Beat", false);
+            SetWaspBool("Beat", false);
         }
     }
 
@@ -320,15 +340,8 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
                 RotateTowardVelocity();
                 if (refreshPatrolMovement)
                 {
-                    if (BuzzSource != null)
-                    {
-                        BuzzSource.SetActive(true);
-                    }
-
-                    if (Wasp != null)
-                    {
-                        Wasp.SetBool("Sting", false);
-                    }
+                    SetBuzzActive(true);
+                    SetWaspBool("Sting", false);
 
                     RandoMovement();
                     refreshPatrolMovement = false;
@@ -340,15 +353,8 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
                 break;
             case WaspState.Chase:
                 RotateTowardVelocity();
-                if (BuzzSource != null)
-                {
-                    BuzzSource.SetActive(true);
-                }
-
-                if (Wasp != null)
-                {
-                    Wasp.SetBool("Sting", true);
-                }
+                SetBuzzActive(true);
+                SetWaspBool("Sting", true);
 
                 if (NPC != null)
                 {
@@ -356,10 +362,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
                 }
                 break;
             case WaspState.ContactRecover:
-                if (Wasp != null)
-                {
-                    Wasp.SetBool("Sting", false);
-                }
+                SetWaspBool("Sting", false);
 
                 if (NPC != null)
                 {
@@ -468,7 +471,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         {
             if (Wasp != null)
             {
-                Wasp.SetBool("Beat", true);
+                SetWaspBool("Beat", true);
             }
 
             TakeDamage(15);
@@ -489,14 +492,8 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
     }
     public void TurnBack()
     {
-        if (BuzzSource != null)
-        {
-            BuzzSource.SetActive(true);
-        }
-        if (Wasp != null)
-        {
-            Wasp.SetBool("Sting", false);
-        }
+        SetBuzzActive(true);
+        SetWaspBool("Sting", false);
 
         if ((transform.position - SpawnPos).magnitude > LeashDistance)
         {
@@ -549,10 +546,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
    public void Stunned()
     {
         StopFloat();
-        if (BuzzSource != null)
-        {
-            BuzzSource.SetActive(false);
-        }
+        SetBuzzActive(false);
 
         floating = false;
         if (NPC != null)
@@ -561,24 +555,15 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
             NPC.useGravity = true;
         }
 
-        if (Wasp != null)
-        {
-            Wasp.SetBool("Stunned", true);
-            Wasp.SetBool("Sting", false);
-        }
+        SetWaspBool("Stunned", true);
+        SetWaspBool("Sting", false);
     }
 
     void Recovered()
     {
-        if (BuzzSource != null)
-        {
-            BuzzSource.SetActive(true);
-        }
+        SetBuzzActive(true);
         floating = false;
-        if (Wasp != null)
-        {
-            Wasp.SetBool("Stunned", false);
-        }
+        SetWaspBool("Stunned", false);
 
         Recovery = RecoverySeconds;
         if (NPC != null)
@@ -609,10 +594,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
             }
         }
 
-        if (Wasp != null)
-        {
-            Wasp.SetBool("Sting", false);
-        }
+        SetWaspBool("Sting", false);
 
         if (PlayerHealth.isParried == true)
         {
@@ -648,10 +630,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
 
     public void RandoMovement()
     {
-        if (BuzzSource != null)
-        {
-            BuzzSource.SetActive(true);
-        }
+        SetBuzzActive(true);
         if ((SpawnPos - transform.position).magnitude < LeashDistance)
         {
             Recovered();
@@ -673,10 +652,7 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
 
     public void TakeDamage(DamageEvent damageEvent)
     {
-        if (BuzzSource != null)
-        {
-            BuzzSource.SetActive(false);
-        }
+        SetBuzzActive(false);
 
         rotGoal = SafeRotation.LookRotationOrCurrent(Distance, transform.rotation);
         transform.rotation = rotGoal;
@@ -685,11 +661,8 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
             NPC.useGravity = true;
         }
 
-        if (Wasp != null)
-        {
-            Wasp.SetBool("Beat", true);
-            Wasp.SetBool("Sting", false);
-        }
+        SetWaspBool("Beat", true);
+        SetWaspBool("Sting", false);
 
         CurrentHealth -= Mathf.RoundToInt(damageEvent.Amount);
         if (damageEvent.Type == DamageType.Hazard)

--- a/Assets/Scripts/Objects/Hive/Static_Hive.cs
+++ b/Assets/Scripts/Objects/Hive/Static_Hive.cs
@@ -48,7 +48,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
         }
 
         CurrentHealth = MaxHealth;
-        Explosion.SetActive(false);
+        SetActiveIfChanged(Explosion, false);
         feedback?.ResetFeedback();
         CaptureRuntimeState();
     }
@@ -78,7 +78,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
 
         if (Hive != null)
         {
-            Hive.SetActive(initialHiveActive);
+            SetActiveIfChanged(Hive, initialHiveActive);
         }
 
         if (Explosion != null)
@@ -86,7 +86,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
             Explosion.transform.SetParent(initialExplosionParent);
             Explosion.transform.localPosition = initialExplosionLocalPosition;
             Explosion.transform.localRotation = initialExplosionLocalRotation;
-            Explosion.SetActive(initialExplosionActive);
+            SetActiveIfChanged(Explosion, initialExplosionActive);
         }
 
         feedback?.ResetFeedback();
@@ -105,6 +105,14 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
         }
 
         spawnedOnDeath.Clear();
+    }
+
+    static void SetActiveIfChanged(GameObject target, bool active)
+    {
+        if (target != null && target.activeSelf != active)
+        {
+            target.SetActive(active);
+        }
     }
 
     bool ValidateReferences()
@@ -127,14 +135,6 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
 
         return valid;
     }
-    private void LateUpdate()
-    {
-        if (CurrentHealth <= 0 && !deathResolved)
-        {
-            Death();
-        }
-    }
-
     public void Death()
     {
         if (isDead)
@@ -147,7 +147,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
         feedback?.EmitDeath();
         if (Explosion != null)
         {
-            Explosion.SetActive(true);
+            SetActiveIfChanged(Explosion, true);
             Explosion.transform.parent = null;
         }
 
@@ -172,7 +172,7 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
 
         if (Hive != null)
         {
-            Hive.SetActive(false);
+            SetActiveIfChanged(Hive, false);
         }
     }
 
@@ -197,6 +197,11 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
         if (HiveBar != null)
         {
             HiveBar.SetNPCHealth(CurrentHealth);
+        }
+
+        if (CurrentHealth <= 0 && !deathResolved)
+        {
+            Death();
         }
     }
 }

--- a/Assets/Scripts/Player/AnimatedAttack.cs
+++ b/Assets/Scripts/Player/AnimatedAttack.cs
@@ -13,9 +13,14 @@ public class AnimatedAttack : MonoBehaviour
     private void Start()
     {
         Player = GetComponentInParent<Behaviour>();
-        if (GlowEffect != null)
+        SetActiveIfChanged(GlowEffect, false);
+    }
+
+    static void SetActiveIfChanged(GameObject target, bool active)
+    {
+        if (target != null && target.activeSelf != active)
         {
-            GlowEffect.SetActive(false);
+            target.SetActive(active);
         }
     }
 
@@ -165,17 +170,11 @@ public class AnimatedAttack : MonoBehaviour
 
     public void TurnOnGlow()
     {
-        if (GlowEffect != null)
-        {
-            GlowEffect.SetActive(true);
-        }
+        SetActiveIfChanged(GlowEffect, true);
     }
 
     public void TurnOffGlow()
     {
-        if (GlowEffect != null)
-        {
-            GlowEffect.SetActive(false);
-        }
+        SetActiveIfChanged(GlowEffect, false);
     }
 }

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -908,7 +908,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     }
     public void GobletON()
     {
-        gobletOBJ.SetActive(true);
+        SetActiveIfChanged(gobletOBJ, true);
         GobletPicked = true;
         AnimSpeed = 3;
         Walk = 7;
@@ -1276,7 +1276,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         Combat.Initialize(this);
         Movement.Initialize(this);
         Failure.Initialize(this);
-        arrowModel.SetActive(false);
+        SetActiveIfChanged(arrowModel, false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
         TrySetTraderCameraEnabled(false);
         if (PopUpEffect != null && Root != null)
@@ -1285,7 +1285,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
         HideCursor();
         SaveCheckpoint(transform.position);
-        AimIcon.SetActive(false);
+        SetActiveIfChanged(AimIcon, false);
         MunitionDisplay.SetActive(false);
         //Enable/Disable Background music
         if (seekMusic == true)
@@ -1335,8 +1335,8 @@ public class Behaviour : MonoBehaviour, IDamageable
         InsertRun = Run;
         HideLosePanel();
         HologramedBridge.SetActive(false);
-        appleOBJ.SetActive(false);
-        gobletOBJ.SetActive(false);
+        SetActiveIfChanged(appleOBJ, false);
+        SetActiveIfChanged(gobletOBJ, false);
         for (int i = 0; i < ArmorSet.Length; i++)
         {
             ArmorSet[i].SetActive(false);
@@ -1640,7 +1640,7 @@ public class Behaviour : MonoBehaviour, IDamageable
             }
             if (Input.GetKeyUp(KeyCode.T))
             {
-                appleOBJ.SetActive(false);
+                SetActiveIfChanged(appleOBJ, false);
             }
         }
         //Use Goblet
@@ -1661,7 +1661,7 @@ public class Behaviour : MonoBehaviour, IDamageable
 
             if (Input.GetKeyUp(KeyCode.Y))
             {
-                gobletOBJ.SetActive(false);
+                SetActiveIfChanged(gobletOBJ, false);
             }
         }
 
@@ -1790,6 +1790,14 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
     }
 
+    static void SetActiveIfChanged(GameObject target, bool active)
+    {
+        if (target != null && target.activeSelf != active)
+        {
+            target.SetActive(active);
+        }
+    }
+
     [Obsolete]
     public void LateUpdate()
     {
@@ -1851,8 +1859,8 @@ public class Behaviour : MonoBehaviour, IDamageable
                 && !Input.GetKey(KeyCode.LeftControl)
                 && bowEquipped == false && grounded == true)
             {
-                Stone.SetActive(true);
-                AimIcon.SetActive(true);
+                SetActiveIfChanged(Stone, true);
+                SetActiveIfChanged(AimIcon, true);
                 PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Aim, true);
                 Otter.Play("Aim");
                 if (Input.GetKeyDown(KeyCode.Mouse1))
@@ -1878,8 +1886,8 @@ public class Behaviour : MonoBehaviour, IDamageable
             }
             if (!Input.GetKey(KeyCode.Mouse1))
             {
-                Stone.SetActive(false);
-                AimIcon.SetActive(false);
+                SetActiveIfChanged(Stone, false);
+                SetActiveIfChanged(AimIcon, false);
             }
         }
         //Bow action       
@@ -1897,10 +1905,10 @@ public class Behaviour : MonoBehaviour, IDamageable
                     CountArrows();
                     Sound.ArrowDraw();
                     arrowReady = true;
-                    AimIcon.SetActive(true);
+                    SetActiveIfChanged(AimIcon, true);
                     keepLooking = true;
-                    arrowModel.SetActive(true);
-                    bowString.SetActive(false);
+                    SetActiveIfChanged(arrowModel, true);
+                    SetActiveIfChanged(bowString, false);
                     PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Draw, true);
                     stringLine.enabled = true;
                     stringLine.useWorldSpace = false;
@@ -1935,9 +1943,9 @@ public class Behaviour : MonoBehaviour, IDamageable
                 {
                     HealthBar.SetStamina(CurrentStamina);
                 }
-                arrowModel.SetActive(false);
+                SetActiveIfChanged(arrowModel, false);
                 stringLine.enabled = false;
-                bowString.SetActive(true);
+                SetActiveIfChanged(bowString, true);
                 PlayerAnimatorParameters.TrySetBool(Otter, PlayerAnimatorParameters.Draw, false);
                 arrowReady = false;
             }

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class Projectile : MonoBehaviour
@@ -15,9 +14,11 @@ public class Projectile : MonoBehaviour
     [SerializeField] GameObject Explosion;
     [SerializeField] int Damage;
     [SerializeField] GameObject arrowPickup;
+    bool isDisposed;
     // Start is called before the first frame update
     void Start()
     {
+        StartCoroutine(ExpireAfterLifetime());
         var mainCamera = Camera.main;
         PlayerReference.TryGetPlayer(out Player);
 
@@ -54,37 +55,44 @@ public class Projectile : MonoBehaviour
 
         return valid;
     }
-    private void Update()
-    {
-        clock -= Time.deltaTime;
-        if (clock<=0)
-        {
-            Destroy(gameObject);
-            if (isArrow==true && arrowPickup != null)
-            {
-                Instantiate(arrowPickup, transform.position, Quaternion.identity);
-            }
-        }
-        
-    }
 
+    IEnumerator ExpireAfterLifetime()
+    {
+        yield return new WaitForSeconds(clock);
+        Dispose(spawnArrowPickup: isArrow, explode: false);
+    }
 
     public void Explode()
     {
-        if (Explosion == null)
+        Dispose(spawnArrowPickup: false, explode: true);
+    }
+
+    void Dispose(bool spawnArrowPickup, bool explode)
+    {
+        if (isDisposed)
         {
-            Destroy(transform.gameObject);
             return;
         }
 
-        var explode = Instantiate(Explosion, transform.position, transform.rotation);
-        explode.transform.localScale += new Vector3(1, 1, 1);
-        Destroy(transform.gameObject);
+        isDisposed = true;
+
+        if (explode && Explosion != null)
+        {
+            var explodeInstance = Instantiate(Explosion, transform.position, transform.rotation);
+            explodeInstance.transform.localScale += new Vector3(1, 1, 1);
+        }
+
+        if (spawnArrowPickup && arrowPickup != null)
+        {
+            Instantiate(arrowPickup, transform.position, Quaternion.identity);
+        }
+
+        Destroy(gameObject);
     }
 
     public void RockHit()
     {
-        if (Sound == null)
+        if (Sound == null || isDisposed)
         {
             return;
         }
@@ -95,7 +103,7 @@ public class Projectile : MonoBehaviour
     }
     private void OnCollisionEnter(Collision OBJ)
     {
-        if (OBJ == null || OBJ.gameObject == null)
+        if (isDisposed || OBJ == null || OBJ.gameObject == null)
         {
             return;
         }

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -19,15 +19,46 @@ public sealed class DebugReference : MonoBehaviour
 
     HudPresenter presenter;
 
+    private void Awake()
+    {
+        ApplyReferences();
+    }
+
     private void Start()
+    {
+        ApplyReferences();
+        enabled = presenter == null;
+    }
+
+    private void Update()
+    {
+        if (presenter == null)
+        {
+            ApplyReferences();
+        }
+
+        enabled = false;
+    }
+
+    private void OnValidate()
+    {
+        ApplyReferences();
+    }
+
+    void ApplyReferences()
     {
         presenter = GetComponent<HudPresenter>();
         if (presenter == null)
         {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
             presenter = gameObject.AddComponent<HudPresenter>();
         }
 
-        presenter.Bind(Player, PlayerObjective, CheckpointService.GetOrCreate());
+        presenter.Bind(Player, PlayerObjective, Application.isPlaying ? CheckpointService.GetOrCreate() : null);
         presenter.ObjectiveText = ObjectiveText;
         presenter.DisplayText = DisplayText;
         presenter.StaminaText = StaminaText;
@@ -38,13 +69,5 @@ public sealed class DebugReference : MonoBehaviour
         presenter.GobletCount = GobletCount;
         presenter.AppleCount = AppleCount;
         presenter.ArrowMunition = ArrowMunition;
-    }
-
-    private void Update()
-    {
-        if (presenter != null)
-        {
-            presenter.RenderNow();
-        }
     }
 }

--- a/Assets/Scripts/UI/HudPresenter.cs
+++ b/Assets/Scripts/UI/HudPresenter.cs
@@ -19,6 +19,16 @@ public sealed class HudPresenter : MonoBehaviour
     public TextMeshProUGUI ArrowMunition;
 
     CheckpointService checkpointService;
+    string lastObjectiveText;
+    string lastDisplayText;
+    string lastStaminaText;
+    string lastLogCountText;
+    string lastHealingDisplay;
+    string lastCurrencyCount;
+    string lastSeedCount;
+    string lastGobletCount;
+    string lastAppleCount;
+    string lastArrowMunition;
 
     private void Start()
     {
@@ -38,16 +48,16 @@ public sealed class HudPresenter : MonoBehaviour
         }
 
         var state = Player.State;
-        SetText(ObjectiveText, BuildObjectiveText());
-        SetText(DisplayText, BuildHealthText(state));
-        SetText(StaminaText, BuildStaminaText(state));
-        SetText(LogCountText, BuildLogCountText(state));
-        SetText(CurrencyCount, BuildCurrencyText(state));
-        SetText(HealingDisplay, BuildStatusText(state));
-        SetText(SeedCount, BuildSeedText(state));
-        SetText(GobletCount, BuildGobletText(state));
-        SetText(AppleCount, BuildAppleText(state));
-        SetText(ArrowMunition, BuildArrowText(state));
+        SetTextIfChanged(ObjectiveText, BuildObjectiveText(), ref lastObjectiveText);
+        SetTextIfChanged(DisplayText, BuildHealthText(state), ref lastDisplayText);
+        SetTextIfChanged(StaminaText, BuildStaminaText(state), ref lastStaminaText);
+        SetTextIfChanged(LogCountText, BuildLogCountText(state), ref lastLogCountText);
+        SetTextIfChanged(CurrencyCount, BuildCurrencyText(state), ref lastCurrencyCount);
+        SetTextIfChanged(HealingDisplay, BuildStatusText(state), ref lastHealingDisplay);
+        SetTextIfChanged(SeedCount, BuildSeedText(state), ref lastSeedCount);
+        SetTextIfChanged(GobletCount, BuildGobletText(state), ref lastGobletCount);
+        SetTextIfChanged(AppleCount, BuildAppleText(state), ref lastAppleCount);
+        SetTextIfChanged(ArrowMunition, BuildArrowText(state), ref lastArrowMunition);
     }
 
     public void Bind(Behaviour player, ObjectiveUI objective, CheckpointService checkpoints)
@@ -178,11 +188,14 @@ public sealed class HudPresenter : MonoBehaviour
         return Math.Round((current / max) * 100f, 1) + "%";
     }
 
-    static void SetText(TextMeshProUGUI text, string value)
+    static void SetTextIfChanged(TextMeshProUGUI text, string value, ref string lastValue)
     {
-        if (text != null)
+        if (text == null || lastValue == value)
         {
-            text.text = value;
+            return;
         }
+
+        text.text = value;
+        lastValue = value;
     }
 }

--- a/Assets/Scripts/UI/MusicPlaylist.cs
+++ b/Assets/Scripts/UI/MusicPlaylist.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class MusicPlaylist : MonoBehaviour
@@ -22,7 +21,7 @@ public class MusicPlaylist : MonoBehaviour
             BuildSafeLogger.ErrorOnce("MusicPlaylist.MissingAudioSource", "No AudioSource component found on the GameObject.", this, missingField: nameof(MusicSource));
             return;
         }
-        if (MusicClip.Length == 0)
+        if (MusicClip == null || MusicClip.Length == 0)
         {
             BuildSafeLogger.ErrorOnce("MusicPlaylist.NoMusicClips", "No music clips assigned in the MusicClip array.", this, missingField: nameof(MusicClip));
             return;
@@ -32,6 +31,11 @@ public class MusicPlaylist : MonoBehaviour
 
     private void StartPlaylist()
     {
+        if (MusicSource == null || MusicClip == null || MusicClip.Length == 0)
+        {
+            return;
+        }
+
         if (playlistCoroutine != null)
         {
             StopCoroutine(playlistCoroutine);
@@ -41,44 +45,64 @@ public class MusicPlaylist : MonoBehaviour
 
     IEnumerator Playlist()
     {
-        while (true)
+        while (MusicSource != null && MusicClip != null && MusicClip.Length > 0)
         {
-            if (currentSong != previousSong)
+            if (currentSong < 0 || currentSong >= MusicClip.Length)
             {
-                PlayCurrentSong();
-                previousSong = currentSong;
+                yield break;
             }
 
-            // Check if the current clip has finished playing
-            if (!MusicSource.isPlaying)
+            AudioClip clip = MusicClip[currentSong];
+            if (clip == null)
             {
-                // Replay the current song
+                BuildSafeLogger.WarnOnce("MusicPlaylist.NullClip." + currentSong, "Null music clip at index: " + currentSong, this);
+                yield break;
+            }
+
+            if (currentSong != previousSong || MusicSource.clip != clip)
+            {
+                PlayCurrentSong(clip);
+                previousSong = currentSong;
+            }
+            else if (!MusicSource.isPlaying)
+            {
                 MusicSource.Play();
             }
 
-            yield return null; // Wait until the next frame to recheck
+            yield return new WaitForSeconds(Mathf.Max(0.05f, clip.length - MusicSource.time));
         }
     }
 
-    private void PlayCurrentSong()
+    private void PlayCurrentSong(AudioClip clip)
     {
-        MusicSource.clip = MusicClip[currentSong];
+        if (MusicSource == null || clip == null)
+        {
+            return;
+        }
+
+        MusicSource.clip = clip;
         MusicSource.Play();
     }
 
     public void StopMusic()
     {
-        MusicSource.Pause();
+        if (MusicSource != null)
+        {
+            MusicSource.Pause();
+        }
     }
 
     public void ResumeMusic()
     {
-        MusicSource.Play();
+        if (MusicSource != null)
+        {
+            MusicSource.Play();
+        }
     }
 
     public void ChangeSong(int newSongIndex)
     {
-        if (newSongIndex >= 0 && newSongIndex < MusicClip.Length)
+        if (MusicClip != null && newSongIndex >= 0 && newSongIndex < MusicClip.Length)
         {
             currentSong = newSongIndex;
             StartPlaylist();


### PR DESCRIPTION
### Motivation
- Reduce redundant per-frame work across UI, audio playlist, NPCs and projectiles while preserving gameplay timing and state transitions.
- Avoid repeated expensive assignments and duplicate SetActive/SetBool calls that spike CPU usage without changing gameplay logic.

### Description
- Cache last-rendered HUD strings and only assign `TextMeshProUGUI.text` when the value changes via `SetTextIfChanged` in `HudPresenter.cs`.
- Move `DebugReference.ApplyReferences()` out of continuous `Update()` into `Awake`/`Start`/`OnValidate` with a one-shot runtime fallback that disables the component once synced in `DebugReference.cs`.
- Replace playlist frame-polling loop with clip-duration waits and null/index guards in `MusicPlaylist.cs`, preserving `ChangeSong(int)` behavior.
- Add local guard helpers (`SetActiveIfChanged`, `SetAnimatorBoolIfChanged`) and small wrapper setters for repeated calls in `NPC_Basic.cs` and `ScorpionScript.cs` to skip duplicate `SetActive`/`SetBool` invocations without reordering state/physics logic.
- Convert projectile lifetime per-frame decrement to a guarded lifetime coroutine plus a single `Dispose` path and `isDisposed` guard in `Projectile.cs` to prevent double-spawn of pickups/explosions on collision and expiry.
- Replace direct per-frame UI/effect toggles with `SetActiveIfChanged` in `AnimatedAttack.cs` and `Behaviour.cs` to avoid redundant `SetActive` calls.
- Remove `Static_Hive` `LateUpdate` polling and invoke `Death()` directly from `TakeDamage()` with guarded activation helpers.

### Testing
- Ran `git diff --check` and fixed no issues (succeeded).
- Searched for `void Update|void FixedUpdate|void LateUpdate` across target files to verify reduced per-frame work (succeeded).
- Verified brace/balance and basic compile-safety heuristics via local scans (no unbalanced braces found; succeeded).
- Noted that `dotnet --info` and Unity editor runs are not available in CI/container, so runtime Unity validation must be performed in-editor (warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00fde44a9c832aac387d09154af337)