### PR TITLE
Migrate Grow input to PlayerInputReader

### DIFF
--- a/Assets/Scripts/Objects/Trees and Logs/Grow.cs
+++ b/Assets/Scripts/Objects/Trees and Logs/Grow.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Beavermania.Core.Input;
 using UnityEngine;
 
 public class Grow : MonoBehaviour
@@ -36,7 +37,7 @@ public class Grow : MonoBehaviour
     {
         if (OBJ.gameObject.tag == "Player")
         {
-            if (Input.GetKey(KeyCode.Mouse0))
+            if (PlayerInputReader.IsPrimaryHeld())
             {
                 Instantiate(Log1, transform.position, Quaternion.identity);
                 Instantiate(Log2, transform.position, Quaternion.identity);


### PR DESCRIPTION
### Motivation
- Consolidate direct input polling into the centralized `Beavermania.Core.Input.PlayerInputReader` to prepare for upcoming input mapping changes.

### Description
- Replaced `Input.GetKey(KeyCode.Mouse0)` with `PlayerInputReader.IsPrimaryHeld()` in `Assets/Scripts/Objects/Trees and Logs/Grow.cs` and added `using Beavermania.Core.Input;`.

### Testing
- Ran `git diff --check` and `rg "Input\.GetKey\(KeyCode\.Mouse0\)" 'Assets/Scripts/Objects/Trees and Logs/Grow.cs'`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033cef3c40832ab271b95488728d47)