### PR TITLE
Extract PlayerCursorController from Behaviour

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -159,6 +159,7 @@ public class Behaviour : MonoBehaviour
     public GameObject AimIcon;
     public CinemachineFreeLook FreeLook;
     public CinemachineFreeLook CamForTraders;
+    [SerializeField] PlayerCursorController cursorController;
     public float ChangeSpeech = 1F;
 
     public void OnCollisionEnter(Collision OBJ)
@@ -654,18 +655,31 @@ public class Behaviour : MonoBehaviour
             i++;
         }
     }
+    PlayerCursorController CursorController
+    {
+        get
+        {
+            if (cursorController == null)
+            {
+                cursorController = GetComponent<PlayerCursorController>();
+            }
+
+            if (cursorController == null)
+            {
+                cursorController = gameObject.AddComponent<PlayerCursorController>();
+            }
+
+            cursorController.Bind(Root, FreeLook);
+            return cursorController;
+        }
+    }
     public void ShowCursor()
     {
-        //show mouse icon
-        Cursor.lockState = CursorLockMode.None;
-        Cursor.visible = true;
+        CursorController.ShowCursor();
     }
     public void HideCursor()
     {
-        //Lock and hide mouse icon
-        FreeLook.m_LookAt = Root;
-        Cursor.lockState = CursorLockMode.Locked;
-        Cursor.visible = false;
+        CursorController.HideCursor();
     }
     public void ActivateLooseMenu()
     {

--- a/Assets/Scripts/Player/Components.meta
+++ b/Assets/Scripts/Player/Components.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f1ce1ea32184dc98f4f4a9646779060
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Components/PlayerCursorController.cs
+++ b/Assets/Scripts/Player/Components/PlayerCursorController.cs
@@ -1,0 +1,31 @@
+using Cinemachine;
+using UnityEngine;
+
+public class PlayerCursorController : MonoBehaviour
+{
+    public Transform Root;
+    public CinemachineFreeLook FreeLook;
+
+    public void Bind(Transform root, CinemachineFreeLook freeLook)
+    {
+        Root = root;
+        FreeLook = freeLook;
+    }
+
+    public void ShowCursor()
+    {
+        Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
+    }
+
+    public void HideCursor()
+    {
+        if (FreeLook != null && Root != null)
+        {
+            FreeLook.m_LookAt = Root;
+        }
+
+        Cursor.lockState = CursorLockMode.Locked;
+        Cursor.visible = false;
+    }
+}

--- a/Assets/Scripts/Player/Components/PlayerCursorController.cs.meta
+++ b/Assets/Scripts/Player/Components/PlayerCursorController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d9b64c4ba774e059896d05ef00e287f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Separate cursor visibility/lock and `CinemachineFreeLook.m_LookAt` binding from the large `Behaviour` class to reduce responsibility while preserving `Behaviour` as the prefab-facing facade for compatibility.

### Description
- Added `Assets/Scripts/Player/Components/PlayerCursorController.cs` with `Bind(Transform,CinemachineFreeLook)`, `ShowCursor()` and `HideCursor()` to own cursor logic.
- Updated `Assets/Scripts/Player/Behaviour.cs` to declare `[SerializeField] PlayerCursorController cursorController`, add a lazy `CursorController` getter that `GetComponent`/`AddComponent` and calls `Bind(Root, FreeLook)`, and delegate `ShowCursor()`/`HideCursor()` to the new component.
- Added `Assets/Scripts/Player/Components/` folder meta files and committed the changes.

### Testing
- Ran `git diff --check` which produced no issues.
- Committed changes successfully (`git commit` completed).
- Play Mode verification was not run because the Unity editor executable is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022f601d04832a81f0c47e6b3b21d1)