### PR TITLE
Add editor/dev PerformanceDiagnosticsOverlay and PerformanceAuditMenu

### DIFF
--- a/Assets/Scripts/Debug/PerformanceDiagnosticsOverlay.cs
+++ b/Assets/Scripts/Debug/PerformanceDiagnosticsOverlay.cs
@@ -1,0 +1,172 @@
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public sealed class PerformanceDiagnosticsOverlay : MonoBehaviour
+{
+    [SerializeField] bool overlayEnabled;
+    [SerializeField] KeyCode toggleKey = KeyCode.F8;
+    [SerializeField] float sampleIntervalSeconds = 0.5f;
+
+    readonly List<string> warnings = new List<string>();
+    float smoothedDeltaTime;
+    float nextSampleTime;
+    int activeObjectCount;
+    int particleSystemCount;
+    int audioSourceCount;
+    GUIStyle labelStyle;
+    GUIStyle warningStyle;
+
+    public bool OverlayEnabled
+    {
+        get { return overlayEnabled; }
+        set { overlayEnabled = value; }
+    }
+
+    void Update()
+    {
+        if (toggleKey != KeyCode.None && Input.GetKeyDown(toggleKey))
+        {
+            overlayEnabled = !overlayEnabled;
+        }
+
+        if (!overlayEnabled)
+        {
+            return;
+        }
+
+        smoothedDeltaTime += (Time.unscaledDeltaTime - smoothedDeltaTime) * 0.1f;
+        if (Time.unscaledTime >= nextSampleTime)
+        {
+            SampleSceneDiagnostics();
+            nextSampleTime = Time.unscaledTime + Mathf.Max(0.1f, sampleIntervalSeconds);
+        }
+    }
+
+    void OnGUI()
+    {
+        if (!overlayEnabled)
+        {
+            return;
+        }
+
+        EnsureStyles();
+
+        var ms = smoothedDeltaTime * 1000f;
+        var fps = smoothedDeltaTime > 0f ? 1f / smoothedDeltaTime : 0f;
+        var y = 10f;
+
+        GUI.Label(new Rect(10f, y, 360f, 24f), string.Format("FPS: {0:0} ({1:0.0} ms)", fps, ms), labelStyle);
+        y += 20f;
+        GUI.Label(new Rect(10f, y, 360f, 24f), "Active GameObjects: " + activeObjectCount, labelStyle);
+        y += 20f;
+        GUI.Label(new Rect(10f, y, 360f, 24f), "ParticleSystems: " + particleSystemCount, labelStyle);
+        y += 20f;
+        GUI.Label(new Rect(10f, y, 360f, 24f), "AudioSources: " + audioSourceCount, labelStyle);
+        y += 24f;
+
+        foreach (var warning in warnings)
+        {
+            GUI.Label(new Rect(10f, y, 900f, 24f), warning, warningStyle);
+            y += 20f;
+        }
+    }
+
+    void SampleSceneDiagnostics()
+    {
+        var gameObjects = Resources.FindObjectsOfTypeAll<GameObject>()
+            .Where(IsRuntimeSceneObject)
+            .ToArray();
+
+        activeObjectCount = gameObjects.Count(gameObject => gameObject.activeInHierarchy);
+        particleSystemCount = CountRuntimeComponents<ParticleSystem>();
+        audioSourceCount = CountRuntimeComponents<AudioSource>();
+
+        warnings.Clear();
+        AddDuplicateMusicWarning();
+        AddDuplicateRuntimeServiceWarnings();
+    }
+
+    static int CountRuntimeComponents<T>() where T : Component
+    {
+        return Resources.FindObjectsOfTypeAll<T>()
+            .Count(component => component != null && IsRuntimeSceneObject(component.gameObject));
+    }
+
+    void AddDuplicateMusicWarning()
+    {
+        var musicObjects = Resources.FindObjectsOfTypeAll<MusicPlaylist>()
+            .Where(component => component != null && IsRuntimeSceneObject(component.gameObject))
+            .Select(component => ScenePath(component.transform))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        if (musicObjects.Length > 1)
+        {
+            warnings.Add("WARN duplicate MusicPlaylist objects: " + string.Join(", ", musicObjects));
+        }
+    }
+
+    void AddDuplicateRuntimeServiceWarnings()
+    {
+        var serviceComponents = Resources.FindObjectsOfTypeAll<MonoBehaviour>()
+            .Where(component => component != null && IsRuntimeSceneObject(component.gameObject))
+            .Where(component => IsDeclaredRuntimeService(component))
+            .GroupBy(component => component.GetType())
+            .OrderBy(group => group.Key.FullName, StringComparer.Ordinal);
+
+        foreach (var group in serviceComponents)
+        {
+            var paths = group.Select(component => ScenePath(component.transform))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+
+            if (paths.Length > 1)
+            {
+                warnings.Add("WARN duplicate runtime service " + group.Key.Name + ": " + string.Join(", ", paths));
+            }
+        }
+    }
+
+    static bool IsDeclaredRuntimeService(MonoBehaviour component)
+    {
+        ServiceLifetime lifetime;
+        return RuntimeServices.TryGetDeclaredLifetime(component.GetType(), out lifetime);
+    }
+
+    static bool IsRuntimeSceneObject(GameObject gameObject)
+    {
+        return gameObject != null && gameObject.scene.IsValid() && gameObject.scene.isLoaded;
+    }
+
+    static string ScenePath(Transform transform)
+    {
+        var names = new Stack<string>();
+        while (transform != null)
+        {
+            names.Push(transform.name);
+            transform = transform.parent;
+        }
+
+        return string.Join("/", names.ToArray());
+    }
+
+    void EnsureStyles()
+    {
+        if (labelStyle != null)
+        {
+            return;
+        }
+
+        labelStyle = new GUIStyle(GUI.skin.label)
+        {
+            fontSize = 13,
+        };
+        labelStyle.normal.textColor = Color.white;
+        warningStyle = new GUIStyle(labelStyle);
+        warningStyle.normal.textColor = Color.yellow;
+    }
+}
+#endif

--- a/Assets/Scripts/Debug/PerformanceDiagnosticsOverlay.cs.meta
+++ b/Assets/Scripts/Debug/PerformanceDiagnosticsOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16f5bd76c3144532a492c9e0b9f79edb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/PerformanceAuditMenu.cs
+++ b/Assets/Scripts/Editor/PerformanceAuditMenu.cs
@@ -12,13 +12,13 @@ public static class PerformanceAuditMenu
 
     static readonly Regex TickMethodRegex = new Regex(@"\b(?:void|IEnumerator)\s+(Update|FixedUpdate|LateUpdate)\s*\(", RegexOptions.Compiled);
 
-    static readonly string[] FlaggedCalls =
+    static readonly KeyValuePair<string, Regex>[] FlaggedCalls =
     {
-        "Camera.main",
-        "FindGameObjectWithTag",
-        "Instantiate",
-        "Destroy",
-        "Debug.Log"
+        new KeyValuePair<string, Regex>("Camera.main", new Regex(@"\bCamera\s*\.\s*main\b", RegexOptions.Compiled)),
+        new KeyValuePair<string, Regex>("FindGameObjectWithTag", new Regex(@"\bFindGameObjectWithTag\s*\(", RegexOptions.Compiled)),
+        new KeyValuePair<string, Regex>("Instantiate", new Regex(@"\bInstantiate\s*\(", RegexOptions.Compiled)),
+        new KeyValuePair<string, Regex>("Destroy", new Regex(@"\bDestroy\s*\(", RegexOptions.Compiled)),
+        new KeyValuePair<string, Regex>("Debug.Log", new Regex(@"\bDebug\s*\.\s*Log\s*\(", RegexOptions.Compiled))
     };
 
     [MenuItem(MenuPath)]
@@ -69,22 +69,155 @@ public static class PerformanceAuditMenu
     static void AppendFlaggedCalls(StringBuilder report, string[] scripts)
     {
         report.AppendLine();
-        report.AppendLine("Flagged calls:");
+        report.AppendLine("Flagged calls (runtime scripts only):");
 
         var rows = new List<string>();
-        foreach (var script in scripts)
+        foreach (var script in scripts.Where(IsRuntimeScript))
         {
-            var source = AssetDatabase.LoadAssetAtPath<MonoScript>(script).text;
+            var source = StripCommentsAndStrings(AssetDatabase.LoadAssetAtPath<MonoScript>(script).text);
             foreach (var flaggedCall in FlaggedCalls)
             {
-                if (source.Contains(flaggedCall))
+                if (flaggedCall.Value.IsMatch(source))
                 {
-                    rows.Add("- " + script + ": " + flaggedCall);
+                    rows.Add("- " + script + ": " + flaggedCall.Key);
                 }
             }
         }
 
         AppendRowsOrNone(report, rows);
+    }
+
+    static bool IsRuntimeScript(string path)
+    {
+        return path.IndexOf("/Editor/", StringComparison.OrdinalIgnoreCase) < 0;
+    }
+
+    static string StripCommentsAndStrings(string source)
+    {
+        var chars = source.ToCharArray();
+        var inLineComment = false;
+        var inBlockComment = false;
+        var inString = false;
+        var inVerbatimString = false;
+        var inCharacter = false;
+
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var current = chars[i];
+            var next = i + 1 < chars.Length ? chars[i + 1] : '\0';
+
+            if (inLineComment)
+            {
+                if (current == '\r' || current == '\n')
+                {
+                    inLineComment = false;
+                }
+                else
+                {
+                    chars[i] = ' ';
+                }
+
+                continue;
+            }
+
+            if (inBlockComment)
+            {
+                if (current == '*' && next == '/')
+                {
+                    chars[i] = ' ';
+                    chars[i + 1] = ' ';
+                    i++;
+                    inBlockComment = false;
+                }
+                else if (current != '\r' && current != '\n')
+                {
+                    chars[i] = ' ';
+                }
+
+                continue;
+            }
+
+            if (inString)
+            {
+                if (current == '\r' || current == '\n')
+                {
+                    inString = false;
+                    continue;
+                }
+
+                chars[i] = ' ';
+                if (current == '"')
+                {
+                    if (inVerbatimString && next == '"')
+                    {
+                        chars[i + 1] = ' ';
+                        i++;
+                    }
+                    else
+                    {
+                        inString = false;
+                        inVerbatimString = false;
+                    }
+                }
+                else if (!inVerbatimString && current == '\\' && next != '\0')
+                {
+                    chars[i + 1] = ' ';
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (inCharacter)
+            {
+                if (current == '\r' || current == '\n')
+                {
+                    inCharacter = false;
+                    continue;
+                }
+
+                chars[i] = ' ';
+                if (current == '\'')
+                {
+                    inCharacter = false;
+                }
+                else if (current == '\\' && next != '\0')
+                {
+                    chars[i + 1] = ' ';
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (current == '/' && next == '/')
+            {
+                chars[i] = ' ';
+                chars[i + 1] = ' ';
+                i++;
+                inLineComment = true;
+            }
+            else if (current == '/' && next == '*')
+            {
+                chars[i] = ' ';
+                chars[i + 1] = ' ';
+                i++;
+                inBlockComment = true;
+            }
+            else if (current == '"')
+            {
+                chars[i] = ' ';
+                inString = true;
+                inVerbatimString = i > 0 && chars[i - 1] == '@';
+            }
+            else if (current == '\'')
+            {
+                chars[i] = ' ';
+                inCharacter = true;
+            }
+        }
+
+        return new string(chars);
     }
 
     static void AppendPrefabValidation(StringBuilder report)

--- a/Assets/Scripts/Editor/PerformanceAuditMenu.cs
+++ b/Assets/Scripts/Editor/PerformanceAuditMenu.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+
+public static class PerformanceAuditMenu
+{
+    const string MenuPath = "Tools/Beavermania/Run Performance Audit";
+
+    static readonly Regex TickMethodRegex = new Regex(@"\b(?:void|IEnumerator)\s+(Update|FixedUpdate|LateUpdate)\s*\(", RegexOptions.Compiled);
+
+    static readonly string[] FlaggedCalls =
+    {
+        "Camera.main",
+        "FindGameObjectWithTag",
+        "Instantiate",
+        "Destroy",
+        "Debug.Log"
+    };
+
+    [MenuItem(MenuPath)]
+    public static void RunPerformanceAudit()
+    {
+        var scripts = AssetDatabase.FindAssets("t:MonoScript", new[] { "Assets/Scripts" })
+            .Select(AssetDatabase.GUIDToAssetPath)
+            .Where(path => path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        var report = new StringBuilder();
+        report.AppendLine("[BeaverMania Performance Audit]");
+        report.AppendLine("Scripts scanned: " + scripts.Length);
+        AppendTickMethods(report, scripts);
+        AppendFlaggedCalls(report, scripts);
+        AppendPrefabValidation(report);
+
+        Debug.Log(report.ToString());
+        PrefabPerformanceValidator.ValidateAllowedPrefabs();
+    }
+
+    static void AppendTickMethods(StringBuilder report, string[] scripts)
+    {
+        report.AppendLine();
+        report.AppendLine("Tick methods:");
+
+        var rows = new List<string>();
+        foreach (var script in scripts)
+        {
+            var source = AssetDatabase.LoadAssetAtPath<MonoScript>(script).text;
+            var methods = TickMethodRegex.Matches(source)
+                .Cast<Match>()
+                .Select(match => match.Groups[1].Value)
+                .Distinct()
+                .OrderBy(method => method, StringComparer.Ordinal)
+                .ToArray();
+
+            if (methods.Length > 0)
+            {
+                rows.Add("- " + script + ": " + string.Join(", ", methods));
+            }
+        }
+
+        AppendRowsOrNone(report, rows);
+    }
+
+    static void AppendFlaggedCalls(StringBuilder report, string[] scripts)
+    {
+        report.AppendLine();
+        report.AppendLine("Flagged calls:");
+
+        var rows = new List<string>();
+        foreach (var script in scripts)
+        {
+            var source = AssetDatabase.LoadAssetAtPath<MonoScript>(script).text;
+            foreach (var flaggedCall in FlaggedCalls)
+            {
+                if (source.Contains(flaggedCall))
+                {
+                    rows.Add("- " + script + ": " + flaggedCall);
+                }
+            }
+        }
+
+        AppendRowsOrNone(report, rows);
+    }
+
+    static void AppendPrefabValidation(StringBuilder report)
+    {
+        report.AppendLine();
+        report.AppendLine("Allowed prefab validation:");
+        report.AppendLine("- Invoked after this audit; see the [BeaverMania Allowed Prefab Validation] console report.");
+    }
+
+    static void AppendRowsOrNone(StringBuilder report, List<string> rows)
+    {
+        if (rows.Count == 0)
+        {
+            report.AppendLine("- none");
+            return;
+        }
+
+        foreach (var row in rows.OrderBy(row => row, StringComparer.Ordinal))
+        {
+            report.AppendLine(row);
+        }
+    }
+}

--- a/Assets/Scripts/Editor/PerformanceAuditMenu.cs.meta
+++ b/Assets/Scripts/Editor/PerformanceAuditMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 73fa1bca236a4f278b8e1d5f45867d7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/SteamReleaseReadinessValidator.cs
+++ b/Assets/Scripts/Editor/SteamReleaseReadinessValidator.cs
@@ -24,7 +24,8 @@ public static class SteamReleaseReadinessValidator
         "Assets/Scripts/Debug/DebugDamageTrigger.cs",
         "Assets/Scripts/Debug/DebugCheckpointTeleport.cs",
         "Assets/Scripts/Debug/DebugSceneResetShortcut.cs",
-        "Assets/Scripts/Debug/FpsDisplay.cs"
+        "Assets/Scripts/Debug/FpsDisplay.cs",
+        "Assets/Scripts/Debug/PerformanceDiagnosticsOverlay.cs"
     };
 
     [MenuItem(MenuPath)]

--- a/Docs/PERFORMANCE_STEAM_RELEASE_CHECKLIST.md
+++ b/Docs/PERFORMANCE_STEAM_RELEASE_CHECKLIST.md
@@ -5,7 +5,8 @@ Use this checklist before every Steam release candidate. Do not change project o
 ## Automated audit
 
 - Run `Tools/Beavermania/Validate Steam Release Readiness` in the Unity editor.
-- Save the console output with the release-candidate notes.
+- Run `Tools/Beavermania/Run Performance Audit` in the Unity editor.
+- Save both console outputs with the release-candidate notes.
 - Confirm the validator is report-only and did not modify `ProjectSettings/*`, scenes, prefabs, or assets.
 
 ## Display defaults
@@ -22,7 +23,7 @@ Use this checklist before every Steam release candidate. Do not change project o
   - `vSyncCount > 0`: Unity uses display sync; target frame rate may be ignored.
   - `vSyncCount == 0`: `Application.targetFrameRate` / platform default governs frame pacing.
 - Target frame-rate behavior is tested on the target hardware class.
-- No development-only FPS overlay appears in release builds.
+- No development-only FPS or performance diagnostics overlay appears in release builds.
 
 ## Quality / rendering
 
@@ -46,7 +47,9 @@ Use this checklist before every Steam release candidate. Do not change project o
 - `BuildSafeLogger` calls are compiled out for non-development players.
 - Non-development player build emits no development diagnostic UI or log spam.
 - Logging configuration exists for editor/development-build diagnostics if those builds are being produced.
-- Runtime diagnostic helpers under `Assets/Scripts/Debug` and `DevelopmentRuntimeDiagnostics` are unavailable in non-development players.
+- Runtime diagnostic helpers under `Assets/Scripts/Debug`, including `PerformanceDiagnosticsOverlay`, and `DevelopmentRuntimeDiagnostics` are unavailable in non-development players.
+- `PerformanceDiagnosticsOverlay` is not attached to release scenes/prefabs and remains disabled unless explicitly toggled in editor/development builds.
+- Duplicate music/runtime-service warnings from development diagnostics are investigated before release.
 
 ## Steam smoke test
 


### PR DESCRIPTION
### Motivation

- Provide lightweight, development-only runtime diagnostics that can be toggled in-editor and compiled out of release builds to aid performance triage. 
- Provide a fast editor audit that surfaces script tick usage and flagged API calls and reuses existing prefab validation to spot problematic prefab/service usage.
- Surface duplicate music/service instances at runtime for quicker investigation without adding persistent service ownership or scene dependencies.

### Description

- Add `Assets/Scripts/Debug/PerformanceDiagnosticsOverlay.cs` gated by `#if UNITY_EDITOR || DEVELOPMENT_BUILD` with default-off toggle, F8 key toggle, FPS/frame-ms display, active GameObject/ParticleSystem/AudioSource counts, and duplicate `MusicPlaylist` and declared-runtime-service warnings. 
- Add `Assets/Scripts/Editor/PerformanceAuditMenu.cs` with menu `Tools/Beavermania/Run Performance Audit` that scans `Assets/Scripts` for `Update`/`FixedUpdate`/`LateUpdate`, flags uses of `Camera.main`, `FindGameObjectWithTag`, `Instantiate`, `Destroy`, and `Debug.Log`, and invokes `PrefabPerformanceValidator.ValidateAllowedPrefabs()`.
- Update `Assets/Scripts/Editor/SteamReleaseReadinessValidator.cs` to include the new diagnostics file in development-diagnostics tracking and update `Docs/PERFORMANCE_STEAM_RELEASE_CHECKLIST.md` to require running the new audit and to note the overlay must be absent/inactive in non-development builds.
- No prefabs or scenes modified and no runtime persistent owners added; all runtime code is guarded to avoid release overhead.

### Testing

- Ran `git diff --check` to ensure no whitespace/patch errors and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016a6c4890832a910d225aa6268557)