### PR TITLE
Extract trader trigger handling into PlayerTraderTriggerController

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -179,6 +179,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     PlayerHealthController healthController;
     PlayerInventory inventory;
     PlayerInteractionController interactionController;
+    PlayerTraderTriggerController traderTriggerController;
     PlayerCombatController combatController;
     PlayerMovementController movementController;
     PlayerFailureController failureController;
@@ -248,6 +249,24 @@ public class Behaviour : MonoBehaviour, IDamageable
             }
 
             return interactionController;
+        }
+    }
+
+    PlayerTraderTriggerController TraderTriggers
+    {
+        get
+        {
+            if (traderTriggerController == null)
+            {
+                traderTriggerController = GetComponent<PlayerTraderTriggerController>();
+                if (traderTriggerController == null)
+                {
+                    traderTriggerController = gameObject.AddComponent<PlayerTraderTriggerController>();
+                }
+                traderTriggerController.Initialize(this);
+            }
+
+            return traderTriggerController;
         }
     }
 
@@ -551,18 +570,7 @@ public class Behaviour : MonoBehaviour, IDamageable
             if (CurrentHealth >= MaxHealth)
                 TouchShroom = false;
         }
-        if (OBJ.gameObject.CompareTag("Trader"))
-        {
-            var skip = OBJ.gameObject.GetComponent<Trader>().skipPressed;
-            if (skip ==false)
-            {
-                Interaction.EnterTrader(OBJ);
-            }
-            if (skip ==true)
-            {
-                Interaction.ExitTrader();
-            }
-        }
+        TraderTriggers.HandleTriggerStay(OBJ);
         if (OBJ.gameObject.CompareTag("House"))
         {
             TrySetFreeLookOrbits(FreeLook, 1f, 2f, 1f);
@@ -589,10 +597,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         {
             TouchShroom = false;
         }
-        if (OBJ.gameObject.CompareTag("Trader"))
-        {
-            Interaction.ExitTrader();
-        }
+        TraderTriggers.HandleTriggerExit(OBJ);
         if (OBJ.gameObject.CompareTag("House"))
         {
             TrySetFreeLookOrbits(FreeLook, 4f, 6f, 5f);
@@ -810,6 +815,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     }
     public void ShowCursor() => Interaction.ShowCursor();
     public void HideCursor() => Interaction.HideCursor();
+    public void EnterTraderInteraction(Collider trader) => Interaction.EnterTrader(trader);
     public void ExitTraderInteraction() => Interaction.ExitTrader();
     public void RestoreGameplayCursorAfterUiClose() => Interaction.RestoreGameplayCursorAfterUiClose();
     public void ActivateLooseMenu()
@@ -1276,6 +1282,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         GameFlowController.GetOrCreate().TrySetPlayingFromSceneStartup(nameof(Behaviour));
         Inventory.Initialize(this);
         Interaction.Initialize(this, inputReader);
+        TraderTriggers.Initialize(this);
         Combat.Initialize(this);
         Movement.Initialize(this);
         Failure.Initialize(this);

--- a/Assets/Scripts/Player/PlayerTraderTriggerController.cs
+++ b/Assets/Scripts/Player/PlayerTraderTriggerController.cs
@@ -1,0 +1,86 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class PlayerTraderTriggerController : MonoBehaviour
+{
+    Behaviour owner;
+    Collider cachedCollider;
+    Trader cachedTrader;
+    Collider activeCollider;
+    Trader activeTrader;
+    bool activeSkipPressed;
+
+    public void Initialize(Behaviour behaviour)
+    {
+        owner = behaviour;
+    }
+
+    public void HandleTriggerStay(Collider traderCollider)
+    {
+        var trader = ResolveTrader(traderCollider);
+        if (trader == null)
+        {
+            return;
+        }
+
+        var skipPressed = trader.skipPressed;
+        if (activeTrader == trader)
+        {
+            if (!activeSkipPressed && skipPressed)
+            {
+                ExitActiveTrader();
+                return;
+            }
+
+            activeSkipPressed = skipPressed;
+            return;
+        }
+
+        if (skipPressed)
+        {
+            return;
+        }
+
+        activeTrader = trader;
+        activeCollider = traderCollider;
+        activeSkipPressed = false;
+        owner.EnterTraderInteraction(traderCollider);
+    }
+
+    public void HandleTriggerExit(Collider traderCollider)
+    {
+        if (activeCollider == traderCollider || activeTrader == ResolveTrader(traderCollider))
+        {
+            ExitActiveTrader();
+        }
+    }
+
+    Trader ResolveTrader(Collider traderCollider)
+    {
+        if (traderCollider == null || !traderCollider.gameObject.CompareTag("Trader"))
+        {
+            return null;
+        }
+
+        if (cachedCollider != traderCollider)
+        {
+            cachedCollider = traderCollider;
+            cachedTrader = traderCollider.gameObject.GetComponent<Trader>();
+        }
+
+        return cachedTrader;
+    }
+
+    void ExitActiveTrader()
+    {
+        if (activeTrader == null)
+        {
+            return;
+        }
+
+        activeTrader = null;
+        activeCollider = null;
+        activeSkipPressed = false;
+        owner.ExitTraderInteraction();
+    }
+}

--- a/Assets/Scripts/Player/PlayerTraderTriggerController.cs.meta
+++ b/Assets/Scripts/Player/PlayerTraderTriggerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac347dba41ac4d49b30ed26d70127326
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Move Trader trigger-specific logic out of `Behaviour` to centralize state, avoid duplicate Enter/Exit calls, and reduce repeated `Trader` resolution per frame.

### Description
- Added `Assets/Scripts/Player/PlayerTraderTriggerController.cs` which caches collider->`Trader` resolution, tracks active collider/trader and `skipPressed` state, and gates enter/exit calls.
- Replaced inline Trader handling in `Behaviour.OnTriggerStay` / `Behaviour.OnTriggerExit` with delegated calls to `TraderTriggers.HandleTriggerStay` and `TraderTriggers.HandleTriggerExit` and added a `TraderTriggers` property that lazy-initializes and `Initialize`s the controller.
- Added `Behaviour.EnterTraderInteraction(Collider trader)` compatibility wrapper and preserved `ExitTraderInteraction()` and the public `isAtTrader` field.
- Initialized `TraderTriggers` during `Behaviour.Start()` to ensure wiring at startup.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019270bd68832aa1fadf3cac0fd428)