### PR TITLE
Add Beavermania namespaces to PauseController and PlayerCursorController

### DIFF
--- a/Assets/Scripts/Core/GameFlow/PauseController.cs
+++ b/Assets/Scripts/Core/GameFlow/PauseController.cs
@@ -1,14 +1,16 @@
 using UnityEngine;
 
+namespace Beavermania.Core.GameFlow
+{
 public class PauseController : MonoBehaviour
 {
     public bool ActivePause = false;
 
     GameObject pauseMenu;
     GameObject question;
-    Behaviour player;
+    global::Behaviour player;
 
-    public void Bind(GameObject pauseMenu, GameObject question, Behaviour player)
+    public void Bind(GameObject pauseMenu, GameObject question, global::Behaviour player)
     {
         this.pauseMenu = pauseMenu;
         this.question = question;
@@ -72,4 +74,5 @@ public class PauseController : MonoBehaviour
         if (question != null)
             question.SetActive(visible);
     }
+}
 }

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Beavermania.Player;
 using Cinemachine;
 using Cinemachine.Utility;
 using UnityEngine;

--- a/Assets/Scripts/Player/Components/PlayerCursorController.cs
+++ b/Assets/Scripts/Player/Components/PlayerCursorController.cs
@@ -1,6 +1,8 @@
 using Cinemachine;
 using UnityEngine;
 
+namespace Beavermania.Player
+{
 public class PlayerCursorController : MonoBehaviour
 {
     public Transform Root;
@@ -28,4 +30,5 @@ public class PlayerCursorController : MonoBehaviour
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
     }
+}
 }

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -1,3 +1,4 @@
+using Beavermania.Core.GameFlow;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;


### PR DESCRIPTION
### Motivation
- Extract controller classes into the new namespace structure to start incremental namespacing during extraction while keeping legacy globals intact.
- Ensure existing global `Behaviour` usage remains functional when a controller moves to a namespace.

### Description
- Added `namespace Beavermania.Player` around `PlayerCursorController` in `Assets/Scripts/Player/Components/PlayerCursorController.cs`.
- Added `namespace Beavermania.Core.GameFlow` around `PauseController` in `Assets/Scripts/Core/GameFlow/PauseController.cs` and changed its `Bind` parameter type to `global::Behaviour` while storing the field as `global::Behaviour` for safe interop with the global class.
- Added `using Beavermania.Player;` to `Assets/Scripts/Player/Behaviour.cs` to allow the behaviour to reference the new namespaced component.
- Added `using Beavermania.Core.GameFlow;` to `Assets/Scripts/UI/UIMenu.cs` so `UIMenu` can reference the namespaced `PauseController`.

### Testing
- Ran `git diff --check` with no issues reported (success).
- Verified namespace and using changes with `rg "^(namespace Beavermania\.Player|namespace Beavermania\.Core\.GameFlow|using Beavermania\.Player;|using Beavermania\.Core\.GameFlow;)"` which matched the updated files (success).
- Committed changes; repository status shows the four modified files staged and committed (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0233b76ebc832aa4e7ff4265f7dc9d)