### PR TITLE
Move pause ownership into PauseController

### DIFF
--- a/Assets/Scripts/Core/GameFlow/PauseController.cs
+++ b/Assets/Scripts/Core/GameFlow/PauseController.cs
@@ -2,77 +2,82 @@ using UnityEngine;
 
 namespace Beavermania.Core.GameFlow
 {
-public class PauseController : MonoBehaviour
-{
-    public bool ActivePause = false;
-
-    GameObject pauseMenu;
-    GameObject question;
-    global::Behaviour player;
-
-    public void Bind(GameObject pauseMenu, GameObject question, global::Behaviour player)
+    public class PauseController : MonoBehaviour
     {
-        this.pauseMenu = pauseMenu;
-        this.question = question;
-        this.player = player;
+        public bool ActivePause = false;
 
-        ActivePause = false;
-        ApplyPauseState();
-    }
+        GameObject pauseMenu;
+        GameObject question;
+        global::Behaviour player;
 
-    public void Pause()
-    {
-        ApplyPauseState();
-    }
-
-    public void HideQuestion()
-    {
-        SetQuestionVisible(false);
-    }
-
-    public void ChangeBolean()
-    {
-        ActivePause = !ActivePause;
-        ApplyPauseState();
-    }
-
-    void Update()
-    {
-        if (Input.GetKeyDown(KeyCode.Escape))
-            ChangeBolean();
-    }
-
-    void ApplyPauseState()
-    {
-        if (ActivePause)
+        public void Bind(GameObject pauseMenu, GameObject question, global::Behaviour player)
         {
-            SetMenuVisible(true);
-            Time.timeScale = 0;
+            this.pauseMenu = pauseMenu;
+            this.question = question;
+            this.player = player;
 
-            if (player != null)
-                player.ShowCursor();
-
-            return;
+            ActivePause = false;
+            ApplyPauseState();
         }
 
-        SetMenuVisible(false);
-        Time.timeScale = 1f;
-        SetQuestionVisible(false);
+        public void Pause()
+        {
+            ApplyPauseState();
+        }
 
-        if (player != null && player.isAtTrader == false)
-            player.HideCursor();
-    }
+        public void HideQuestion()
+        {
+            SetQuestionVisible(false);
+        }
 
-    void SetMenuVisible(bool visible)
-    {
-        if (pauseMenu != null)
-            pauseMenu.SetActive(visible);
-    }
+        public void ChangeBolean()
+        {
+            SetPaused(!ActivePause);
+        }
 
-    void SetQuestionVisible(bool visible)
-    {
-        if (question != null)
-            question.SetActive(visible);
+        void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.Escape))
+                ChangeBolean();
+        }
+
+        void SetPaused(bool paused)
+        {
+            ActivePause = paused;
+            ApplyPauseState();
+        }
+
+        void ApplyPauseState()
+        {
+            if (ActivePause)
+            {
+                SetMenuVisible(true);
+                Time.timeScale = 0;
+
+                if (player != null)
+                    player.ShowCursor();
+
+                return;
+            }
+
+            SetMenuVisible(false);
+            Time.timeScale = 1f;
+            SetQuestionVisible(false);
+
+            if (player != null && player.isAtTrader == false)
+                player.HideCursor();
+        }
+
+        void SetMenuVisible(bool visible)
+        {
+            if (pauseMenu != null)
+                pauseMenu.SetActive(visible);
+        }
+
+        void SetQuestionVisible(bool visible)
+        {
+            if (question != null)
+                question.SetActive(visible);
+        }
     }
-}
 }


### PR DESCRIPTION
### Motivation
- Centralize pause responsibilities (pause flag, `Time.timeScale`, pause/question visibility, cursor show/hide, and Escape input) into a dedicated controller to keep `UIMenu` as a thin button-binding facade.
- Preserve existing UI-button method signatures and current runtime behavior (Escape toggles pause, pause -> `Time.timeScale = 0`, resume -> `Time.timeScale = 1`, cursor visible at trader).

### Description
- Added/refined `Assets/Scripts/Core/GameFlow/PauseController.cs` (namespace `Beavermania.Core.GameFlow`) implementing `Bind`, `SetPaused`, `ChangeBolean`, `ApplyPauseState`, and `Update` Escape polling.
- `PauseController` now owns `ActivePause`, menu/question visibility, `Time.timeScale`, and cursor calls (`player.ShowCursor()` / `player.HideCursor()`), and resets state on `Bind`.
- `UIMenu` remains a facade with original public methods delegating to `PauseController` and no inline pause logic changes to button signatures.

### Testing
- Ran `git diff --check` and it completed without reported issues.
- Searched for pause-related symbols with `rg -n "ActivePause|Time\.timeScale|PauseMenu\.SetActive|Question\.SetActive|ShowCursor\(|HideCursor\(|KeyCode\.Escape|void Update\(\)"` and verified occurrences are centralized in `PauseController`.
- Confirmed only one `KeyCode.Escape` poll via `rg -n "KeyCode\.Escape" Assets -g '*.cs'` which returned the `PauseController` occurrence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024cb0e098832a90a02e24953e52e7)