### PR TITLE
Clear trader trigger state after external exits

### DIFF
--- a/Assets/Scripts/Player/PlayerTraderTriggerController.cs
+++ b/Assets/Scripts/Player/PlayerTraderTriggerController.cs
@@ -26,14 +26,21 @@ public class PlayerTraderTriggerController : MonoBehaviour
         var skipPressed = trader.skipPressed;
         if (activeTrader == trader)
         {
-            if (!activeSkipPressed && skipPressed)
+            if (!owner.isAtTrader)
             {
-                ExitActiveTrader();
+                ClearActiveTraderState();
+            }
+            else
+            {
+                if (!activeSkipPressed && skipPressed)
+                {
+                    ExitActiveTrader();
+                    return;
+                }
+
+                activeSkipPressed = skipPressed;
                 return;
             }
-
-            activeSkipPressed = skipPressed;
-            return;
         }
 
         if (skipPressed)
@@ -78,9 +85,14 @@ public class PlayerTraderTriggerController : MonoBehaviour
             return;
         }
 
+        ClearActiveTraderState();
+        owner.ExitTraderInteraction();
+    }
+
+    void ClearActiveTraderState()
+    {
         activeTrader = null;
         activeCollider = null;
         activeSkipPressed = false;
-        owner.ExitTraderInteraction();
     }
 }


### PR DESCRIPTION
### Motivation
- Fix a race where external code paths can close a trader interaction (for example via dialogue cancelation) without going through the trigger exit path, leaving `PlayerTraderTriggerController`'s cached `activeTrader` set and preventing the same trigger from being re-entered until the collider is exited and re-entered.

### Description
- Update `PlayerTraderTriggerController.HandleTriggerStay` to check `owner.isAtTrader` when `activeTrader == trader` and clear the cached state if the owner is no longer marked at a trader so the same `OnTriggerStay` cycle can re-enter the interaction.
- Add a `ClearActiveTraderState()` helper and reuse it from `ExitActiveTrader()` to keep `activeTrader`, `activeCollider`, and `activeSkipPressed` reset logic consistent.
- Change is contained in `Assets/Scripts/Player/PlayerTraderTriggerController.cs` and does not alter public `Behaviour` APIs.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01946828d8832a91186f17288d9487)