### PR TITLE
Stabilize gameplay camera readiness checks

### DIFF
--- a/Assets/Scripts/Editor.meta
+++ b/Assets/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27c8e7c3c7bb46f0ad0c697d4694f2d7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Editor/RenderingReadinessValidator.cs
+++ b/Assets/Scripts/Editor/RenderingReadinessValidator.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.SceneManagement;
+
+public static class RenderingReadinessValidator
+{
+    const string MenuPath = "Tools/Beavermania/Validate Rendering Readiness";
+
+    [MenuItem(MenuPath)]
+    public static void ValidateRenderingReadiness()
+    {
+        var report = new StringBuilder();
+        var warningCount = 0;
+
+        report.AppendLine("Rendering readiness validation (checks only; no scene/project mutation).");
+        ValidateActiveSceneCameras(report, ref warningCount);
+        ValidateRenderPipeline(report, ref warningCount);
+        AppendQualityAudit(report);
+        AppendReleaseDisplayAudit(report);
+        AppendManualValidationSteps(report);
+
+        if (warningCount > 0)
+        {
+            Debug.LogWarning(report.ToString());
+        }
+        else
+        {
+            Debug.Log(report.ToString());
+        }
+    }
+
+    static void ValidateActiveSceneCameras(StringBuilder report, ref int warningCount)
+    {
+        var scene = SceneManager.GetActiveScene();
+        report.AppendLine("Active scene: " + (scene.IsValid() ? scene.path : "<invalid>"));
+
+        if (!PlayerCameraReference.TryGetActiveGameplayCamera(out var gameplayCamera))
+        {
+            warningCount++;
+            report.AppendLine("WARN: No valid gameplay camera from CinemachineBrain.OutputCamera or enabled MainCamera.");
+        }
+        else
+        {
+            report.AppendLine("Gameplay camera: " + GetPath(gameplayCamera.transform));
+        }
+
+        int mainCameraCount = PlayerCameraReference.CountActiveMainCameras();
+        report.AppendLine("Enabled MainCamera-tagged cameras: " + mainCameraCount);
+        if (mainCameraCount > 1)
+        {
+            warningCount++;
+            report.AppendLine("WARN: Multiple enabled MainCamera-tagged cameras can destabilize Camera.main lookup.");
+        }
+    }
+
+    static void ValidateRenderPipeline(StringBuilder report, ref int warningCount)
+    {
+        PlayerCameraReference.HasRenderPipelineMismatch(out var graphicsAsset, out var qualityAsset);
+        var activeAsset = QualitySettings.renderPipeline != null ? QualitySettings.renderPipeline : GraphicsSettings.renderPipelineAsset;
+
+        report.AppendLine("Graphics render pipeline asset: " + AssetName(graphicsAsset));
+        report.AppendLine("Active quality render pipeline asset: " + AssetName(qualityAsset));
+        if (graphicsAsset != qualityAsset)
+        {
+            warningCount++;
+            report.AppendLine("WARN: GraphicsSettings and active QualitySettings render pipeline assets differ.");
+        }
+
+        if (!IsUniversalRenderPipelineAsset(activeAsset))
+        {
+            warningCount++;
+            report.AppendLine("WARN: Active render pipeline asset does not appear to be URP.");
+        }
+    }
+
+    static void AppendQualityAudit(StringBuilder report)
+    {
+        int qualityLevel = QualitySettings.GetQualityLevel();
+        string[] qualityNames = QualitySettings.names;
+        string qualityName = qualityLevel >= 0 && qualityLevel < qualityNames.Length ? qualityNames[qualityLevel] : "<unknown>";
+
+        report.AppendLine("Quality audit (no automatic changes):");
+        report.AppendLine("- active quality: " + qualityLevel + " / " + qualityName);
+        report.AppendLine("- shadows: " + QualitySettings.shadows);
+        report.AppendLine("- shadow resolution: " + QualitySettings.shadowResolution);
+        report.AppendLine("- shadow cascades: " + QualitySettings.shadowCascades);
+        report.AppendLine("- shadow distance: " + QualitySettings.shadowDistance);
+        report.AppendLine("- vSyncCount: " + QualitySettings.vSyncCount);
+    }
+
+    static void AppendReleaseDisplayAudit(StringBuilder report)
+    {
+        report.AppendLine("Steam/release display defaults audit (no automatic changes):");
+        report.AppendLine("- fullscreen mode: " + PlayerSettings.fullScreenMode);
+        report.AppendLine("- default native resolution: " + PlayerSettings.defaultIsNativeResolution);
+        report.AppendLine("- default resolution: " + PlayerSettings.defaultScreenWidth + "x" + PlayerSettings.defaultScreenHeight);
+        report.AppendLine("- allow fullscreen switch: " + PlayerSettings.allowFullscreenSwitch);
+        report.AppendLine("- run in background: " + PlayerSettings.runInBackground);
+    }
+
+    static void AppendManualValidationSteps(StringBuilder report)
+    {
+        report.AppendLine("Manual target-hardware validation required:");
+        report.AppendLine("- Confirm camera-relative projectile direction after scene reload/player respawn.");
+        report.AppendLine("- Confirm waypoint marker tracks/clamps and hides when target is behind camera.");
+        report.AppendLine("- Confirm menu-to-level load emits no null camera errors.");
+        report.AppendLine("- Confirm URP asset is active in player build.");
+        report.AppendLine("- Confirm shadows/lights and fullscreen/resolution match Steam release expectations.");
+    }
+
+    static bool IsUniversalRenderPipelineAsset(RenderPipelineAsset asset)
+    {
+        return asset != null && asset.GetType().FullName.Contains("UniversalRenderPipelineAsset");
+    }
+
+    static string AssetName(Object asset)
+    {
+        return asset != null ? asset.name + " (" + AssetDatabase.GetAssetPath(asset) + ")" : "<null>";
+    }
+
+    static string GetPath(Transform transform)
+    {
+        if (transform == null)
+        {
+            return "<null>";
+        }
+
+        var path = transform.name;
+        while (transform.parent != null)
+        {
+            transform = transform.parent;
+            path = transform.name + "/" + path;
+        }
+
+        return path;
+    }
+}

--- a/Assets/Scripts/Editor/RenderingReadinessValidator.cs.meta
+++ b/Assets/Scripts/Editor/RenderingReadinessValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca20ea509c7843878663431923553b38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -199,6 +199,11 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
     }
 
+    public bool TryGetGameplayCamera(out Camera gameplayCamera)
+    {
+        return GameplayCamera.TryGetCamera(out gameplayCamera);
+    }
+
     PlayerHealthController Health
     {
         get

--- a/Assets/Scripts/Player/PlayerCameraReference.cs
+++ b/Assets/Scripts/Player/PlayerCameraReference.cs
@@ -19,13 +19,13 @@ public sealed class PlayerCameraReference
 
     [SerializeField] Camera camera;
 
-    [NonSerialized] Behaviour owner;
+    [NonSerialized] UnityEngine.Object owner;
     [NonSerialized] CinemachineFreeLook freeLook;
     [NonSerialized] Transform cachedTransform;
     [NonSerialized] Camera cachedCamera;
     [NonSerialized] Source cachedSource;
 
-    public void Configure(Behaviour owner, CinemachineFreeLook freeLook)
+    public void Configure(UnityEngine.Object owner, CinemachineFreeLook freeLook)
     {
         this.owner = owner;
         this.freeLook = freeLook;

--- a/Assets/Scripts/Player/PlayerCameraReference.cs
+++ b/Assets/Scripts/Player/PlayerCameraReference.cs
@@ -1,6 +1,7 @@
 using System;
 using Cinemachine;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 [Serializable]
 public sealed class PlayerCameraReference
@@ -35,8 +36,44 @@ public sealed class PlayerCameraReference
         ClearCache();
     }
 
+    public bool TryGetCamera(out Camera gameplayCamera)
+    {
+        WarnRenderingReadiness(owner);
+
+        if (IsCachedCameraValid())
+        {
+            gameplayCamera = cachedCamera;
+            return true;
+        }
+
+        ClearCache();
+        if (TryResolveCamera(out gameplayCamera))
+        {
+            Cache(gameplayCamera, gameplayCamera == Camera.main ? Source.MainCamera : Source.BrainCamera);
+            return true;
+        }
+
+        gameplayCamera = null;
+        return false;
+    }
+
+    public static bool TryGetActiveGameplayCamera(out Camera gameplayCamera, UnityEngine.Object owner = null)
+    {
+        WarnRenderingReadiness(owner);
+
+        if (TryResolveCamera(out gameplayCamera))
+        {
+            return true;
+        }
+
+        gameplayCamera = null;
+        return false;
+    }
+
     public bool TryGetPlanarBasis(out Vector3 forward, out Vector3 right)
     {
+        WarnRenderingReadiness(owner);
+
         if (!IsCachedValid() && !TryResolve())
         {
             WarnMissingCamera();
@@ -70,15 +107,9 @@ public sealed class PlayerCameraReference
             return true;
         }
 
-        if (TryGetBrainOutputCamera(out var brainCamera))
+        if (TryResolveCamera(out var gameplayCamera))
         {
-            Cache(brainCamera, Source.BrainCamera);
-            return true;
-        }
-
-        if (IsCameraValid(Camera.main))
-        {
-            Cache(Camera.main, Source.MainCamera);
+            Cache(gameplayCamera, gameplayCamera == Camera.main ? Source.MainCamera : Source.BrainCamera);
             return true;
         }
 
@@ -90,6 +121,11 @@ public sealed class PlayerCameraReference
 
         ClearCache();
         return false;
+    }
+
+    bool IsCachedCameraValid()
+    {
+        return cachedCamera != null && IsCameraValid(cachedCamera);
     }
 
     bool IsCachedValid()
@@ -153,6 +189,17 @@ public sealed class PlayerCameraReference
             && freeLook.VirtualCameraGameObject.activeInHierarchy;
     }
 
+    static bool TryResolveCamera(out Camera gameplayCamera)
+    {
+        if (TryGetBrainOutputCamera(out gameplayCamera))
+        {
+            return true;
+        }
+
+        gameplayCamera = Camera.main;
+        return IsCameraValid(gameplayCamera);
+    }
+
     static bool TryGetBrainOutputCamera(out Camera outputCamera)
     {
         var brain = UnityEngine.Object.FindObjectOfType<CinemachineBrain>();
@@ -166,6 +213,28 @@ public sealed class PlayerCameraReference
         return false;
     }
 
+    public static int CountActiveMainCameras()
+    {
+        int count = 0;
+        var cameras = UnityEngine.Object.FindObjectsOfType<Camera>();
+        for (int i = 0; i < cameras.Length; i++)
+        {
+            if (IsCameraValid(cameras[i]) && cameras[i].CompareTag("MainCamera"))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    public static bool HasRenderPipelineMismatch(out RenderPipelineAsset graphicsAsset, out RenderPipelineAsset qualityAsset)
+    {
+        graphicsAsset = GraphicsSettings.renderPipelineAsset;
+        qualityAsset = QualitySettings.renderPipeline;
+        return graphicsAsset != qualityAsset;
+    }
+
     static bool IsCameraValid(Camera candidate)
     {
         return candidate != null && candidate.enabled && candidate.gameObject.activeInHierarchy;
@@ -175,6 +244,41 @@ public sealed class PlayerCameraReference
     {
         vector.y = 0f;
         return vector;
+    }
+
+    static void WarnRenderingReadiness(UnityEngine.Object owner)
+    {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        if (!TryResolveCamera(out _))
+        {
+            BuildSafeLogger.WarnOnce(
+                "RenderingReadiness.MissingGameplayCamera",
+                "Active scene has no enabled gameplay camera from CinemachineBrain.OutputCamera or MainCamera.",
+                owner);
+        }
+
+        int mainCameraCount = CountActiveMainCameras();
+        if (mainCameraCount > 1)
+        {
+            BuildSafeLogger.WarnOnce(
+                "RenderingReadiness.MultipleMainCameras",
+                "Active scene has multiple enabled MainCamera-tagged cameras: " + mainCameraCount,
+                owner);
+        }
+
+        if (HasRenderPipelineMismatch(out var graphicsAsset, out var qualityAsset))
+        {
+            BuildSafeLogger.WarnOnce(
+                "RenderingReadiness.RenderPipelineMismatch",
+                "GraphicsSettings.renderPipelineAsset and active QualitySettings.renderPipeline differ. Graphics=" + AssetName(graphicsAsset) + " Quality=" + AssetName(qualityAsset),
+                owner);
+        }
+#endif
+    }
+
+    static string AssetName(UnityEngine.Object asset)
+    {
+        return asset != null ? asset.name : "<null>";
     }
 
     void WarnMissingCamera()

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -18,8 +18,11 @@ public class Projectile : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        var mainCamera = Camera.main;
         PlayerReference.TryGetPlayer(out Player);
+        if (Player == null || !Player.TryGetGameplayCamera(out var mainCamera))
+        {
+            PlayerCameraReference.TryGetActiveGameplayCamera(out mainCamera, this);
+        }
 
         if (!ValidateReferences(mainCamera))
         {

--- a/Assets/Scripts/UI/WayPoint.cs
+++ b/Assets/Scripts/UI/WayPoint.cs
@@ -10,10 +10,12 @@ public class WayPoint : MonoBehaviour
     public Transform[] Locations;
     public Transform Arrow;
     public int i;
+    readonly PlayerCameraReference cameraReference = new PlayerCameraReference();
 
     // Start is called before the first frame update
     void Start()
     {
+        cameraReference.Configure(this, null);
         Arrow.gameObject.SetActive(false);
         for (int index = 0; index < Locations.Length; index++)
         {
@@ -53,13 +55,19 @@ public class WayPoint : MonoBehaviour
         // Waypoint Mark
         if (target != null)
         {
+            if (!cameraReference.TryGetCamera(out var gameplayCamera))
+            {
+                Mark.enabled = false;
+                return;
+            }
+
             float minX = Mark.GetPixelAdjustedRect().width / 2;
             float maxX = Screen.width - minX;
             float minY = Mark.GetPixelAdjustedRect().height / 2;
             float maxY = Screen.height - minY;
-            Vector2 pos = Camera.main.WorldToScreenPoint(target.position + new Vector3(0, 2, 0));
+            Vector2 pos = gameplayCamera.WorldToScreenPoint(target.position + new Vector3(0, 2, 0));
 
-            if (Vector3.Dot((target.position - transform.position), transform.forward) < 0)
+            if (Vector3.Dot((target.position - gameplayCamera.transform.position), gameplayCamera.transform.forward) < 0)
             {
                 // Target is behind player
                 Mark.enabled = false;


### PR DESCRIPTION
### Motivation
- Reduce reliance on `Camera.main` at runtime and surface camera/rendering issues via diagnostics instead of scene edits.
- Make camera lookup robust across menu->level transitions and player respawn without changing art or scene assets.

### Description
- Route projectile camera lookup through the player's `PlayerCameraReference` (via `Behaviour.TryGetGameplayCamera`) and fall back to an active gameplay camera resolver; preserve same launch direction logic. 
- Change `WayPoint` to cache/refresh a `PlayerCameraReference` and use `TryGetCamera(out Camera)` to compute screen position and hide the marker safely when no valid camera exists.
- Extend `PlayerCameraReference` with cached-camera resolution, `TryGetCamera`, `TryGetActiveGameplayCamera`, `TryResolveCamera`, `CountActiveMainCameras`, `HasRenderPipelineMismatch`, and editor/development warnings (`WarnRenderingReadiness`).
- Add editor-only validator `Assets/Scripts/Editor/RenderingReadinessValidator.cs` (menu: `Tools/Beavermania/Validate Rendering Readiness`) that checks for missing gameplay camera, multiple MainCamera-tagged cameras, render-pipeline mismatches, emits a quality/display audit, and lists manual validation steps; it performs checks only and does not mutate scenes or project settings.
- Do not modify scene files or change `ProjectSettings/*` values automatically; quality/rendering files are audited only.

### Testing
- Ran `git diff --check` and it reported no code-style conflicts (passed).
- Verified no staged changes to `ProjectSettings` or scene files using a quiet diff check (passed).
- Searched for residual `Camera.main` usages in the targeted files using `rg` (results inspected; targeted replacements applied) (passed).
- Attempted to run the editor validator in batch mode but the Unity Editor executable was not available in the environment (skipped); runtime verification and visual checks must be performed inside the Unity editor on target hardware (manual).
- No automated Unity compile/run tests executed in CI during this change; please run an editor compile and the `Tools/Beavermania/Validate Rendering Readiness` menu command locally and verify camera-relative projectile direction, waypoint marker behaviour, and URP asset activation on build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01083fead4832aa22231a74cbe426c)