### PR TITLE
Add PlayerInputReader and migrate PauseController to use it

### DIFF
--- a/Assets/Scripts/Core/GameFlow/PauseController.cs
+++ b/Assets/Scripts/Core/GameFlow/PauseController.cs
@@ -1,3 +1,4 @@
+using Beavermania.Core.Input;
 using UnityEngine;
 
 namespace Beavermania.Core.GameFlow
@@ -37,7 +38,7 @@ namespace Beavermania.Core.GameFlow
 
         void Update()
         {
-            if (Input.GetKeyDown(KeyCode.Escape))
+            if (PlayerInputReader.WasPausePressed())
                 ChangeBolean();
         }
 

--- a/Assets/Scripts/Core/Input/PlayerInputReader.cs
+++ b/Assets/Scripts/Core/Input/PlayerInputReader.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace Beavermania.Core.Input
+{
+    public static class PlayerInputReader
+    {
+        public static bool IsPrimaryHeld()
+        {
+            return UnityEngine.Input.GetKey(KeyCode.Mouse0);
+        }
+
+        public static bool IsSecondaryHeld()
+        {
+            return UnityEngine.Input.GetKey(KeyCode.Mouse1);
+        }
+
+        public static bool WasInteractPressed()
+        {
+            return UnityEngine.Input.GetKeyDown(KeyCode.Mouse1);
+        }
+
+        public static bool WasPausePressed()
+        {
+            return UnityEngine.Input.GetKeyDown(KeyCode.Escape);
+        }
+
+        public static bool IsSprintHeld()
+        {
+            return UnityEngine.Input.GetKey(KeyCode.LeftShift);
+        }
+
+        public static bool IsRollHeld()
+        {
+            return UnityEngine.Input.GetKey(KeyCode.LeftControl);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Input/PlayerInputReader.cs.meta
+++ b/Assets/Scripts/Core/Input/PlayerInputReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85da84c7191c4b60ab0add9089244848
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Introduce a centralized input abstraction for post-Steam migration to make per-script replacement incremental and explicit. 
- Provide the requested API surface with explicit methods: `IsPrimaryHeld`, `IsSecondaryHeld`, `WasInteractPressed`, `WasPausePressed`, `IsSprintHeld`, `IsRollHeld`. 
- Apply a minimal safe change to preserve existing key mappings and avoid altering bridge/interaction flow by only migrating the pause check for now. 

### Description
- Added `Assets/Scripts/Core/Input/PlayerInputReader.cs` implementing the six static methods that forward to `UnityEngine.Input` using the existing keys (mouse buttons, `Escape`, `LeftShift`, `LeftControl`).
- Updated `Assets/Scripts/Core/GameFlow/PauseController.cs` to use `PlayerInputReader.WasPausePressed()` and added `using Beavermania.Core.Input;`.
- Added `Assets/Scripts/Core/Input/PlayerInputReader.cs.meta` for Unity import metadata. 

### Testing
- Verified presence and references with ripgrep: `rg -n "static bool (IsPrimaryHeld|IsSecondaryHeld|WasInteractPressed|WasPausePressed|IsSprintHeld|IsRollHeld)\(|PlayerInputReader\.WasPausePressed\(|Input\.GetKeyDown\(KeyCode\.Escape\)" Assets/Scripts/Core Assets/Scripts -S`, which located the new API and the migrated `PauseController` reference. 
- Ran `git diff --check` to ensure no whitespace/index issues, which returned clean. 
- No automated compile/test suite was run in this patch; manual code-level checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f422b258832a8b93aed1ee6c0a4b)