### PR TITLE
Extract Scorpion trigger handling to PlayerEnemyContactController

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -185,6 +185,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     PlayerFailureController failureController;
     PlayerPickupController pickupController;
     PlayerCameraZoneController cameraZoneController;
+    PlayerEnemyContactController enemyContactController;
     bool wasGameplayBlocked;
 
     PlayerCameraReference GameplayCamera
@@ -362,6 +363,24 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
     }
 
+    PlayerEnemyContactController EnemyContacts
+    {
+        get
+        {
+            if (enemyContactController == null)
+            {
+                enemyContactController = GetComponent<PlayerEnemyContactController>();
+                if (enemyContactController == null)
+                {
+                    enemyContactController = gameObject.AddComponent<PlayerEnemyContactController>();
+                }
+                enemyContactController.Initialize(this);
+            }
+
+            return enemyContactController;
+        }
+    }
+
     public void ToggleParryCounterAttack() => WhichAttack = !WhichAttack;
     public void SetAppleModelActive(bool active) => appleOBJ.SetActive(active);
     public bool CanCollectArrowPickup => Arrows != null && arrowMunition < Arrows.Length && bowEquipped;
@@ -376,6 +395,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     public void AddSeedPickup() => Inventory.AddSeed();
     public void AddApplePickup() => Inventory.AddApple();
     public void AddGobletPickup() => Inventory.AddGoblet();
+    public void SetScorpionContactAttacking(bool attacking) => scorpAttack = attacking;
 
     public void OnCollisionEnter(Collision OBJ)
     {
@@ -468,10 +488,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     }
     public void OnTriggerStay(Collider OBJ)
     {
-        if (OBJ.gameObject.CompareTag("Scorpion"))
-        {
-            scorpAttack = OBJ.gameObject.GetComponent<ScorpionScript>().isAttacking;
-        }
+        EnemyContacts.HandleTriggerStay(OBJ);
         if (OBJ.gameObject.CompareTag("Tile"))
         {
             OnPlatform = true;
@@ -520,10 +537,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
         TraderTriggers.HandleTriggerExit(OBJ);
         CameraZones.HandleTriggerExit(OBJ);
-        if (OBJ.gameObject.CompareTag("Scorpion"))
-        {
-            scorpAttack = false;
-        }
+        EnemyContacts.HandleTriggerExit(OBJ);
     }
     public void TakeDamage(float Damage) => TakeDamage(new DamageEvent { Amount = Damage, Source = null, Point = transform.position, Type = DamageType.Generic, CanStun = false });
     public void TakeDamage(DamageEvent damageEvent) => Health.TakeDamage(damageEvent.Amount);
@@ -1186,6 +1200,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     {
         SceneManager.sceneLoaded -= OnSceneLoaded;
         cameraZoneController?.RestoreDefaultCameraOrbits();
+        enemyContactController?.ClearScorpionContacts();
     }
 
     void OnSceneLoaded(Scene scene, LoadSceneMode mode)

--- a/Assets/Scripts/Player/PlayerEnemyContactController.cs
+++ b/Assets/Scripts/Player/PlayerEnemyContactController.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class PlayerEnemyContactController : MonoBehaviour
+{
+    readonly Dictionary<Collider, ScorpionScript> activeScorpionContacts = new Dictionary<Collider, ScorpionScript>();
+    Behaviour owner;
+
+    public void Initialize(Behaviour behaviour)
+    {
+        owner = behaviour;
+    }
+
+    public void HandleTriggerStay(Collider enemyCollider)
+    {
+        if (!IsScorpion(enemyCollider))
+        {
+            return;
+        }
+
+        if (!activeScorpionContacts.ContainsKey(enemyCollider))
+        {
+            activeScorpionContacts.Add(enemyCollider, enemyCollider.GetComponent<ScorpionScript>());
+        }
+
+        UpdateScorpionContactState();
+    }
+
+    public void HandleTriggerExit(Collider enemyCollider)
+    {
+        if (!IsScorpion(enemyCollider))
+        {
+            return;
+        }
+
+        activeScorpionContacts.Remove(enemyCollider);
+        UpdateScorpionContactState();
+    }
+
+    public void ClearScorpionContacts()
+    {
+        activeScorpionContacts.Clear();
+        owner?.SetScorpionContactAttacking(false);
+    }
+
+    void OnDisable()
+    {
+        ClearScorpionContacts();
+    }
+
+    void UpdateScorpionContactState()
+    {
+        var attacking = false;
+        foreach (var contact in activeScorpionContacts)
+        {
+            if (contact.Value != null && contact.Value.isAttacking)
+            {
+                attacking = true;
+                break;
+            }
+        }
+
+        owner?.SetScorpionContactAttacking(attacking);
+    }
+
+    static bool IsScorpion(Collider enemyCollider)
+    {
+        return enemyCollider != null && enemyCollider.gameObject.CompareTag("Scorpion");
+    }
+}

--- a/Assets/Scripts/Player/PlayerEnemyContactController.cs.meta
+++ b/Assets/Scripts/Player/PlayerEnemyContactController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6e2f93d512f4c36adaa7313f2aeb509
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Reduce per-frame `GetComponent<ScorpionScript>()` calls and centralize Scorpion contact logic outside of `Behaviour` to improve performance and clarity. 
- Correctly track multiple Scorpion colliders and their attack state so the player `scorpAttack` flag reflects any active attacker. 
- Ensure contact state is cleared on collider exit and when the player is disabled to avoid stale state.

### Description
- Added `Assets/Scripts/Player/PlayerEnemyContactController.cs` implementing a per-collider cache (`Dictionary<Collider, ScorpionScript>`), `Initialize`, `HandleTriggerStay`, `HandleTriggerExit`, `UpdateScorpionContactState`, and `ClearScorpionContacts`, and cleaning up in `OnDisable`.
- Updated `Assets/Scripts/Player/Behaviour.cs` to add an `enemyContactController` field and `EnemyContacts` accessor, introduced `SetScorpionContactAttacking(bool)` compatibility setter, routed former Scorpion trigger logic to `EnemyContacts.HandleTriggerStay/HandleTriggerExit`, and call `enemyContactController?.ClearScorpionContacts()` in `OnDisable`.
- Added corresponding `.meta` file for the new controller.

### Testing
- Ran `git diff --check` with no issues reported (success).
- Checked for Unity CLI with `command -v unity || command -v Unity || command -v unity-editor`, which returned no available Unity CLI in this environment (informational).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a1df0f1c832a8a37b2ac823e59f8)