### PR TITLE
Reduce redundant UI updates (DebugReference / PauseMenu / LoadingScreen)

### DIFF
--- a/Assets/Scripts/SceneScripts/LoadingScreenController.cs
+++ b/Assets/Scripts/SceneScripts/LoadingScreenController.cs
@@ -7,6 +7,8 @@ public class LoadingScreenController : MonoBehaviour
     public Slider loadingBar; // Reference to a loading progress bar (if applicable)
     public float fillSpeed = 0.5f; // Speed at which the loading bar fills (adjust as needed)
 
+    bool isLoading;
+
     void Start()
     {
         // Disable the loading screen canvas on Start
@@ -18,6 +20,13 @@ public class LoadingScreenController : MonoBehaviour
 
     public void LoadScene(string sceneName)
     {
+        if (isLoading)
+        {
+            return;
+        }
+
+        isLoading = true;
+
         // Activate the loading screen canvas
         if (loadingScreen != null)
         {
@@ -34,6 +43,7 @@ public class LoadingScreenController : MonoBehaviour
         AsyncOperation operation = SceneTransitionService.LoadSceneAsync(sceneName);
         if (operation == null)
         {
+            isLoading = false;
             yield break;
         }
 

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -18,6 +18,7 @@ public sealed class DebugReference : MonoBehaviour
     public TextMeshProUGUI ArrowMunition;
 
     HudPresenter presenter;
+    bool appliedAtRuntime;
 
     private void Awake()
     {
@@ -26,18 +27,10 @@ public sealed class DebugReference : MonoBehaviour
 
     private void Start()
     {
-        ApplyReferences();
-        enabled = presenter == null;
-    }
-
-    private void Update()
-    {
-        if (presenter == null)
+        if (!appliedAtRuntime)
         {
             ApplyReferences();
         }
-
-        enabled = false;
     }
 
     private void OnValidate()
@@ -58,6 +51,7 @@ public sealed class DebugReference : MonoBehaviour
             presenter = gameObject.AddComponent<HudPresenter>();
         }
 
+        appliedAtRuntime |= Application.isPlaying;
         presenter.Bind(Player, PlayerObjective, Application.isPlaying ? CheckpointService.GetOrCreate() : null);
         presenter.ObjectiveText = ObjectiveText;
         presenter.DisplayText = DisplayText;

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -197,7 +197,11 @@ public class PauseMenuController : MonoBehaviour
     {
         if (panel != null)
         {
-            panel.SetActive(active);
+            if (panel.activeSelf != active)
+            {
+                panel.SetActive(active);
+            }
+
             return;
         }
 


### PR DESCRIPTION
### Motivation
- Remove redundant per-frame reference/application work and unnecessary TMP assignments to reduce GC/CPU churn while preserving HUD layout and behavior.
- Prevent duplicate UI state changes and duplicate scene load triggers without redesigning UI hierarchy.

### Description
- `Assets/Scripts/UI/DebugReference.cs`: convert to a compatibility shim that assigns references during `Awake`, `Start` (one-time fallback) and `OnValidate`; remove frame-by-frame `Update` writes and track `appliedAtRuntime` to avoid repeated runtime binding.
- `Assets/Scripts/UI/HudPresenter.cs`: validated existing caching and write-guards (`SetTextIfChanged`) are present and left unchanged to ensure TMP text is only set when values change.
- `Assets/Scripts/UI/PauseMenuController.cs`: avoid duplicate `SetActive` calls by checking `panel.activeSelf` before calling `panel.SetActive(active)`.
- `Assets/Scripts/SceneScripts/LoadingScreenController.cs`: add `bool isLoading` guard to bail out on reentrant `LoadScene` calls and reset the flag if async load creation fails; preserve existing loading bar interpolation behavior.
- No UI hierarchy or prefab modifications are performed in this change; `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab` was inspected only for validation.

### Testing
- Ran `git diff --check` to validate diffs and whitespace; the check completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0162dfd1b0832a9c2a3bf09ce4437b)