### PR TITLE
Low-risk NPC cleanup

### DIFF
--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -4,6 +4,14 @@ using UnityEngine;
 
 public class ScorpionScript : MonoBehaviour
 {
+    private const string StateIdle = "Idle";
+    private const string StateLook = "Look";
+    private const string StateCharge = "Charge";
+    private const string StateStop = "Stop";
+    private const string StateReverse = "Reverse";
+    private const string StateStunned = "Stunned";
+    private const string StateRecovered = "Recovered";
+
     [Header("General Stats")]
     Rigidbody RBScorpion;
     [SerializeField] Animator Scorpion;
@@ -29,7 +37,7 @@ public class ScorpionScript : MonoBehaviour
     public Collider Jaw2A;
     public Collider Jaw2B;
     public Collider Sting;
-    public string state = "Idle";
+    public string state = StateIdle;
 
     [Header("Mobility")]
     public float lookDistance;
@@ -69,17 +77,17 @@ public class ScorpionScript : MonoBehaviour
         currentDistance = Mathf.Abs(Distance.magnitude);
         switch (state)
         {
-            case "Idle":
+            case StateIdle:
                 {
                     Idle();
                     break;
                 }
-            case "Look":
+            case StateLook:
                 {
                     LookAtPlayer();
                     break;
                 }
-            case "Charge":
+            case StateCharge:
                 {
                     var speed = chargeSpeed;
                     if (Input.GetKey(KeyCode.LeftShift))
@@ -96,22 +104,22 @@ public class ScorpionScript : MonoBehaviour
                     Charge(speed);
                     break;
                 }
-            case "Stop":
+            case StateStop:
                 {
                     StopAndAttack();
                     break;
                 }
-            case "Reverse":
+            case StateReverse:
                 {
                     Reverse();
                     break;
                 }
-            case "Stunned":
+            case StateStunned:
                 {
                     Stunned();
                     break;
                 }
-            case "Recovered":
+            case StateRecovered:
                 {
                     Recovered();
                     break;
@@ -141,15 +149,15 @@ public class ScorpionScript : MonoBehaviour
         {
             if (combo==1)
             {
-                state = "Look";
+                state = StateLook;
             }
             if (combo==3)
             {
-                state = "Charge";
+                state = StateCharge;
             }
             if (currentDistance > lookDistance)
             {
-                state = "Idle";
+                state = StateIdle;
             }
             if(currentDistance <= lookDistance)
             {
@@ -159,11 +167,11 @@ public class ScorpionScript : MonoBehaviour
                     {
                         if (currentDistance<chargeDistance-10)
                         {
-                            state = "Reverse";
+                            state = StateReverse;
                         }
                         else
                         {
-                            state = "Look";
+                            state = StateLook;
                         }
                         
                     }
@@ -171,25 +179,25 @@ public class ScorpionScript : MonoBehaviour
                     {
                         if (currentDistance > chargeDistance)
                         {
-                            state = "Look";
+                            state = StateLook;
                         }
                         if (currentDistance <= chargeDistance)
                         {
 
                             if (chargeClock > 0)
                             {
-                                state = "Charge";
+                                state = StateCharge;
                                 chargeClock -= Time.deltaTime;
                             }
                             if (chargeClock <= 0)
                             {
                                 if (currentDistance > attackDistance)
                                 {
-                                    state = "Charge";
+                                    state = StateCharge;
                                 }
                                 else
                                 {
-                                    state = "Stop";
+                                    state = StateStop;
 
                                     if (Input.GetKeyUp(KeyCode.Mouse0) || Input.GetKeyUp(KeyCode.Mouse1))
                                     {
@@ -202,7 +210,7 @@ public class ScorpionScript : MonoBehaviour
                 }
                 else
                 {
-                    state = "Charge";
+                    state = StateCharge;
                 }
       
             }
@@ -211,11 +219,11 @@ public class ScorpionScript : MonoBehaviour
         }
         if (combo >= comboLimit)
         {
-            state = "Stunned";
+            state = StateStunned;
             StunnedClock -= Time.deltaTime;
             if (StunnedClock <= 0)
             {
-                state = "Recovered";
+                state = StateRecovered;
             }
         }
 

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -8,6 +8,8 @@ public class NPC_Basic : MonoBehaviour
     [Header("Body and animation")]
     public Rigidbody NPC;
     [SerializeField] Animator Wasp;
+    Collider npcCollider;
+
     [Header("Movement")]
     GameObject PlayerTarget;
     Behaviour PlayerHealth;
@@ -56,6 +58,7 @@ public class NPC_Basic : MonoBehaviour
     {
         SpawnPos = transform.position;
         Wasp = GetComponent<Animator>();
+        npcCollider = GetComponent<Collider>();
         CurrentHealth = MaxHealth;
         PlayerTarget = GameObject.FindGameObjectWithTag("Player");
         PlayerHealth = PlayerTarget.GetComponent<Behaviour>();
@@ -104,7 +107,7 @@ public class NPC_Basic : MonoBehaviour
                     {
                         BuzzSource.SetActive(true);
                         ChargeClock = 0.7f;
-                        Physics.IgnoreCollision(AnotherWasp.GetComponent<Collider>(), transform.GetComponent<Collider>());
+                        Physics.IgnoreCollision(AnotherWasp.GetComponent<Collider>(), npcCollider);
                         NPC.velocity = (Distance.normalized * 50f);
                         Wasp.SetBool("Sting", true);
                         ChangeNav = 0;
@@ -181,7 +184,7 @@ public class NPC_Basic : MonoBehaviour
                 Sting();
             }
             Contact = true;
-            if (OBJ.gameObject.GetComponent<Behaviour>().isParried== true)
+            if (PlayerHealth.isParried== true)
             {
                 TakeDamage(20);
                 combo += 10;
@@ -299,8 +302,8 @@ public class NPC_Basic : MonoBehaviour
         Wasp.SetBool("Beat", true);
         Wasp.SetBool("Sting", false);
         CurrentHealth -= Damage;
-        var playerArsenal = PlayerTarget.GetComponent<Behaviour>().Arsenal;
-        var currentWeapon = PlayerTarget.GetComponent<Behaviour>().arsenalBrowser;
+        var playerArsenal = PlayerHealth.Arsenal;
+        var currentWeapon = PlayerHealth.arsenalBrowser;
         switch (playerArsenal[currentWeapon])
         {
             case "Bare Hands":


### PR DESCRIPTION
### Motivation
- Reduce fragile string literals in the Scorpion state machine and eliminate repeated component lookups in the Wasp NPC to improve maintainability with minimal behavioral risk.

### Description
- Added private state constants and replaced all state switch/assign string literals in `Assets/Scripts/NPC/Scorpion/ScorpionScript.cs` with those constants without changing state logic or timing.
- Cached the wasp instance collider by adding `npcCollider = GetComponent<Collider>()` in `Assets/Scripts/NPC/Wasp/NPC_Basic.cs` and replaced `transform.GetComponent<Collider>()` uses with the cached field.
- Reused the existing `PlayerHealth` reference in `NPC_Basic` for `isParried` and arsenal lookups instead of calling `GetComponent<Behaviour>()` repeatedly.
- Changes limited to low-risk refactors only; movement/attack/stun/combo/animation semantics were not modified.

### Testing
- Ran `git diff --check` to ensure no whitespace/conflict markers and it passed.
- Verified with ripgrep that Scorpion state string literals were replaced and that `GetComponent<Behaviour>` usages in `NPC_Basic` were removed; the searches returned the expected results.
- Checked for Unity availability with `command -v unity` and it was not present, so runtime boss-fight validation (idle/chase/charge/attack/stun/damage/death) was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02a7d55d10832a9b6127c66c4cb57f)