### PR TITLE
Extract player platform/stairs trigger handling to PlayerPlatformController

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -186,6 +186,7 @@ public class Behaviour : MonoBehaviour, IDamageable
     PlayerPickupController pickupController;
     PlayerCameraZoneController cameraZoneController;
     PlayerEnemyContactController enemyContactController;
+    PlayerPlatformController platformController;
     bool wasGameplayBlocked;
 
     PlayerCameraReference GameplayCamera
@@ -381,6 +382,24 @@ public class Behaviour : MonoBehaviour, IDamageable
         }
     }
 
+    PlayerPlatformController Platforms
+    {
+        get
+        {
+            if (platformController == null)
+            {
+                platformController = GetComponent<PlayerPlatformController>();
+                if (platformController == null)
+                {
+                    platformController = gameObject.AddComponent<PlayerPlatformController>();
+                }
+                platformController.Initialize(this);
+            }
+
+            return platformController;
+        }
+    }
+
     public void ToggleParryCounterAttack() => WhichAttack = !WhichAttack;
     public void SetAppleModelActive(bool active) => appleOBJ.SetActive(active);
     public bool CanCollectArrowPickup => Arrows != null && arrowMunition < Arrows.Length && bowEquipped;
@@ -396,6 +415,18 @@ public class Behaviour : MonoBehaviour, IDamageable
     public void AddApplePickup() => Inventory.AddApple();
     public void AddGobletPickup() => Inventory.AddGoblet();
     public void SetScorpionContactAttacking(bool attacking) => scorpAttack = attacking;
+    public void SetOnPlatform(bool onPlatform) => OnPlatform = onPlatform;
+    public void SetStep(bool value) => step = value;
+    public void DetachFromPlatform()
+    {
+        if (Player == null)
+        {
+            return;
+        }
+
+        Player.transform.parent = null;
+        Player.transform.localScale = new(1, 1, 1);
+    }
 
     public void OnCollisionEnter(Collision OBJ)
     {
@@ -480,24 +511,10 @@ public class Behaviour : MonoBehaviour, IDamageable
         {
             Player.velocity += new Vector3(0, 1, 0);
         }
-        if (OBJ.gameObject.CompareTag("Tile"))
-        {   
-            Player.transform.SetParent(OBJ.gameObject.transform, true);
-            OnPlatform = true;
-        }
     }
     public void OnTriggerStay(Collider OBJ)
     {
         EnemyContacts.HandleTriggerStay(OBJ);
-        if (OBJ.gameObject.CompareTag("Tile"))
-        {
-            OnPlatform = true;
-            Player.transform.parent = OBJ.gameObject.transform;
-        }
-        if (OBJ.gameObject.CompareTag("stairs"))
-        {
-            step = true;
-        }
         if (OBJ.gameObject.CompareTag("Life"))
         {
             SaveCheckpoint(OBJ.transform.position);
@@ -520,17 +537,6 @@ public class Behaviour : MonoBehaviour, IDamageable
     }
     public void OnTriggerExit(Collider OBJ)
     {
-        if (OBJ.gameObject.CompareTag("stairs"))
-        {
-            step = false;
-        }
-        if (OBJ.gameObject.CompareTag("Tile"))
-        {
-            grounded = false;
-            OnPlatform = false;
-            Player.transform.parent = null;
-            Player.transform.localScale = new(1, 1, 1);
-        }
         if (OBJ.gameObject.CompareTag("Life"))
         {
             TouchShroom = false;
@@ -1201,6 +1207,9 @@ public class Behaviour : MonoBehaviour, IDamageable
         SceneManager.sceneLoaded -= OnSceneLoaded;
         cameraZoneController?.RestoreDefaultCameraOrbits();
         enemyContactController?.ClearScorpionContacts();
+        SetOnPlatform(false);
+        SetStep(false);
+        DetachFromPlatform();
     }
 
     void OnSceneLoaded(Scene scene, LoadSceneMode mode)
@@ -1225,6 +1234,7 @@ public class Behaviour : MonoBehaviour, IDamageable
         Failure.Initialize(this);
         Pickup.Initialize(this);
         CameraZones.Initialize(this);
+        Platforms.Initialize(this);
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
         TrySetTraderCameraEnabled(false);

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -1219,6 +1219,8 @@ public class Behaviour : MonoBehaviour, IDamageable
 
     public void Start()
     {
+        Platforms.Initialize(this);
+
         if (!ValidateStartReferences())
         {
             return;
@@ -1234,7 +1236,6 @@ public class Behaviour : MonoBehaviour, IDamageable
         Failure.Initialize(this);
         Pickup.Initialize(this);
         CameraZones.Initialize(this);
-        Platforms.Initialize(this);
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
         TrySetTraderCameraEnabled(false);

--- a/Assets/Scripts/Player/PlayerPlatformController.cs
+++ b/Assets/Scripts/Player/PlayerPlatformController.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class PlayerPlatformController : MonoBehaviour
+{
+    Behaviour owner;
+
+    public void Initialize(Behaviour behaviour)
+    {
+        owner = behaviour;
+    }
+
+    void OnTriggerEnter(Collider OBJ)
+    {
+        if (IsTile(OBJ))
+        {
+            AttachToPlatform(OBJ.transform);
+        }
+    }
+
+    void OnTriggerStay(Collider OBJ)
+    {
+        if (IsTile(OBJ))
+        {
+            AttachToPlatform(OBJ.transform);
+        }
+
+        if (IsStairs(OBJ))
+        {
+            owner?.SetStep(true);
+        }
+    }
+
+    void OnTriggerExit(Collider OBJ)
+    {
+        if (IsStairs(OBJ))
+        {
+            owner?.SetStep(false);
+        }
+
+        if (IsTile(OBJ) && owner != null)
+        {
+            owner.grounded = false;
+            owner.SetOnPlatform(false);
+            owner.DetachFromPlatform();
+        }
+    }
+
+    void OnDisable()
+    {
+        owner?.SetOnPlatform(false);
+        owner?.SetStep(false);
+        owner?.DetachFromPlatform();
+    }
+
+    void AttachToPlatform(Transform platform)
+    {
+        if (owner == null || owner.Player == null)
+        {
+            return;
+        }
+
+        owner.Player.transform.SetParent(platform, true);
+        owner.SetOnPlatform(true);
+    }
+
+    static bool IsTile(Collider OBJ)
+    {
+        return OBJ != null && OBJ.gameObject.CompareTag("Tile");
+    }
+
+    static bool IsStairs(Collider OBJ)
+    {
+        return OBJ != null && OBJ.gameObject.CompareTag("stairs");
+    }
+}

--- a/Assets/Scripts/Player/PlayerPlatformController.cs.meta
+++ b/Assets/Scripts/Player/PlayerPlatformController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20cf1b4f57034827a3b9dc52181ffadc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Separate platform parenting and stairs step state from the large `Behaviour` class to a focused controller for clarity and future movement extraction.  
- Provide a compatibility surface on `Behaviour` so existing code can query/update platform/step state without changing callers.  
- Ensure platform detach and local-scale restore happen on trigger exit and on disable while preserving jump-time unparent logic in `Behaviour`.

### Description
- Added `Assets/Scripts/Player/PlayerPlatformController.cs` implementing `OnTriggerEnter/Stay/Exit` and `OnDisable` to own `Tile` parenting and `stairs` step state.  
- Added `PlayerPlatformController Platforms` getter on `Behaviour` that `Initialize(this)` and lazy-adds the component.  
- Added `Behaviour` compatibility methods `SetOnPlatform(bool)`, `SetStep(bool)`, and `DetachFromPlatform()` and kept public `OnPlatform` and public field `grounded`.  
- Removed `Tile`/`stairs` handling from `Behaviour` trigger methods and call `Platforms.Initialize(this)` from `Start()`, and clear platform/step state plus call `DetachFromPlatform()` in `OnDisable()`.

### Testing
- Ran `git diff --check` to verify no whitespace/merge issues and it succeeded.  
- Ran a Python brace-count check on modified C# files to verify balanced braces and it succeeded.  
- Verified with grep/inspection that `Tile` and `stairs` handling was removed from `Behaviour` trigger blocks and moved to `PlayerPlatformController`, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a73d7a1c832a86f1147a9039ce29)