### PR TITLE
Suppress trader re-entry after external close

### DIFF
--- a/Assets/Scripts/Player/PlayerTraderTriggerController.cs
+++ b/Assets/Scripts/Player/PlayerTraderTriggerController.cs
@@ -9,6 +9,8 @@ public class PlayerTraderTriggerController : MonoBehaviour
     Collider activeCollider;
     Trader activeTrader;
     bool activeSkipPressed;
+    Collider suppressedCollider;
+    Trader suppressedTrader;
 
     public void Initialize(Behaviour behaviour)
     {
@@ -24,11 +26,18 @@ public class PlayerTraderTriggerController : MonoBehaviour
         }
 
         var skipPressed = trader.skipPressed;
+        if (IsSuppressedTrader(traderCollider, trader))
+        {
+            return;
+        }
+
         if (activeTrader == trader)
         {
             if (!owner.isAtTrader)
             {
+                SuppressTraderUntilExit(traderCollider, trader);
                 ClearActiveTraderState();
+                return;
             }
             else
             {
@@ -56,9 +65,15 @@ public class PlayerTraderTriggerController : MonoBehaviour
 
     public void HandleTriggerExit(Collider traderCollider)
     {
-        if (activeCollider == traderCollider || activeTrader == ResolveTrader(traderCollider))
+        var trader = ResolveTrader(traderCollider);
+        if (activeCollider == traderCollider || activeTrader == trader)
         {
             ExitActiveTrader();
+        }
+
+        if (suppressedCollider == traderCollider || suppressedTrader == trader)
+        {
+            ClearSuppressedTraderState();
         }
     }
 
@@ -76,6 +91,24 @@ public class PlayerTraderTriggerController : MonoBehaviour
         }
 
         return cachedTrader;
+    }
+
+
+    bool IsSuppressedTrader(Collider traderCollider, Trader trader)
+    {
+        return suppressedCollider == traderCollider || suppressedTrader == trader;
+    }
+
+    void SuppressTraderUntilExit(Collider traderCollider, Trader trader)
+    {
+        suppressedCollider = traderCollider;
+        suppressedTrader = trader;
+    }
+
+    void ClearSuppressedTraderState()
+    {
+        suppressedCollider = null;
+        suppressedTrader = null;
     }
 
     void ExitActiveTrader()


### PR DESCRIPTION
### Motivation
- Prevent the trader UI from immediately re-opening when `owner.isAtTrader` is cleared externally while the player remains inside the same trader trigger. 
- Preserve a suppression state for the specific trader/collider until the player actually exits the trigger so the player can leave cleanly.

### Description
- Added `suppressedCollider` and `suppressedTrader` fields to remember a trader that was externally closed while the player is still inside its trigger. 
- Updated `HandleTriggerStay` to return early for suppressed traders via `IsSuppressedTrader` and to call `SuppressTraderUntilExit` (then `return`) when `activeTrader` was cleared externally. 
- Updated `HandleTriggerExit` to clear suppression when the matching collider/trader exits. 
- Added helper methods `IsSuppressedTrader`, `SuppressTraderUntilExit`, and `ClearSuppressedTraderState` to encapsulate the suppression logic.

### Testing
- Ran `git diff --check` and it reported no issues. 
- Checked for availability of the .NET/Unity toolchain (`dotnet`, `mcs`, `csc`, `unity`) and they were not available in this environment, so a full C# compile / playmode test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0201c2ca48832a9ac40e3b2af6adb4)