### PR TITLE
Extract pause flow controller

### DIFF
--- a/Assets/Scripts/Core.meta
+++ b/Assets/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c9a659cfff94e9ca46142874f26965d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameFlow.meta
+++ b/Assets/Scripts/Core/GameFlow.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ef43d30d11b4987828210b11cd3639c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameFlow/PauseController.cs
+++ b/Assets/Scripts/Core/GameFlow/PauseController.cs
@@ -14,11 +14,8 @@ public class PauseController : MonoBehaviour
         this.question = question;
         this.player = player;
 
-        if (player != null)
-            player.HideCursor();
-
-        SetMenuVisible(false);
-        SetQuestionVisible(false);
+        ActivePause = false;
+        ApplyPauseState();
     }
 
     public void Pause()

--- a/Assets/Scripts/Core/GameFlow/PauseController.cs
+++ b/Assets/Scripts/Core/GameFlow/PauseController.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+
+public class PauseController : MonoBehaviour
+{
+    public bool ActivePause = false;
+
+    GameObject pauseMenu;
+    GameObject question;
+    Behaviour player;
+
+    public void Bind(GameObject pauseMenu, GameObject question, Behaviour player)
+    {
+        this.pauseMenu = pauseMenu;
+        this.question = question;
+        this.player = player;
+
+        if (player != null)
+            player.HideCursor();
+
+        SetMenuVisible(false);
+        SetQuestionVisible(false);
+    }
+
+    public void Pause()
+    {
+        ApplyPauseState();
+    }
+
+    public void HideQuestion()
+    {
+        SetQuestionVisible(false);
+    }
+
+    public void ChangeBolean()
+    {
+        ActivePause = !ActivePause;
+        ApplyPauseState();
+    }
+
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Escape))
+            ChangeBolean();
+    }
+
+    void ApplyPauseState()
+    {
+        if (ActivePause)
+        {
+            SetMenuVisible(true);
+            Time.timeScale = 0;
+
+            if (player != null)
+                player.ShowCursor();
+
+            return;
+        }
+
+        SetMenuVisible(false);
+        Time.timeScale = 1f;
+        SetQuestionVisible(false);
+
+        if (player != null && player.isAtTrader == false)
+            player.HideCursor();
+    }
+
+    void SetMenuVisible(bool visible)
+    {
+        if (pauseMenu != null)
+            pauseMenu.SetActive(visible);
+    }
+
+    void SetQuestionVisible(bool visible)
+    {
+        if (question != null)
+            question.SetActive(visible);
+    }
+}

--- a/Assets/Scripts/Core/GameFlow/PauseController.cs.meta
+++ b/Assets/Scripts/Core/GameFlow/PauseController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99bd4973b27a4ed18af19e86fc68c6ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
@@ -9,56 +7,51 @@ public class UIMenu : MonoBehaviour
     public GameObject PauseMenu;
     public GameObject Question;
     public Behaviour Player;
-    public bool ActivePause = false;
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
+
+    PauseController pauseController;
+
+    PauseController PauseController
+    {
+        get
+        {
+            if (pauseController == null)
+                pauseController = GetComponent<PauseController>();
+
+            if (pauseController == null)
+                pauseController = gameObject.AddComponent<PauseController>();
+
+            return pauseController;
+        }
+    }
 
     // Start is called before the first frame update
     private void Start()
     {
         Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
-        if (Player.seekMusic==true)
+        if (Player.seekMusic == true)
         {
             Music = GameObject.FindGameObjectWithTag("Music").GetComponent<AudioSource>();
         }
-        Player.HideCursor();
-        PauseMenu.SetActive(false);
-        Question.SetActive(false);
+
+        PauseController.Bind(PauseMenu, Question, Player);
     }
+
     public void Pause()
     {
-        if (Input.GetKeyDown(KeyCode.Escape))
-        {
-            ChangeBolean();
-        }
-
-        if (ActivePause == true)
-        {
-            PauseMenu.SetActive(true);
-            Time.timeScale = 0;
-            Player.ShowCursor();
-        }
-
-
-        if (ActivePause == false)
-        {
-            PauseMenu.SetActive(false);
-            Time.timeScale = 1f;
-            Question.SetActive(false);
-            if (Player.isAtTrader == false)
-                Player.HideCursor();
-        }
+        PauseController.Pause();
     }
 
     public void ChangeBolean()
     {
-        ActivePause = !ActivePause;
+        PauseController.ChangeBolean();
     }
 
     public void RestartCheckpointFromMenu()
     {
         Player.RestartCheckpoint();
-        Question.SetActive(false);
+        PauseController.HideQuestion();
     }
     public void QuitGame()
     {
@@ -72,15 +65,9 @@ public class UIMenu : MonoBehaviour
     public void Volume()
     {
         //AudioListener.volume = volumeSlider.value;
-        if (Player.seekMusic==true)
+        if (Player.seekMusic == true)
         {
             Music.volume = volumeSlider.value;
         }
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        Pause();
     }
 }


### PR DESCRIPTION
### Motivation
- Move pause ownership out of `UIMenu` so pause state, timescale, menu/question visibility, cursor calls, and Escape polling are centralized for clearer gameflow ownership.
- Keep `UIMenu` as the UI-facing MonoBehaviour so existing button bindings and public method signatures remain unchanged.
- Preserve current runtime behaviour: Escape toggles pause, pause sets `Time.timeScale = 0`, resume sets `Time.timeScale = 1`, and cursor stays visible while at trader.

### Description
- Added `Assets/Scripts/Core/GameFlow/PauseController.cs` which owns `ActivePause`, `Bind(...)`, `Pause()`, `ChangeBolean()`, `HideQuestion()`, Escape polling in `Update()`, `ApplyPauseState()` to set `Time.timeScale`, and menu/question visibility and cursor calls.
- Updated `Assets/Scripts/UI/UIMenu.cs` to remove pause state and polling, add a `PauseController` accessor, and delegate `Pause()`, `ChangeBolean()`, and hiding the question to the `PauseController` while preserving existing public method signatures.
- Created meta files for the new folders and the `PauseController` script (`Assets/Scripts/Core.meta`, `Assets/Scripts/Core/GameFlow.meta`, `Assets/Scripts/Core/GameFlow/PauseController.cs.meta`).
- Made minor whitespace/formatting consistency changes in `UIMenu.cs` only.

### Testing
- Ran `git diff --check` and it returned clean results (no whitespace errors). — passed.
- Searched project for Escape polling with `rg -n "KeyCode\.Escape|Escape" Assets/Scripts -g '*.cs'` to verify `Escape` is polled only in `PauseController`; results confirm single location. — passed.
- Verified pause-related symbols moved with `rg -n "public bool ActivePause|Time\.timeScale|SetActive\(|ShowCursor\(|HideCursor\(" Assets/Scripts/UI/UIMenu.cs Assets/Scripts/Core/GameFlow/PauseController.cs` to ensure ownership moved; results show expected locations. — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0230ff9b7c832a81282081ddd0e324)