### PR TITLE
Add serialized UI dependency fallbacks

### DIFF
--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -5,9 +5,9 @@ using TMPro;
 using UnityEngine.UI;
 public class DebugReference : MonoBehaviour
 {
-    public Behaviour Player;
-    public PlayerHudState PlayerHudState;
-    public ObjectiveUI PlayerObjective;
+    [SerializeField] public Behaviour Player;
+    [SerializeField] public PlayerHudState PlayerHudState;
+    [SerializeField] public ObjectiveUI PlayerObjective;
 
     public TextMeshProUGUI ObjectiveText;
     public TextMeshProUGUI DisplayText;
@@ -19,6 +19,10 @@ public class DebugReference : MonoBehaviour
     public TextMeshProUGUI GobletCount;
     public TextMeshProUGUI AppleCount;
     public TextMeshProUGUI ArrowMunition;
+
+    bool loggedMissingPlayer;
+    bool loggedMissingPlayerObjective;
+
     private void Start()
     {
         BindPlayerHudState();
@@ -27,7 +31,17 @@ public class DebugReference : MonoBehaviour
     void BindPlayerHudState()
     {
         if (Player == null)
-            Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
+        {
+            GameObject playerObject = GameObject.FindGameObjectWithTag("Player");
+            if (playerObject != null)
+                Player = playerObject.GetComponent<Behaviour>();
+
+            if (Player == null)
+            {
+                LogMissingReference(nameof(Player), ref loggedMissingPlayer);
+                return;
+            }
+        }
 
         if (PlayerHudState == null)
             PlayerHudState = Player.GetComponent<PlayerHudState>();
@@ -37,12 +51,18 @@ public class DebugReference : MonoBehaviour
 
         if (PlayerObjective == null)
             PlayerObjective = Player.GetComponent<ObjectiveUI>();
+
+        if (PlayerObjective == null)
+            LogMissingReference(nameof(PlayerObjective), ref loggedMissingPlayerObjective);
     }
 
     void Update()
     {
         if (PlayerHudState == null)
             BindPlayerHudState();
+
+        if (PlayerHudState == null)
+            return;
 
         PlayerHudState.CopyFrom(Player, PlayerObjective);
 
@@ -56,5 +76,16 @@ public class DebugReference : MonoBehaviour
         GobletCount.text = PlayerHudState.GobletText;
         AppleCount.text = PlayerHudState.AppleText;
         ArrowMunition.text = PlayerHudState.ArrowText;
+    }
+
+    void LogMissingReference(string referenceName, ref bool logged)
+    {
+        if (logged)
+            return;
+
+        logged = true;
+#if DEVELOPMENT_BUILD
+        Debug.LogWarning($"{nameof(DebugReference)} could not resolve {referenceName} fallback.", this);
+#endif
     }
 }

--- a/Assets/Scripts/UI/Dialogue.cs
+++ b/Assets/Scripts/UI/Dialogue.cs
@@ -4,9 +4,9 @@ using UnityEngine;
 using TMPro;
 public class Dialogue : MonoBehaviour
 {
-    public Behaviour Player;
+    [SerializeField] public Behaviour Player;
     public ScorpionScript Scorpion;
-    public ObjectiveUI PlayerObjective;
+    [SerializeField] public ObjectiveUI PlayerObjective;
     public TextMeshProUGUI textComponent;
     public GameObject ContinueButton;
     public GameObject SkipButton;
@@ -19,9 +19,26 @@ public class Dialogue : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
+        if (Player == null || PlayerObjective == null)
+        {
+            GameObject playerObject = GameObject.FindGameObjectWithTag("Player");
+            if (playerObject != null)
+            {
+                if (Player == null)
+                    Player = playerObject.GetComponent<Behaviour>();
+
+                if (PlayerObjective == null)
+                    PlayerObjective = playerObject.GetComponent<ObjectiveUI>();
+            }
+
+            if (Player == null)
+                LogMissingReference(nameof(Player));
+
+            if (PlayerObjective == null)
+                LogMissingReference(nameof(PlayerObjective));
+        }
+
         //Boss = GameObject.FindGameObjectWithTag("Boss").GetComponent<BossScript>();
-        PlayerObjective = GameObject.FindGameObjectWithTag("Player").GetComponent<ObjectiveUI>();
         panel = gameObject.transform.parent.GetComponent<Transform>();
         SkipButton.SetActive(true);
         textComponent.text = string.Empty;
@@ -74,7 +91,9 @@ public class Dialogue : MonoBehaviour
 
     public void EndConversation()
     {
-        PlayerObjective.UpdateObjective();
+        if (PlayerObjective != null)
+            PlayerObjective.UpdateObjective();
+
         if (isBoss==true)
         {
             EndBossDialogue();
@@ -87,8 +106,18 @@ public class Dialogue : MonoBehaviour
 
     public void EndBossDialogue()
     {
-        PlayerObjective.UpdateObjective();
-        Player.GetComponent<BossHandler>().SkipBossChat();
+        if (PlayerObjective != null)
+            PlayerObjective.UpdateObjective();
+
+        if (Player != null)
+            Player.GetComponent<BossHandler>().SkipBossChat();
         //Scorpion.InitiateCharge();
+    }
+
+    void LogMissingReference(string referenceName)
+    {
+#if DEVELOPMENT_BUILD
+        Debug.LogWarning($"{nameof(Dialogue)} could not resolve {referenceName} fallback.", this);
+#endif
     }
 }

--- a/Assets/Scripts/UI/Dialogue.cs
+++ b/Assets/Scripts/UI/Dialogue.cs
@@ -19,6 +19,9 @@ public class Dialogue : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        if (PlayerObjective == null && Player != null)
+            PlayerObjective = Player.GetComponent<ObjectiveUI>();
+
         if (Player == null || PlayerObjective == null)
         {
             GameObject playerObject = GameObject.FindGameObjectWithTag("Player");

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -7,7 +7,7 @@ public class UIMenu : MonoBehaviour
 {
     public GameObject PauseMenu;
     public GameObject Question;
-    public Behaviour Player;
+    [SerializeField] public Behaviour Player;
     [SerializeField] Slider volumeSlider;
     [SerializeField] AudioSource Music;
 
@@ -30,10 +30,24 @@ public class UIMenu : MonoBehaviour
     // Start is called before the first frame update
     private void Start()
     {
-        Player = GameObject.FindGameObjectWithTag("Player").GetComponent<Behaviour>();
-        if (Player.seekMusic == true)
+        if (Player == null)
         {
-            Music = GameObject.FindGameObjectWithTag("Music").GetComponent<AudioSource>();
+            GameObject playerObject = GameObject.FindGameObjectWithTag("Player");
+            if (playerObject != null)
+                Player = playerObject.GetComponent<Behaviour>();
+
+            if (Player == null)
+                LogMissingReference(nameof(Player));
+        }
+
+        if (Player != null && Player.seekMusic == true && Music == null)
+        {
+            GameObject musicObject = GameObject.FindGameObjectWithTag("Music");
+            if (musicObject != null)
+                Music = musicObject.GetComponent<AudioSource>();
+
+            if (Music == null)
+                LogMissingReference(nameof(Music));
         }
 
         PauseController.Bind(PauseMenu, Question, Player);
@@ -51,6 +65,9 @@ public class UIMenu : MonoBehaviour
 
     public void RestartCheckpointFromMenu()
     {
+        if (Player == null)
+            return;
+
         Player.RestartCheckpoint();
         PauseController.HideQuestion();
     }
@@ -66,9 +83,16 @@ public class UIMenu : MonoBehaviour
     public void Volume()
     {
         //AudioListener.volume = volumeSlider.value;
-        if (Player.seekMusic == true)
+        if (Player != null && Player.seekMusic == true && Music != null)
         {
             Music.volume = volumeSlider.value;
         }
+    }
+
+    void LogMissingReference(string referenceName)
+    {
+#if DEVELOPMENT_BUILD
+        Debug.LogWarning($"{nameof(UIMenu)} could not resolve {referenceName} fallback.", this);
+#endif
     }
 }


### PR DESCRIPTION
### Motivation
- Start introducing explicit serialized dependencies for low-risk UI scripts to enable inspector wiring while preserving existing `Find` fallbacks.  
- Prevent null-dereference crashes during scene load by guarding the fallback path and returning early when resolution fails.  
- Surface missing bindings only in development builds to aid debugging without polluting release logs.  
- Defer intrusive DI changes for boss/enemy/player systems until after Steam integration as requested.

### Description
- Added `[SerializeField]` inspector fields for `Player`, `PlayerHudState`, and `PlayerObjective` in `Assets/Scripts/UI/DebugReference.cs`, `Assets/Scripts/UI/UIMenu.cs`, and `Assets/Scripts/UI/Dialogue.cs`.  
- Preserved existing `GameObject.FindGameObjectWithTag("Player")` and `Find` fallback logic but wrapped it with null checks and early returns to avoid NREs.  
- Added per-script `LogMissingReference` helpers that emit a single `Debug.LogWarning` only under `DEVELOPMENT_BUILD`.  
- Hardened `UIMenu` to safely resolve `Music` and guard `RestartCheckpointFromMenu` and `Volume` calls with null checks.  
- Introduced a one-time logged-flag in `DebugReference` to avoid repeated warnings.

### Testing
- Ran `rg` searches to confirm `Find` usage in the touched files is now guarded and limited to the fallback paths (succeeded).  
- Ran `git diff --check` to validate no whitespace/merge issues (succeeded).  
- Ran a Python check to verify `Assets/Scenes/Menu.unity` and `Assets/Scenes/Level 1.unity` are present in `EditorBuildSettings.asset` (succeeded).  
- Attempted to run Unity Play Mode tests via `Unity -batchmode -runTests` but the Unity editor executable is unavailable in this environment (Play Mode validation skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a030672f1fc832a8c6d67c6039dbe7a)