### PR TITLE
Add Allowed Prefab Performance Validator

### DIFF
--- a/Assets/Scripts/Editor/PrefabPerformanceValidator.cs
+++ b/Assets/Scripts/Editor/PrefabPerformanceValidator.cs
@@ -122,18 +122,33 @@ public static class PrefabPerformanceValidator
     static void ValidateAlwaysActiveEffects(GameObject prefab, PrefabReport report)
     {
         foreach (var particleSystem in prefab.GetComponentsInChildren<ParticleSystem>(true)
-            .Where(component => component != null && component.gameObject.activeInHierarchy && component.main.playOnAwake)
+            .Where(component => component != null && IsActiveInPrefabHierarchy(component.transform) && component.main.playOnAwake)
             .OrderBy(component => TransformPath(component.transform), StringComparer.Ordinal))
         {
             report.Warnings.Add("Always-active ParticleSystem for manual review at " + TransformPath(particleSystem.transform));
         }
 
         foreach (var light in prefab.GetComponentsInChildren<Light>(true)
-            .Where(component => component != null && component.enabled && component.gameObject.activeInHierarchy)
+            .Where(component => component != null && component.enabled && IsActiveInPrefabHierarchy(component.transform))
             .OrderBy(component => TransformPath(component.transform), StringComparer.Ordinal))
         {
             report.Warnings.Add("Always-active Light for manual review at " + TransformPath(light.transform));
         }
+    }
+
+    static bool IsActiveInPrefabHierarchy(Transform transform)
+    {
+        while (transform != null)
+        {
+            if (!transform.gameObject.activeSelf)
+            {
+                return false;
+            }
+
+            transform = transform.parent;
+        }
+
+        return true;
     }
 
     static void AddDuplicateComponentWarning(string componentName, string[] matches, PrefabReport report)

--- a/Assets/Scripts/Editor/PrefabPerformanceValidator.cs
+++ b/Assets/Scripts/Editor/PrefabPerformanceValidator.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+public static class PrefabPerformanceValidator
+{
+    const string MenuPath = "Tools/Beavermania/Validate Allowed Prefabs";
+
+    static readonly string[] AllowedPrefabPaths =
+    {
+        "Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab",
+        "Assets/Prefabs/OtterPlayer/Player Updated.prefab",
+        "Assets/Prefabs/Wasp/LVL1 Wasp.prefab",
+        "Assets/Prefabs/Scorpion/ScorpionBoss.prefab",
+        "Assets/Prefabs/Scorpion/Scorpion.prefab",
+        "Assets/Prefabs/Hive/NewHive.prefab",
+        "Assets/Prefabs/Objects/UI/PlayerCanvas.prefab",
+        "Assets/Prefabs/Objects/UI/GameMusic.prefab"
+    };
+
+    static readonly string[] EnemyOrPlayerPrefabPaths =
+    {
+        "Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab",
+        "Assets/Prefabs/OtterPlayer/Player Updated.prefab",
+        "Assets/Prefabs/Wasp/LVL1 Wasp.prefab",
+        "Assets/Prefabs/Scorpion/ScorpionBoss.prefab",
+        "Assets/Prefabs/Scorpion/Scorpion.prefab"
+    };
+
+    static readonly string[] CriticalMonoBehaviourTypeNames =
+    {
+        "Behaviour",
+        "NPC_Basic",
+        "ScorpionScript",
+        "Static_Hive",
+        "HudPresenter",
+        "DebugReference",
+        "MusicPlaylist"
+    };
+
+    static readonly Type[] CriticalUnityComponentTypes =
+    {
+        typeof(AudioSource),
+        typeof(Animator)
+    };
+
+    [MenuItem(MenuPath)]
+    public static void ValidateAllowedPrefabs()
+    {
+        var report = new ValidationReport();
+
+        foreach (var prefabPath in AllowedPrefabPaths)
+        {
+            ValidatePrefab(prefabPath, report.ForPrefab(prefabPath));
+        }
+
+        report.Log();
+    }
+
+    static void ValidatePrefab(string prefabPath, PrefabReport report)
+    {
+        var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+        if (prefab == null)
+        {
+            report.Errors.Add("Prefab asset not found.");
+            return;
+        }
+
+        ValidateMissingScripts(prefab, report);
+        ValidateDuplicateCriticalComponents(prefab, report);
+
+        if (EnemyOrPlayerPrefabPaths.Contains(prefabPath))
+        {
+            ValidateAlwaysActiveEffects(prefab, report);
+        }
+    }
+
+    static void ValidateMissingScripts(GameObject prefab, PrefabReport report)
+    {
+        foreach (var transform in OrderedTransforms(prefab))
+        {
+            var components = transform.GetComponents<Component>();
+            for (var i = 0; i < components.Length; i++)
+            {
+                if (components[i] == null)
+                {
+                    report.Errors.Add("Missing script at " + TransformPath(transform) + " componentIndex=" + i);
+                }
+            }
+        }
+    }
+
+    static void ValidateDuplicateCriticalComponents(GameObject prefab, PrefabReport report)
+    {
+        foreach (var typeName in CriticalMonoBehaviourTypeNames)
+        {
+            var matches = prefab.GetComponentsInChildren<MonoBehaviour>(true)
+                .Where(component => component != null && component.GetType().Name == typeName)
+                .Select(component => TransformPath(component.transform))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+
+            AddDuplicateComponentWarning(typeName, matches, report);
+        }
+
+        foreach (var type in CriticalUnityComponentTypes)
+        {
+            var matches = prefab.GetComponentsInChildren(type, true)
+                .Cast<Component>()
+                .Where(component => component != null && component.GetType() == type)
+                .Select(component => TransformPath(component.transform))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+
+            AddDuplicateComponentWarning(type.Name, matches, report);
+        }
+    }
+
+    static void ValidateAlwaysActiveEffects(GameObject prefab, PrefabReport report)
+    {
+        foreach (var particleSystem in prefab.GetComponentsInChildren<ParticleSystem>(true)
+            .Where(component => component != null && component.gameObject.activeInHierarchy && component.main.playOnAwake)
+            .OrderBy(component => TransformPath(component.transform), StringComparer.Ordinal))
+        {
+            report.Warnings.Add("Always-active ParticleSystem for manual review at " + TransformPath(particleSystem.transform));
+        }
+
+        foreach (var light in prefab.GetComponentsInChildren<Light>(true)
+            .Where(component => component != null && component.enabled && component.gameObject.activeInHierarchy)
+            .OrderBy(component => TransformPath(component.transform), StringComparer.Ordinal))
+        {
+            report.Warnings.Add("Always-active Light for manual review at " + TransformPath(light.transform));
+        }
+    }
+
+    static void AddDuplicateComponentWarning(string componentName, string[] matches, PrefabReport report)
+    {
+        if (matches.Length <= 1)
+        {
+            return;
+        }
+
+        report.Errors.Add("Duplicate critical component " + componentName + " count=" + matches.Length + " at " + string.Join(", ", matches));
+    }
+
+    static IEnumerable<Transform> OrderedTransforms(GameObject prefab)
+    {
+        return prefab.GetComponentsInChildren<Transform>(true).OrderBy(TransformPath, StringComparer.Ordinal);
+    }
+
+    static string TransformPath(Transform transform)
+    {
+        var names = new Stack<string>();
+        while (transform != null)
+        {
+            names.Push(transform.name);
+            transform = transform.parent;
+        }
+
+        return string.Join("/", names.ToArray());
+    }
+
+    sealed class ValidationReport
+    {
+        readonly List<PrefabReport> prefabReports = new List<PrefabReport>();
+
+        public PrefabReport ForPrefab(string prefabPath)
+        {
+            var report = new PrefabReport(prefabPath);
+            prefabReports.Add(report);
+            return report;
+        }
+
+        public void Log()
+        {
+            var errorCount = prefabReports.Sum(report => report.Errors.Count);
+            var warningCount = prefabReports.Sum(report => report.Warnings.Count);
+            var builder = new StringBuilder();
+
+            builder.AppendLine("[BeaverMania Allowed Prefab Validation]");
+            builder.AppendLine("Prefabs scanned: " + prefabReports.Count);
+            builder.AppendLine("Errors: " + errorCount);
+            builder.AppendLine("Warnings: " + warningCount);
+
+            foreach (var prefabReport in prefabReports.OrderBy(report => report.PrefabPath, StringComparer.Ordinal))
+            {
+                builder.AppendLine();
+                builder.AppendLine(prefabReport.PrefabPath);
+                AppendMessages(builder, "ERROR", prefabReport.Errors);
+                AppendMessages(builder, "WARN", prefabReport.Warnings);
+
+                if (prefabReport.Errors.Count == 0 && prefabReport.Warnings.Count == 0)
+                {
+                    builder.AppendLine("  OK");
+                }
+            }
+
+            if (errorCount > 0)
+            {
+                Debug.LogError(builder.ToString());
+            }
+            else if (warningCount > 0)
+            {
+                Debug.LogWarning(builder.ToString());
+            }
+            else
+            {
+                Debug.Log(builder.ToString());
+            }
+        }
+
+        static void AppendMessages(StringBuilder builder, string prefix, List<string> messages)
+        {
+            foreach (var message in messages.OrderBy(message => message, StringComparer.Ordinal))
+            {
+                builder.AppendLine("  " + prefix + " | " + message);
+            }
+        }
+    }
+
+    sealed class PrefabReport
+    {
+        public readonly string PrefabPath;
+        public readonly List<string> Errors = new List<string>();
+        public readonly List<string> Warnings = new List<string>();
+
+        public PrefabReport(string prefabPath)
+        {
+            PrefabPath = prefabPath;
+        }
+    }
+}

--- a/Assets/Scripts/Editor/PrefabPerformanceValidator.cs.meta
+++ b/Assets/Scripts/Editor/PrefabPerformanceValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51679eba55754ebe9d16b88be29b3ec3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
### Motivation
- Detect risky prefab setups in a small, approved prefab set without performing destructive YAML edits or asset replacements.
- Surface missing scripts, duplicate critical components, and always-active VFX/Lights for manual Unity review while preserving runtime reference validation behavior.

### Description
- Add editor validator `Assets/Scripts/Editor/PrefabPerformanceValidator.cs` exposing `Tools/Beavermania/Validate Allowed Prefabs` and an allowlist `AllowedPrefabPaths`.
- Scan only the allowlist and report missing `MonoBehaviour` scripts and duplicate critical MonoBehaviour names (`Behaviour`, `NPC_Basic`, `ScorpionScript`, `Static_Hive`, `HudPresenter`, `DebugReference`, `MusicPlaylist`) and duplicate Unity types `AudioSource` and `Animator`.
- Warn about always-active `ParticleSystem` (`main.playOnAwake`) and enabled `Light` on player/enemy prefabs for manual review; do not auto-fix prefab YAML or change runtime ownership.
- Add grouped report output and the Unity `.meta` for the validator (`Assets/Scripts/Editor/PrefabPerformanceValidator.cs.meta`).

### Testing
- Ran `git diff --cached --check` and resolved whitespace issues; check passed.
- Attempted Unity CLI presence check via `command -v unity || command -v Unity || command -v unity-editor` but Unity is not available in the container, so in-editor validation / compile was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016076a524832a9075221b4ebda80d)