### PR TITLE
Guard repeated combat and pickup effects

### DIFF
--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -235,10 +235,11 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
             RuntimeReferenceValidator.Require(Jaw2B, this, nameof(Jaw2B)) &
             RuntimeReferenceValidator.Require(Sting, this, nameof(Sting)) &
             RuntimeReferenceValidator.Require(feedback, this, nameof(feedback)) &
-            RuntimeReferenceValidator.Require(HitEffect, this, nameof(HitEffect)) &
             RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion)) &
-            RuntimeReferenceValidator.Require(StunEffect, this, nameof(StunEffect)) &
             RuntimeReferenceValidator.Require(Sound, this, nameof(Sound));
+
+        RuntimeReferenceValidator.Optional(HitEffect, this, nameof(HitEffect));
+        RuntimeReferenceValidator.Optional(StunEffect, this, nameof(StunEffect));
 
         if (drops != null)
         {
@@ -460,6 +461,11 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
 
     public void TakeDamage(DamageEvent damageEvent)
     {
+        if (isDead)
+        {
+            return;
+        }
+
         transform.rotation = rotGoal;
         if (damageEvent.Type == DamageType.Hazard)
         {
@@ -483,6 +489,11 @@ public class ScorpionScript : MonoBehaviour, IDamageable, IRuntimeResettable
         if (BossHealth != null)
         {
             BossHealth.SetNPCHealth(CurrentHealth);
+        }
+
+        if (CurrentHealth <= 0)
+        {
+            SetState(EnemyState.Dead);
         }
     }
     private void Stunned()

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -242,8 +242,6 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
             RuntimeReferenceValidator.Require(PlayerHealth, this, nameof(PlayerHealth)) &
             RuntimeReferenceValidator.Require(NPCHealthBar, this, nameof(NPCHealthBar)) &
             RuntimeReferenceValidator.Require(feedback, this, nameof(feedback)) &
-            RuntimeReferenceValidator.Require(HitEffect, this, nameof(HitEffect)) &
-            RuntimeReferenceValidator.Require(SlashEffect, this, nameof(SlashEffect)) &
             RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion)) &
             RuntimeReferenceValidator.Require(Sound, this, nameof(Sound)) &
             RuntimeReferenceValidator.Require(BuzzSource, this, nameof(BuzzSource)) &
@@ -252,6 +250,9 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
             RuntimeReferenceValidator.Require(Wing, this, nameof(Wing)) &
             RuntimeReferenceValidator.Require(Leg, this, nameof(Leg)) &
             RuntimeReferenceValidator.Require(Reward, this, nameof(Reward));
+
+        RuntimeReferenceValidator.Optional(HitEffect, this, nameof(HitEffect));
+        RuntimeReferenceValidator.Optional(SlashEffect, this, nameof(SlashEffect));
 
         return valid;
     }
@@ -653,6 +654,11 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
 
     public void TakeDamage(DamageEvent damageEvent)
     {
+        if (isDead)
+        {
+            return;
+        }
+
         SetBuzzActive(false);
 
         rotGoal = SafeRotation.LookRotationOrCurrent(Distance, transform.rotation);
@@ -717,6 +723,11 @@ public class NPC_Basic : MonoBehaviour, IDamageable, IRuntimeResettable
         if (NPCHealthBar != null)
         {
             NPCHealthBar.SetNPCHealth(CurrentHealth);
+        }
+
+        if (CurrentHealth <= 0)
+        {
+            SetState(WaspState.Dead);
         }
     }
 

--- a/Assets/Scripts/Objects/Hive/Static_Hive.cs
+++ b/Assets/Scripts/Objects/Hive/Static_Hive.cs
@@ -122,8 +122,9 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
             RuntimeReferenceValidator.Require(Wasp, this, nameof(Wasp)) &
             RuntimeReferenceValidator.Require(Explosion, this, nameof(Explosion)) &
             RuntimeReferenceValidator.Require(feedback, this, nameof(feedback)) &
-            RuntimeReferenceValidator.Require(Sound, this, nameof(Sound)) &
-            RuntimeReferenceValidator.Require(HitEffect, this, nameof(HitEffect));
+            RuntimeReferenceValidator.Require(Sound, this, nameof(Sound));
+
+        RuntimeReferenceValidator.Optional(HitEffect, this, nameof(HitEffect));
 
         if (SpawnedObjects != null)
         {
@@ -180,6 +181,11 @@ public class Static_Hive : MonoBehaviour, IDamageable, IRuntimeResettable
 
     public void TakeDamage(DamageEvent damageEvent)
     {
+        if (deathResolved)
+        {
+            return;
+        }
+
         if (damageEvent.Type == DamageType.Hazard)
         {
             feedback?.EmitHazard();

--- a/Assets/Scripts/Player/AnimatedAttack.cs
+++ b/Assets/Scripts/Player/AnimatedAttack.cs
@@ -32,10 +32,16 @@ public class AnimatedAttack : MonoBehaviour
         }
 
         Collider[] hitEnemies = Physics.OverlapSphere(origin, range, enemyLayers);
+        var damaged = new HashSet<IDamageable>();
         foreach (Collider enemy in hitEnemies)
         {
             if (enemy.TryGetComponent(out IDamageable damageable))
             {
+                if (!damaged.Add(damageable))
+                {
+                    continue;
+                }
+
                 damageable.TakeDamage(new DamageEvent
                 {
                     Amount = Damage,

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -147,6 +147,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     [SerializeField] Light HurtLight;
     [SerializeField] GameObject PopUpEffect;
     [SerializeField] GameObject PickUpEffect;
+    readonly HashSet<int> handledPickups = new HashSet<int>();
     [SerializeField] GameObject KickWind;
     [SerializeField] GameObject SwordCopter;
     [SerializeField] GameObject SwordPlainTrail;
@@ -308,19 +309,55 @@ public class Behaviour : MonoBehaviour, IDamageable
     public void ToggleParryCounterAttack() => WhichAttack = !WhichAttack;
     public void SetAppleModelActive(bool active) => appleOBJ.SetActive(active);
 
+    bool TryBeginPickup(GameObject pickup)
+    {
+        return pickup != null && handledPickups.Add(pickup.GetInstanceID());
+    }
+
+    void SpawnPickupEffect(Vector3 position)
+    {
+        SpawnOptionalEffect(PickUpEffect, position, Quaternion.identity, null, nameof(PickUpEffect));
+    }
+
+    GameObject SpawnOptionalEffect(GameObject prefab, Vector3 position, Quaternion rotation, Transform parent, string fieldName)
+    {
+        if (!RuntimeReferenceValidator.Optional(prefab, this, fieldName))
+        {
+            return null;
+        }
+
+        var instance = Instantiate(prefab, position, rotation);
+        if (parent != null)
+        {
+            instance.transform.parent = parent;
+        }
+
+        return instance;
+    }
+
     public void OnCollisionEnter(Collision OBJ)
     {
         if (OBJ.gameObject.CompareTag("Part")&& Load.CanCarry == true && grounded==true && !Input.GetKey(KeyCode.Mouse0)&& !Input.GetKey(KeyCode.Mouse1))
         {
+            if (!TryBeginPickup(OBJ.gameObject))
+            {
+                return;
+            }
+
             Otter.Play("Crouch");
             Sound.PickItem();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+            SpawnPickupEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
             Destroy(OBJ.gameObject);
         }
         if ( OBJ.gameObject.CompareTag("Seed") || OBJ.gameObject.CompareTag("Apple") || OBJ.gameObject.CompareTag("GobletKey"))
         {
+            if (!TryBeginPickup(OBJ.gameObject))
+            {
+                return;
+            }
+
             Otter.Play("Crouch");
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+            SpawnPickupEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
             Destroy(OBJ.gameObject);
 
             if (OBJ.gameObject.CompareTag("Seed"))
@@ -337,8 +374,6 @@ public class Behaviour : MonoBehaviour, IDamageable
             {
                 Sound.PickUp2();
                 Inventory.AddGoblet();
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-                Destroy(OBJ.gameObject);
             }
 
         }
@@ -356,17 +391,27 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
         if (OBJ.gameObject.CompareTag("Coin"))
         {
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+            if (!TryBeginPickup(OBJ.gameObject))
+            {
+                return;
+            }
+
+            SpawnPickupEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
             Sound.Coin();
         }
         if (arrowMunition<Arrows.Length && bowEquipped==true)
         {
             if (OBJ.gameObject.CompareTag("Arrow"))
             {
+                if (!TryBeginPickup(OBJ.gameObject))
+                {
+                    return;
+                }
+
                 Otter.Play("Crouch");
                 Sound.PickUp2();
                 arrowMunition++;
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                SpawnPickupEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                 if (bowEquipped == true)
                 {
                     CountArrows();
@@ -375,9 +420,14 @@ public class Behaviour : MonoBehaviour, IDamageable
             }
             if (OBJ.gameObject.CompareTag("ArrowBundle"))
             {
+                if (!TryBeginPickup(OBJ.gameObject))
+                {
+                    return;
+                }
+
                 Otter.Play("Crouch");
                 Sound.PickUp2();
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                SpawnPickupEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                 if (arrowMunition + 10 < Arrows.Length)
                 {
                     arrowMunition += 10;
@@ -413,17 +463,27 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
         if (OBJ.gameObject.CompareTag("Weapon"))
         {
+            if (!TryBeginPickup(OBJ.gameObject))
+            {
+                return;
+            }
+
             Plattering = ("Hammers!");
             ChangeSpeech = 1;
             Otter.Play("Crouch");
             Arsenal.Add("Hammers");
             ArsenalCounter++;
             Sound.PickItem();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+            SpawnPickupEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
             Destroy(OBJ.gameObject);
         }
         if (OBJ.gameObject.CompareTag("Bow"))
         {
+            if (!TryBeginPickup(OBJ.gameObject))
+            {
+                return;
+            }
+
             Plattering = ("Booya!");
             ChangeSpeech = 1;
             Otter.Play("Crouch");
@@ -432,30 +492,45 @@ public class Behaviour : MonoBehaviour, IDamageable
             Sound.PickItem();
             arrowMunition = 5;
             CountArrows();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+            SpawnPickupEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
             Destroy(OBJ.gameObject);
         }
         if (OBJ.gameObject.CompareTag("Armor"))
         {
+            if (!TryBeginPickup(OBJ.gameObject))
+            {
+                return;
+            }
+
             Plattering = ("Oh my!");
             ChangeSpeech = 1;
             Otter.Play("Crouch");
             Arsenal.Add("ArmorSet");
             ArsenalCounter++;
             Sound.PickItem();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+            SpawnPickupEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
             Destroy(OBJ.gameObject);
         }
         if (OBJ.gameObject.CompareTag("Honey") && Honeypicked == false)
         {
+            if (!TryBeginPickup(OBJ.gameObject))
+            {
+                return;
+            }
+
             Otter.Play("Crouch");
             HoneyON();
             Sound.PickItem();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+            SpawnPickupEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
             Destroy(OBJ.gameObject);
         }
         if (OBJ.gameObject.CompareTag("Gold") && GoldPicked == false)
         {
+            if (!TryBeginPickup(OBJ.gameObject))
+            {
+                return;
+            }
+
             Otter.Play("Crouch");
             GoldON();
             Destroy(OBJ.gameObject);
@@ -1087,15 +1162,22 @@ public class Behaviour : MonoBehaviour, IDamageable
             RuntimeReferenceValidator.Require(HealthBar, this, nameof(HealthBar)) &
             RuntimeReferenceValidator.Require(HoneyJar, this, nameof(HoneyJar)) &
             RuntimeReferenceValidator.Require(GoldBrick, this, nameof(GoldBrick)) &
-            RuntimeReferenceValidator.Require(PopUpEffect, this, nameof(PopUpEffect)) &
-            RuntimeReferenceValidator.Require(HealEffect, this, nameof(HealEffect)) &
+            RuntimeReferenceValidator.Require(PopUpEffect, this, nameof(PopUpEffect));
+
+        RuntimeReferenceValidator.Optional(PickUpEffect, this, nameof(PickUpEffect));
+        RuntimeReferenceValidator.Optional(KickWind, this, nameof(KickWind));
+        RuntimeReferenceValidator.Optional(SwordCopter, this, nameof(SwordCopter));
+        RuntimeReferenceValidator.Optional(BoxWind, this, nameof(BoxWind));
+
+        valid &= RuntimeReferenceValidator.Require(HealEffect, this, nameof(HealEffect)) &
             RuntimeReferenceValidator.Require(ElectricEffect, this, nameof(ElectricEffect)) &
             RuntimeReferenceValidator.Require(MunitionDisplay, this, nameof(MunitionDisplay)) &
             RuntimeReferenceValidator.Require(LooseScreen, this, nameof(LooseScreen)) &
             RuntimeReferenceValidator.Require(AimIcon, this, nameof(AimIcon)) &
             RuntimeReferenceValidator.Require(HologramedBridge, this, nameof(HologramedBridge)) &
             RuntimeReferenceValidator.Require(appleOBJ, this, nameof(appleOBJ)) &
-            RuntimeReferenceValidator.Require(gobletOBJ, this, nameof(gobletOBJ));
+            RuntimeReferenceValidator.Require(gobletOBJ, this, nameof(gobletOBJ)) &
+            RuntimeReferenceValidator.Require(KickEffectPos, this, nameof(KickEffectPos));
 
         if (ArmorSet != null)
         {
@@ -1709,13 +1791,11 @@ public class Behaviour : MonoBehaviour, IDamageable
                     {
                         if (Otter.GetCurrentAnimatorStateInfo(0).IsName("Air Kick"))
                         {
-                            var WindTrail = Instantiate(KickWind, KickEffectPos.position, Quaternion.Euler(-90, UnityEngine.Random.Range(0f, 360f), 0));
-                            WindTrail.transform.parent = KickEffectPos;
+                            SpawnOptionalEffect(KickWind, KickEffectPos.position, Quaternion.Euler(-90, UnityEngine.Random.Range(0f, 360f), 0), KickEffectPos, nameof(KickWind));
                         }
                         if (Otter.GetCurrentAnimatorStateInfo(0).IsName("HuricaneSword"))
                         {
-                            var SwordTrail = Instantiate(SwordCopter, KickEffectPos.position +new Vector3(0,0.5f,0), Quaternion.Euler(-90, UnityEngine.Random.Range(0f, 360f), 0));
-                            SwordTrail.transform.parent = KickEffectPos;
+                            SpawnOptionalEffect(SwordCopter, KickEffectPos.position +new Vector3(0,0.5f,0), Quaternion.Euler(-90, UnityEngine.Random.Range(0f, 360f), 0), KickEffectPos, nameof(SwordCopter));
                         }                        
                         if (Otter.speed > 0.4)
                         {
@@ -1753,16 +1833,14 @@ public class Behaviour : MonoBehaviour, IDamageable
                         {
                             if (Root.childCount == 0)
                             {
-                                var RightWind = Instantiate(BoxWind, Root.position - new Vector3(0, 0.3f, 0), rotGoal * Quaternion.Euler(-90, 90, 0));
-                                RightWind.transform.parent = Root;
+                                SpawnOptionalEffect(BoxWind, Root.position - new Vector3(0, 0.3f, 0), rotGoal * Quaternion.Euler(-90, 90, 0), Root, nameof(BoxWind));
                             }
                         }
                         if (Otter.GetCurrentAnimatorStateInfo(1).IsName("AttackB"))
                         {
                             if (Root.childCount == 0)
                             {
-                                var LeftWind = Instantiate(BoxWind, Root.position - new Vector3(0, 0.3f, 0), rotGoal * Quaternion.Euler(90, 90, 0));
-                                LeftWind.transform.parent = Root;
+                                SpawnOptionalEffect(BoxWind, Root.position - new Vector3(0, 0.3f, 0), rotGoal * Quaternion.Euler(90, 90, 0), Root, nameof(BoxWind));
                             }
                         }
                     }

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -18,14 +18,16 @@ public class Projectile : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        StartCoroutine(ExpireAfterLifetime());
         var mainCamera = Camera.main;
         PlayerReference.TryGetPlayer(out Player);
 
         if (!ValidateReferences(mainCamera))
         {
+            isDisposed = true;
             return;
         }
+
+        StartCoroutine(ExpireAfterLifetime());
 
         Vector3 launchDirection = mainCamera.transform.TransformDirection(Vector3.forward);
         Physics.IgnoreLayerCollision(1, 3);


### PR DESCRIPTION
### Motivation

- Prevent duplicate visual/audio effects and repeated death/drop spawning when multiple damage/pickup events hit the same object while preserving existing visuals and prefabs.
- Normalize optional VFX handling so missing non-critical effects warn once in dev builds without disabling behaviors.

### Description

- Add one-shot pickup guard by introducing `handledPickups` and `TryBeginPickup(GameObject)` and replace inline pickup effect `Instantiate` with `SpawnPickupEffect`/`SpawnOptionalEffect` in `Behaviour.cs` to avoid duplicated pickup VFX and to treat pickup VFX as optional.
- Ensure `Projectile` does not start its expiry coroutine until required references validate and mark invalid projectiles `isDisposed = true` to avoid race between timeout pickup spawn and collision explosion in `Projectile.cs`.
- Prevent post-death re-entry by short-circuiting damage handlers with guards and/or `deathResolved` flags and invoke death state on health <= 0 in `NPC_Basic.cs`, `ScorpionScript.cs`, and `Static_Hive.cs` so death effects/drops run once.
- Make non-critical visual references optional with `RuntimeReferenceValidator.Optional(...)` for hit/stun/pickup/wind-trail assets and add `SpawnOptionalEffect` helper to centralize optional-instantiation behavior in `Behaviour.cs`.
- Deduplicate melee overlap damage per AoE pass by tracking damaged targets with a `HashSet<IDamageable>` in `AnimatedAttack.cs` to avoid multiple damage/effect triggers from overlapping colliders.

### Testing

- Ran `git diff --check` to verify no whitespace/diff issues and it returned clean.
- Ran a serialized-prefab spot-check script (prefabs: Player, Player Updated, LVL1 Wasp, Scorpion, ScorpionBoss, NewHive) to validate required vs optional serialized references and the script passed.
- Performed local source diffs and smoke-checked modified control paths to ensure early-return guards and optional VFX paths are present and syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01039bade0832a8a3579c68b72f873)