### PR TITLE
Add PlayerHudState and bridge DebugReference to read HUD strings

### DIFF
--- a/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
+++ b/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
@@ -16012,6 +16012,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Player: {fileID: 0}
+  PlayerHudState: {fileID: 0}
   PlayerObjective: {fileID: 0}
   ObjectiveText: {fileID: 9220225752409644998}
   DisplayText: {fileID: 3664632416460160701}

--- a/Assets/Prefabs/OtterPlayer/Player Updated.prefab
+++ b/Assets/Prefabs/OtterPlayer/Player Updated.prefab
@@ -66564,6 +66564,7 @@ GameObject:
   - component: {fileID: 7370122799389070937}
   - component: {fileID: 8668838197977538417}
   - component: {fileID: 7624992565179513156}
+  - component: {fileID: 7624992565179513160}
   - component: {fileID: 7624992565179513157}
   - component: {fileID: 7624992565179513154}
   - component: {fileID: 8668838197977538418}
@@ -66838,6 +66839,28 @@ MonoBehaviour:
   FreeLook: {fileID: 1427810939599441655}
   CamForTraders: {fileID: 3156488547051756512}
   ChangeSpeech: 1
+--- !u!114 &7624992565179513160
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7624992565179513158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f356bc3e4f94e4ba9c5e178afeb4ff3, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  ObjectiveText:
+  DebugText:
+  StaminaText:
+  LogCount:
+  HealingText:
+  Wallet:
+  SeedText:
+  GobletText:
+  AppleText:
+  ArrowText:
 --- !u!114 &7624992565179513157
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Tutorial.unity
+++ b/Assets/Scenes/Tutorial.unity
@@ -23153,6 +23153,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Player: {fileID: 0}
+  PlayerHudState: {fileID: 0}
   PlayerObjective: {fileID: 0}
   ObjectiveText: {fileID: 8021354762553498431}
   DisplayText: {fileID: 2485461515819792964}

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -7,6 +7,7 @@ using Cinemachine.Utility;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
+[RequireComponent(typeof(PlayerHudState))]
 public class Behaviour : MonoBehaviour
 {
     [Header("Movement and animation")]

--- a/Assets/Scripts/Player/PlayerHudState.cs
+++ b/Assets/Scripts/Player/PlayerHudState.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class PlayerHudState : MonoBehaviour
+{
+    [Header("Objective")]
+    public string ObjectiveText;
+
+    [Header("Player HUD")]
+    public string DebugText;
+    public string StaminaText;
+    public string LogCount;
+    public string HealingText;
+    public string Wallet;
+    public string SeedText;
+    public string GobletText;
+    public string AppleText;
+    public string ArrowText;
+
+    public void CopyFrom(Behaviour player, ObjectiveUI objective)
+    {
+        if (objective != null)
+            ObjectiveText = objective.Instruction;
+
+        if (player == null)
+            return;
+
+        DebugText = player.DebugText;
+        StaminaText = player.StaminaText;
+        LogCount = player.LogCount;
+        HealingText = player.HealingText;
+        Wallet = player.Wallet;
+        SeedText = player.SeedText;
+        GobletText = player.GobletText;
+        AppleText = player.AppleText;
+        ArrowText = player.ArrowText;
+    }
+}

--- a/Assets/Scripts/Player/PlayerHudState.cs.meta
+++ b/Assets/Scripts/Player/PlayerHudState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f356bc3e4f94e4ba9c5e178afeb4ff3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 public class DebugReference : MonoBehaviour
 {
     public Behaviour Player;
+    public PlayerHudState PlayerHudState;
     public ObjectiveUI PlayerObjective;
 
     public TextMeshProUGUI ObjectiveText;
@@ -20,21 +21,40 @@ public class DebugReference : MonoBehaviour
     public TextMeshProUGUI ArrowMunition;
     private void Start()
     {
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
-        PlayerObjective = GameObject.FindGameObjectWithTag("Player").GetComponent<ObjectiveUI>();
+        BindPlayerHudState();
+    }
+
+    void BindPlayerHudState()
+    {
+        if (Player == null)
+            Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
+
+        if (PlayerHudState == null)
+            PlayerHudState = Player.GetComponent<PlayerHudState>();
+
+        if (PlayerHudState == null)
+            PlayerHudState = Player.gameObject.AddComponent<PlayerHudState>();
+
+        if (PlayerObjective == null)
+            PlayerObjective = Player.GetComponent<ObjectiveUI>();
     }
 
     void Update()
     {
-        ObjectiveText.text = PlayerObjective.Instruction;
-        DisplayText.text = Player.DebugText;
-        StaminaText.text = Player.StaminaText;
-        LogCountText.text = Player.LogCount;
-        CurrencyCount.text = Player.Wallet;
-        HealingDisplay.text = Player.HealingText;
-        SeedCount.text = Player.SeedText;
-        GobletCount.text = Player.GobletText;
-        AppleCount.text = Player.AppleText;
-        ArrowMunition.text = Player.ArrowText;
+        if (PlayerHudState == null)
+            BindPlayerHudState();
+
+        PlayerHudState.CopyFrom(Player, PlayerObjective);
+
+        ObjectiveText.text = PlayerHudState.ObjectiveText;
+        DisplayText.text = PlayerHudState.DebugText;
+        StaminaText.text = PlayerHudState.StaminaText;
+        LogCountText.text = PlayerHudState.LogCount;
+        CurrencyCount.text = PlayerHudState.Wallet;
+        HealingDisplay.text = PlayerHudState.HealingText;
+        SeedCount.text = PlayerHudState.SeedText;
+        GobletCount.text = PlayerHudState.GobletText;
+        AppleCount.text = PlayerHudState.AppleText;
+        ArrowMunition.text = PlayerHudState.ArrowText;
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce a small serializable component to host formatted HUD strings so UI consumers can read from a single source without changing existing Behaviour producers. 
- Keep `DebugReference` assigned in-scene and preserve inspector-visible field names for designers while avoiding event-driven refactors before Steam.

### Description
- Add `PlayerHudState` component with public inspector-visible fields for `ObjectiveText`, `DebugText`, `StaminaText`, `LogCount`, `HealingText`, `Wallet`, `SeedText`, `GobletText`, `AppleText`, and `ArrowText` and a `CopyFrom(Behaviour, ObjectiveUI)` helper. (new: `Assets/Scripts/Player/PlayerHudState.cs`)
- Require `PlayerHudState` on the player `Behaviour` via `[RequireComponent(typeof(PlayerHudState))]` so the component is colocated with the player. (`Assets/Scripts/Player/Behaviour.cs`)
- Update `DebugReference` to bind to a `PlayerHudState` instance (falling back to `AddComponent` if missing) and to read all HUD strings from `PlayerHudState` while still keeping `Player` and `PlayerObjective` serialized on the inspector. (`Assets/Scripts/UI/DebugReference.cs`)
- Add `PlayerHudState` entries next to `Behaviour` on the player prefab and surface the `PlayerHudState` field on existing UI prefab/scene instances so references remain visible in the inspector. (`Assets/Prefabs/OtterPlayer/Player Updated.prefab`, `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`, `Assets/Scenes/Tutorial.unity`)

### Testing
- Ran automated content checks to confirm `DebugReference` now reads: health text, stamina text, coins, nuts, apples, goblets, arrows, and objective text from `PlayerHudState` (success).
- Verified `PlayerHudState` exposes the required public fields in the source file (success).
- Executed `git diff --check` style validation and pattern checks for the new bindings (no errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02feaefbac832ab8809373703770e5)