### PR TITLE
Extract PlayerCheckpointRespawn component

### DIFF
--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -161,6 +161,7 @@ public class Behaviour : MonoBehaviour
     public CinemachineFreeLook FreeLook;
     public CinemachineFreeLook CamForTraders;
     [SerializeField] PlayerCursorController cursorController;
+    [SerializeField] PlayerCheckpointRespawn checkpointRespawn;
     public float ChangeSpeech = 1F;
 
     public void OnCollisionEnter(Collision OBJ)
@@ -656,6 +657,8 @@ public class Behaviour : MonoBehaviour
             i++;
         }
     }
+    public GameObject CheckpointPopUpEffect => PopUpEffect;
+
     PlayerCursorController CursorController
     {
         get
@@ -696,13 +699,28 @@ public class Behaviour : MonoBehaviour
         HideCursor();
         LooseScreen.SetActive(false);
     }
+    PlayerCheckpointRespawn CheckpointRespawn
+    {
+        get
+        {
+            if (checkpointRespawn == null)
+            {
+                checkpointRespawn = GetComponent<PlayerCheckpointRespawn>();
+            }
+
+            if (checkpointRespawn == null)
+            {
+                checkpointRespawn = gameObject.AddComponent<PlayerCheckpointRespawn>();
+            }
+
+            checkpointRespawn.Bind(this);
+            return checkpointRespawn;
+        }
+    }
+
     public void RestartCheckpoint()
     {
-        HealthBar.SetHealth(MaxHealth);
-        CurrentHealth = MaxHealth;
-        transform.position = GM.lastCheckPointPos;
-        Instantiate(PopUpEffect, transform.position, Quaternion.identity);
-        Lives--;
+        CheckpointRespawn.RestartCheckpoint();
     }
     public void RestartGame()
     {

--- a/Assets/Scripts/Player/Components/PlayerCheckpointRespawn.cs
+++ b/Assets/Scripts/Player/Components/PlayerCheckpointRespawn.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+namespace Beavermania.Player
+{
+public class PlayerCheckpointRespawn : MonoBehaviour
+{
+    [SerializeField] global::Behaviour player;
+
+    public void Bind(global::Behaviour behaviour)
+    {
+        player = behaviour;
+    }
+
+    public void RestartCheckpoint()
+    {
+        if (player == null)
+        {
+            player = GetComponent<global::Behaviour>();
+        }
+
+        player.HealthBar.SetHealth(player.MaxHealth);
+        player.CurrentHealth = player.MaxHealth;
+        player.transform.position = player.GM.lastCheckPointPos;
+        Instantiate(player.CheckpointPopUpEffect, player.transform.position, Quaternion.identity);
+        player.Lives--;
+    }
+}
+}

--- a/Assets/Scripts/Player/Components/PlayerCheckpointRespawn.cs.meta
+++ b/Assets/Scripts/Player/Components/PlayerCheckpointRespawn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c1e08ca17c34c7d8b8bc69b1e997a72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Isolate checkpoint respawn responsibility from the large `Behaviour` class so the restart logic can be migrated and tested independently. 
- Preserve `Behaviour` as the prefab-bound facade and keep existing public fields/properties until prefab references are migrated.

### Description
- Add `Assets/Scripts/Player/Components/PlayerCheckpointRespawn.cs` with `Bind(Behaviour)` and `RestartCheckpoint()` that uses `Behaviour` fields (`GM`, `HealthBar`, `PopUpEffect`, `Lives`).
- Add `[SerializeField] PlayerCheckpointRespawn checkpointRespawn;` and `public GameObject CheckpointPopUpEffect => PopUpEffect;` to `Behaviour` for compatibility with existing prefab bindings.
- Add a lazy `CheckpointRespawn` accessor on `Behaviour` that creates/binds the component when needed and change `Behaviour.RestartCheckpoint()` to delegate to `CheckpointRespawn.RestartCheckpoint()`.

### Testing
- Ran `git diff --check` to validate whitespace/merge issues and it passed.
- Searched repository for new symbols with `rg -n "CheckpointPopUpEffect|PlayerCheckpointRespawn|RestartCheckpoint\(\)"` and verified references updated.
- Unity Play Mode verification was not run because the Unity editor binary is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02478d722c832ab5ae973b368f559a)