### PR TITLE
Add PlayerCameraZoneController and move House camera orbit handling out of Behaviour

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -184,6 +184,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     PlayerMovementController movementController;
     PlayerFailureController failureController;
     PlayerPickupController pickupController;
+    PlayerCameraZoneController cameraZoneController;
     bool wasGameplayBlocked;
 
     PlayerCameraReference GameplayCamera
@@ -343,6 +344,24 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
     }
 
+    PlayerCameraZoneController CameraZones
+    {
+        get
+        {
+            if (cameraZoneController == null)
+            {
+                cameraZoneController = GetComponent<PlayerCameraZoneController>();
+                if (cameraZoneController == null)
+                {
+                    cameraZoneController = gameObject.AddComponent<PlayerCameraZoneController>();
+                }
+                cameraZoneController.Initialize(this);
+            }
+
+            return cameraZoneController;
+        }
+    }
+
     public void ToggleParryCounterAttack() => WhichAttack = !WhichAttack;
     public void SetAppleModelActive(bool active) => appleOBJ.SetActive(active);
     public bool CanCollectArrowPickup => Arrows != null && arrowMunition < Arrows.Length && bowEquipped;
@@ -476,10 +495,7 @@ public class Behaviour : MonoBehaviour, IDamageable
                 TouchShroom = false;
         }
         TraderTriggers.HandleTriggerStay(OBJ);
-        if (OBJ.gameObject.CompareTag("House"))
-        {
-            TrySetFreeLookOrbits(FreeLook, 1f, 2f, 1f);
-        }
+        CameraZones.HandleTriggerStay(OBJ);
         if (OBJ.gameObject.CompareTag("What Is this?"))
         {
             Plattering = "Ah shit. what happened here?";
@@ -503,11 +519,7 @@ public class Behaviour : MonoBehaviour, IDamageable
             TouchShroom = false;
         }
         TraderTriggers.HandleTriggerExit(OBJ);
-        if (OBJ.gameObject.CompareTag("House"))
-        {
-            TrySetFreeLookOrbits(FreeLook, 4f, 6f, 5f);
-            //FreeLook.m_Lens.FieldOfView = 25;
-        }
+        CameraZones.HandleTriggerExit(OBJ);
         if (OBJ.gameObject.CompareTag("Scorpion"))
         {
             scorpAttack = false;
@@ -1033,6 +1045,10 @@ public class Behaviour : MonoBehaviour, IDamageable
         return valid;
     }
 
+    public void ApplyHouseCameraOrbits() => TrySetFreeLookOrbits(FreeLook, 1f, 2f, 1f);
+
+    public void RestoreDefaultCameraOrbits() => TrySetFreeLookOrbits(FreeLook, 4f, 6f, 5f);
+
     bool TrySetFreeLookOrbits(CinemachineFreeLook cam, float top, float mid, float bottom)
     {
         if (!WarnMissingCameraReference(cam, nameof(FreeLook)))
@@ -1169,6 +1185,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     void OnDisable()
     {
         SceneManager.sceneLoaded -= OnSceneLoaded;
+        cameraZoneController?.RestoreDefaultCameraOrbits();
     }
 
     void OnSceneLoaded(Scene scene, LoadSceneMode mode)
@@ -1192,6 +1209,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         Movement.Initialize(this);
         Failure.Initialize(this);
         Pickup.Initialize(this);
+        CameraZones.Initialize(this);
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
         TrySetTraderCameraEnabled(false);
@@ -1261,7 +1279,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         {
             Bow[i].SetActive(false);
         }
-        TrySetFreeLookOrbits(FreeLook, 4f, 6f, 5f);
+        RestoreDefaultCameraOrbits();
     }
     [System.Obsolete]
     public void Update()

--- a/Assets/Scripts/Player/PlayerCameraZoneController.cs
+++ b/Assets/Scripts/Player/PlayerCameraZoneController.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class PlayerCameraZoneController : MonoBehaviour
+{
+    readonly HashSet<Collider> activeHouseZones = new HashSet<Collider>();
+    Behaviour owner;
+
+    public bool IsInsideHouseCameraZone => activeHouseZones.Count > 0;
+
+    public void Initialize(Behaviour behaviour)
+    {
+        owner = behaviour;
+    }
+
+    public void HandleTriggerStay(Collider zoneCollider)
+    {
+        if (!IsHouseCameraZone(zoneCollider))
+        {
+            return;
+        }
+
+        if (activeHouseZones.Add(zoneCollider) && activeHouseZones.Count == 1)
+        {
+            owner?.ApplyHouseCameraOrbits();
+        }
+    }
+
+    public void HandleTriggerExit(Collider zoneCollider)
+    {
+        if (!activeHouseZones.Remove(zoneCollider) || activeHouseZones.Count > 0)
+        {
+            return;
+        }
+
+        owner?.RestoreDefaultCameraOrbits();
+    }
+
+    public void RestoreDefaultCameraOrbits()
+    {
+        if (!IsInsideHouseCameraZone)
+        {
+            return;
+        }
+
+        activeHouseZones.Clear();
+        owner?.RestoreDefaultCameraOrbits();
+    }
+
+    void OnDisable()
+    {
+        RestoreDefaultCameraOrbits();
+    }
+
+    static bool IsHouseCameraZone(Collider zoneCollider)
+    {
+        return zoneCollider != null && zoneCollider.gameObject.CompareTag("House");
+    }
+}

--- a/Assets/Scripts/Player/PlayerCameraZoneController.cs.meta
+++ b/Assets/Scripts/Player/PlayerCameraZoneController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76cb302b7bf44518b61ffe92eed7280c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Separate camera zone state from player logic so `House` camera zones are tracked independently of `Behaviour` trigger plumbing.
- Ensure close-orbit camera settings are applied only once on first enter/stay and default orbits are reliably restored on exit or when the controller is disabled.

### Description
- Add `Assets/Scripts/Player/PlayerCameraZoneController.cs` which tracks active `House` colliders, applies house orbits once on first stay, and restores defaults on exit/disable.
- Route `Behaviour.OnTriggerStay` / `Behaviour.OnTriggerExit` `House` handling through `CameraZones.HandleTriggerStay` and `CameraZones.HandleTriggerExit` instead of direct `CompareTag("House")` calls.
- Add `PlayerCameraZoneController CameraZones` lazy property in `Behaviour`, initialize it in `Start()`, and call `cameraZoneController?.RestoreDefaultCameraOrbits()` in `OnDisable()`.
- Expose public orbit wrappers on `Behaviour` as `ApplyHouseCameraOrbits()` and `RestoreDefaultCameraOrbits()` while preserving the existing `TrySetFreeLookOrbits(...)` implementation.

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019a8e58b4832aab409d688bf16742)