### PR TITLE
Extract player pickup handling from Behaviour

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -182,6 +182,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     PlayerCombatController combatController;
     PlayerMovementController movementController;
     PlayerFailureController failureController;
+    PlayerPickupController pickupController;
     bool wasGameplayBlocked;
 
     PlayerCameraReference GameplayCamera
@@ -305,43 +306,41 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
     }
 
+    PlayerPickupController Pickup
+    {
+        get
+        {
+            if (pickupController == null)
+            {
+                pickupController = GetComponent<PlayerPickupController>();
+                if (pickupController == null)
+                {
+                    pickupController = gameObject.AddComponent<PlayerPickupController>();
+                }
+                pickupController.Initialize(this);
+            }
+
+            return pickupController;
+        }
+    }
+
     public void ToggleParryCounterAttack() => WhichAttack = !WhichAttack;
     public void SetAppleModelActive(bool active) => appleOBJ.SetActive(active);
+    public bool CanCollectArrowPickup => Arrows != null && arrowMunition < Arrows.Length && bowEquipped;
+    public int ArrowCapacity => Arrows != null ? Arrows.Length : 0;
+    public void PlayPickupEffect(Vector3 position)
+    {
+        if (PickUpEffect != null)
+        {
+            Instantiate(PickUpEffect, position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+        }
+    }
+    public void AddSeedPickup() => Inventory.AddSeed();
+    public void AddApplePickup() => Inventory.AddApple();
+    public void AddGobletPickup() => Inventory.AddGoblet();
 
     public void OnCollisionEnter(Collision OBJ)
     {
-        if (OBJ.gameObject.CompareTag("Part")&& Load.CanCarry == true && grounded==true && !Input.GetKey(KeyCode.Mouse0)&& !Input.GetKey(KeyCode.Mouse1))
-        {
-            Otter.Play("Crouch");
-            Sound.PickItem();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-            Destroy(OBJ.gameObject);
-        }
-        if ( OBJ.gameObject.CompareTag("Seed") || OBJ.gameObject.CompareTag("Apple") || OBJ.gameObject.CompareTag("GobletKey"))
-        {
-            Otter.Play("Crouch");
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-            Destroy(OBJ.gameObject);
-
-            if (OBJ.gameObject.CompareTag("Seed"))
-            {
-                Inventory.AddSeed();
-                Sound.PickItem();
-            }
-            if (OBJ.gameObject.CompareTag("Apple"))
-            {
-                Sound.PickUp2();
-                Inventory.AddApple();
-            }
-            if (OBJ.gameObject.CompareTag("GobletKey"))
-            {
-                Sound.PickUp2();
-                Inventory.AddGoblet();
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-                Destroy(OBJ.gameObject);
-            }
-
-        }
         if (OBJ.gameObject.CompareTag("Isle") || OBJ.gameObject.CompareTag("Bridge") || OBJ.gameObject.CompareTag("stairs") || OBJ.gameObject.CompareTag("Tile"))
         {
             FallClock = InitialFall;
@@ -353,50 +352,6 @@ public class Behaviour : MonoBehaviour, IDamageable
                     Player.drag = 0;
                 }
             }
-        }
-        if (OBJ.gameObject.CompareTag("Coin"))
-        {
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-            Sound.Coin();
-        }
-        if (arrowMunition<Arrows.Length && bowEquipped==true)
-        {
-            if (OBJ.gameObject.CompareTag("Arrow"))
-            {
-                Otter.Play("Crouch");
-                Sound.PickUp2();
-                arrowMunition++;
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-                if (bowEquipped == true)
-                {
-                    CountArrows();
-                }
-                Destroy(OBJ.gameObject);
-            }
-            if (OBJ.gameObject.CompareTag("ArrowBundle"))
-            {
-                Otter.Play("Crouch");
-                Sound.PickUp2();
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-                if (arrowMunition + 10 < Arrows.Length)
-                {
-                    arrowMunition += 10;
-                }
-                else
-                {
-                    for (int i = 0; i <(arrowMunition-10); i++)
-                    {
-                        Instantiate(ArrowPickup, OBJ.transform.position+new Vector3(0,i* 0.3f, 0), Quaternion.Euler(0,0,90));
-                    }
-                    arrowMunition = Arrows.Length;
-                }
-                if (bowEquipped == true)
-                {
-                    CountArrows();
-                }
-                Destroy(OBJ.gameObject);
-            }
-
         }
 
     }
@@ -410,56 +365,6 @@ public class Behaviour : MonoBehaviour, IDamageable
             OBJ.gameObject.CompareTag("Tile"))
         {
             grounded = true;
-        }
-        if (OBJ.gameObject.CompareTag("Weapon"))
-        {
-            Plattering = ("Hammers!");
-            ChangeSpeech = 1;
-            Otter.Play("Crouch");
-            Arsenal.Add("Hammers");
-            ArsenalCounter++;
-            Sound.PickItem();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-            Destroy(OBJ.gameObject);
-        }
-        if (OBJ.gameObject.CompareTag("Bow"))
-        {
-            Plattering = ("Booya!");
-            ChangeSpeech = 1;
-            Otter.Play("Crouch");
-            Arsenal.Add("Bow");
-            ArsenalCounter++;
-            Sound.PickItem();
-            arrowMunition = 5;
-            CountArrows();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-            Destroy(OBJ.gameObject);
-        }
-        if (OBJ.gameObject.CompareTag("Armor"))
-        {
-            Plattering = ("Oh my!");
-            ChangeSpeech = 1;
-            Otter.Play("Crouch");
-            Arsenal.Add("ArmorSet");
-            ArsenalCounter++;
-            Sound.PickItem();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-            Destroy(OBJ.gameObject);
-        }
-        if (OBJ.gameObject.CompareTag("Honey") && Honeypicked == false)
-        {
-            Otter.Play("Crouch");
-            HoneyON();
-            Sound.PickItem();
-            Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
-            Destroy(OBJ.gameObject);
-        }
-        if (OBJ.gameObject.CompareTag("Gold") && GoldPicked == false)
-        {
-            Otter.Play("Crouch");
-            GoldON();
-            Destroy(OBJ.gameObject);
-            
         }
         if (OBJ.gameObject.CompareTag("NPC") && isParried == true 
             || OBJ.gameObject.CompareTag("Scorpion") && isParried == true 
@@ -1279,6 +1184,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         Combat.Initialize(this);
         Movement.Initialize(this);
         Failure.Initialize(this);
+        Pickup.Initialize(this);
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
         TrySetTraderCameraEnabled(false);

--- a/Assets/Scripts/Player/PlayerPickupController.cs
+++ b/Assets/Scripts/Player/PlayerPickupController.cs
@@ -1,0 +1,273 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class PlayerPickupController : MonoBehaviour
+{
+    readonly HashSet<int> processedPickupIds = new HashSet<int>();
+    Behaviour owner;
+
+    public void Initialize(Behaviour behaviour)
+    {
+        owner = behaviour;
+    }
+
+    void Awake()
+    {
+        if (owner == null)
+        {
+            owner = GetComponent<Behaviour>();
+        }
+    }
+
+    void OnCollisionEnter(Collision collision)
+    {
+        TryProcessPickup(collision);
+    }
+
+    void OnCollisionStay(Collision collision)
+    {
+        TryProcessPickup(collision);
+    }
+
+    void TryProcessPickup(Collision collision)
+    {
+        if (owner == null || collision == null)
+        {
+            return;
+        }
+
+        GameObject pickup = collision.gameObject;
+        if (pickup == null || !pickup.activeInHierarchy)
+        {
+            return;
+        }
+
+        string tag = pickup.tag;
+        if (!IsPickupTag(tag))
+        {
+            return;
+        }
+
+        int id = pickup.GetInstanceID();
+        if (!processedPickupIds.Add(id))
+        {
+            return;
+        }
+
+        if (!HandlePickupByTag(pickup, tag))
+        {
+            processedPickupIds.Remove(id);
+        }
+    }
+
+    bool IsPickupTag(string tag)
+    {
+        switch (tag)
+        {
+            case "Part":
+            case "Seed":
+            case "Apple":
+            case "GobletKey":
+            case "Coin":
+            case "Arrow":
+            case "ArrowBundle":
+            case "Weapon":
+            case "Bow":
+            case "Armor":
+            case "Honey":
+            case "Gold":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    bool HandlePickupByTag(GameObject pickup, string tag)
+    {
+        switch (tag)
+        {
+            case "Part":
+                return TryPickupPart(pickup);
+            case "Seed":
+                PlayCrouchPickup(pickup);
+                owner.AddSeedPickup();
+                PlayPickItemSound();
+                Destroy(pickup);
+                return true;
+            case "Apple":
+                PlayCrouchPickup(pickup);
+                PlayPickup2Sound();
+                owner.AddApplePickup();
+                Destroy(pickup);
+                return true;
+            case "GobletKey":
+                PlayCrouchPickup(pickup);
+                PlayPickup2Sound();
+                owner.AddGobletPickup();
+                Destroy(pickup);
+                return true;
+            case "Coin":
+                owner.PlayPickupEffect(pickup.transform.position);
+                PlayCoinSound();
+                return true;
+            case "Arrow":
+                return TryPickupArrow(pickup);
+            case "ArrowBundle":
+                return TryPickupArrowBundle(pickup);
+            case "Weapon":
+                return PickupArsenalItem(pickup, "Hammers!", "Hammers", 0);
+            case "Bow":
+                return PickupArsenalItem(pickup, "Booya!", "Bow", 5);
+            case "Armor":
+                return PickupArsenalItem(pickup, "Oh my!", "ArmorSet", 0);
+            case "Honey":
+                return TryPickupHoney(pickup);
+            case "Gold":
+                return TryPickupGold(pickup);
+            default:
+                return false;
+        }
+    }
+
+    bool TryPickupPart(GameObject pickup)
+    {
+        if (owner.Load == null || !owner.Load.CanCarry || !owner.grounded || Input.GetKey(KeyCode.Mouse0) || Input.GetKey(KeyCode.Mouse1))
+        {
+            return false;
+        }
+
+        PlayCrouch();
+        PlayPickItemSound();
+        owner.PlayPickupEffect(pickup.transform.position);
+        Destroy(pickup);
+        return true;
+    }
+
+    bool TryPickupArrow(GameObject pickup)
+    {
+        if (!owner.CanCollectArrowPickup)
+        {
+            return false;
+        }
+
+        PlayCrouch();
+        PlayPickup2Sound();
+        owner.arrowMunition++;
+        owner.PlayPickupEffect(pickup.transform.position);
+        owner.CountArrows();
+        Destroy(pickup);
+        return true;
+    }
+
+    bool TryPickupArrowBundle(GameObject pickup)
+    {
+        if (!owner.CanCollectArrowPickup)
+        {
+            return false;
+        }
+
+        PlayCrouch();
+        PlayPickup2Sound();
+        owner.PlayPickupEffect(pickup.transform.position);
+        if (owner.arrowMunition + 10 < owner.ArrowCapacity)
+        {
+            owner.arrowMunition += 10;
+        }
+        else
+        {
+            for (int i = 0; i < (owner.arrowMunition - 10); i++)
+            {
+                Instantiate(owner.ArrowPickup, pickup.transform.position + new Vector3(0, i * 0.3f, 0), Quaternion.Euler(0, 0, 90));
+            }
+            owner.arrowMunition = owner.ArrowCapacity;
+        }
+        owner.CountArrows();
+        Destroy(pickup);
+        return true;
+    }
+
+    bool PickupArsenalItem(GameObject pickup, string message, string arsenalItem, int arrowsOnPickup)
+    {
+        owner.Plattering = message;
+        owner.ChangeSpeech = 1;
+        PlayCrouch();
+        owner.Arsenal.Add(arsenalItem);
+        owner.ArsenalCounter++;
+        PlayPickItemSound();
+        if (arrowsOnPickup > 0)
+        {
+            owner.arrowMunition = arrowsOnPickup;
+            owner.CountArrows();
+        }
+        owner.PlayPickupEffect(pickup.transform.position);
+        Destroy(pickup);
+        return true;
+    }
+
+    bool TryPickupHoney(GameObject pickup)
+    {
+        if (owner.Honeypicked)
+        {
+            return false;
+        }
+
+        PlayCrouch();
+        owner.HoneyON();
+        PlayPickItemSound();
+        owner.PlayPickupEffect(pickup.transform.position);
+        Destroy(pickup);
+        return true;
+    }
+
+    bool TryPickupGold(GameObject pickup)
+    {
+        if (owner.GoldPicked)
+        {
+            return false;
+        }
+
+        PlayCrouch();
+        owner.GoldON();
+        Destroy(pickup);
+        return true;
+    }
+
+    void PlayCrouchPickup(GameObject pickup)
+    {
+        PlayCrouch();
+        owner.PlayPickupEffect(pickup.transform.position);
+    }
+
+    void PlayCrouch()
+    {
+        if (owner.Otter != null)
+        {
+            owner.Otter.Play("Crouch");
+        }
+    }
+
+    void PlayPickItemSound()
+    {
+        if (owner.Sound != null)
+        {
+            owner.Sound.PickItem();
+        }
+    }
+
+    void PlayPickup2Sound()
+    {
+        if (owner.Sound != null)
+        {
+            owner.Sound.PickUp2();
+        }
+    }
+
+    void PlayCoinSound()
+    {
+        if (owner.Sound != null)
+        {
+            owner.Sound.Coin();
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerPickupController.cs.meta
+++ b/Assets/Scripts/Player/PlayerPickupController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e30d2d4b8194df4a8a857e708f9d410
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Reduce the legacy god-component `Behaviour` by extracting collision-based pickup/collection logic to a dedicated component to lower runtime responsibility and improve performance.
- Pickup logic currently executed inside `OnCollisionStay`/`OnCollisionEnter` caused repeated Instantiate/Destroy and duplicate inventory/VFX/sound processing under stay conditions.
- Keep `Behaviour` present and API-compatible so other systems that reference it keep working while we iteratively extract functionality.

### Description
- Added `Assets/Scripts/Player/PlayerPickupController.cs` that owns pickup processing for tags: `Part`, `Seed`, `Apple`, `GobletKey`, `Coin`, `Arrow`, `ArrowBundle`, `Weapon`, `Bow`, `Armor`, `Honey`, `Gold` and preserves existing VFX/sound/inventory semantics.
- Implemented deduplication guard using `HashSet<int> processedPickupIds` and active/null checks to prevent repeated processing from `OnCollisionStay` and repeated VFX/sound or duplicate inventory changes.
- Removed pickup branches from `Behaviour.OnCollisionEnter` and `Behaviour.OnCollisionStay`; added small, backward-compatible pickup helpers to `Behaviour` (`PlayPickupEffect`, `AddSeedPickup`, `AddApplePickup`, `AddGobletPickup`, `CanCollectArrowPickup`, `ArrowCapacity`) and lazily create/initialize `PlayerPickupController` from `Behaviour.Start`.
- No per-frame or per-physics `FindObjectOfType`/`GameObject.Find` introduced; pickup component uses the provided `Behaviour` reference and safe null/active guards; sound/effect calls are wrapped to be null-safe.

### Testing
- Ran repository reference searches to confirm `Behaviour` remains present and pickups moved: `rg` patterns for tags, `PlayerPickupController`, and `PlayPickupEffect`; search succeeded and shows removed branches from `Behaviour` and new controller usage.
- Ran `git diff --check`; no whitespace or diff errors reported.
- Verified modified files staged/committed locally; changes include `Assets/Scripts/Player/Behaviour.cs`, `Assets/Scripts/Player/PlayerPickupController.cs`, and its `.meta` file.
- Unity editor/compile/playmode validation could not be executed in this environment because the Unity CLI is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01766560b0832a8021129db11d5e23)