### PR TITLE
Route debug HUD through PlayerHudState

### DIFF
--- a/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
+++ b/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
@@ -16013,7 +16013,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Player: {fileID: 0}
   PlayerHudState: {fileID: 0}
-  PlayerObjective: {fileID: 0}
   ObjectiveText: {fileID: 9220225752409644998}
   DisplayText: {fileID: 3664632416460160701}
   StaminaText: {fileID: 702658506274280216}

--- a/Assets/Prefabs/OtterPlayer/Player Updated.prefab
+++ b/Assets/Prefabs/OtterPlayer/Player Updated.prefab
@@ -66836,6 +66836,8 @@ MonoBehaviour:
   Wallet: 
   GM: {fileID: 0}
   AimIcon: {fileID: 0}
+  PlayerHudState: {fileID: 7624992565179513160}
+  PlayerObjective: {fileID: 7370122799389070937}
   FreeLook: {fileID: 1427810939599441655}
   CamForTraders: {fileID: 3156488547051756512}
   ChangeSpeech: 1

--- a/Assets/Scenes/Tutorial.unity
+++ b/Assets/Scenes/Tutorial.unity
@@ -23154,7 +23154,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Player: {fileID: 0}
   PlayerHudState: {fileID: 0}
-  PlayerObjective: {fileID: 0}
   ObjectiveText: {fileID: 8021354762553498431}
   DisplayText: {fileID: 2485461515819792964}
   StaminaText: {fileID: 1829897275854821345}

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -161,6 +161,7 @@ public class Behaviour : MonoBehaviour
     public GameObject AimIcon;
     public PlayerHudState PlayerHudState;
     public ObjectiveUI PlayerObjective;
+    bool loggedRuntimeHudStateFallback;
     public CinemachineFreeLook FreeLook;
     public CinemachineFreeLook CamForTraders;
     [SerializeField] PlayerCursorController cursorController;
@@ -1729,8 +1730,23 @@ public class Behaviour : MonoBehaviour
         if (PlayerHudState == null)
             PlayerHudState = GetComponent<PlayerHudState>();
 
+        if (PlayerHudState == null)
+        {
+            PlayerHudState = gameObject.AddComponent<PlayerHudState>();
+            LogHudStateFallback();
+        }
+
         if (PlayerObjective == null)
             PlayerObjective = GetComponent<ObjectiveUI>();
+    }
+
+    void LogHudStateFallback()
+    {
+        if (loggedRuntimeHudStateFallback)
+            return;
+
+        loggedRuntimeHudStateFallback = true;
+        Debug.LogWarning($"{nameof(Behaviour)} added a missing {nameof(PlayerHudState)} component to {name} at runtime so HUD text can update.", this);
     }
 
     void SyncHudState()

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -159,6 +159,8 @@ public class Behaviour : MonoBehaviour
     public string Wallet;
     public GameMaster GM;
     public GameObject AimIcon;
+    public PlayerHudState PlayerHudState;
+    public ObjectiveUI PlayerObjective;
     public CinemachineFreeLook FreeLook;
     public CinemachineFreeLook CamForTraders;
     [SerializeField] PlayerCursorController cursorController;
@@ -808,6 +810,7 @@ public class Behaviour : MonoBehaviour
     }
     public void Start()
     {
+        BindHudState();
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
         CamForTraders.enabled = false;
@@ -870,6 +873,7 @@ public class Behaviour : MonoBehaviour
         FreeLook.m_Orbits[0].m_Radius = 4;
         FreeLook.m_Orbits[1].m_Radius = 6;
         FreeLook.m_Orbits[2].m_Radius = 5;
+        SyncHudState();
     }
     [System.Obsolete]
     public void Update()
@@ -1717,6 +1721,25 @@ public class Behaviour : MonoBehaviour
             }
         }
 
+        SyncHudState();
+    }
+
+    void BindHudState()
+    {
+        if (PlayerHudState == null)
+            PlayerHudState = GetComponent<PlayerHudState>();
+
+        if (PlayerObjective == null)
+            PlayerObjective = GetComponent<ObjectiveUI>();
+    }
+
+    void SyncHudState()
+    {
+        if (PlayerHudState == null)
+            BindHudState();
+
+        if (PlayerHudState != null)
+            PlayerHudState.CopyFrom(this, PlayerObjective);
     }
 }
 

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -43,7 +43,11 @@ public class DebugReference : MonoBehaviour
             PlayerHudState = Player.GetComponent<PlayerHudState>();
 
         if (PlayerHudState == null)
-            LogMissingReference(nameof(PlayerHudState), ref loggedMissingPlayerHudState);
+        {
+            PlayerHudState = Player.gameObject.AddComponent<PlayerHudState>();
+            PlayerHudState.CopyFrom(Player, Player.GetComponent<ObjectiveUI>());
+            LogHudStateFallback();
+        }
     }
 
     void Update()
@@ -81,5 +85,14 @@ public class DebugReference : MonoBehaviour
 #if DEVELOPMENT_BUILD
         Debug.LogWarning($"{nameof(DebugReference)} could not resolve {referenceName} fallback.", this);
 #endif
+    }
+
+    void LogHudStateFallback()
+    {
+        if (loggedMissingPlayerHudState)
+            return;
+
+        loggedMissingPlayerHudState = true;
+        Debug.LogWarning($"{nameof(DebugReference)} added a missing {nameof(PlayerHudState)} component to {Player.name} at runtime so HUD text can update.", this);
     }
 }

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -1,13 +1,9 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
-using UnityEngine.UI;
 public class DebugReference : MonoBehaviour
 {
     [SerializeField] public Behaviour Player;
     [SerializeField] public PlayerHudState PlayerHudState;
-    [SerializeField] public ObjectiveUI PlayerObjective;
 
     public TextMeshProUGUI ObjectiveText;
     public TextMeshProUGUI DisplayText;
@@ -21,9 +17,9 @@ public class DebugReference : MonoBehaviour
     public TextMeshProUGUI ArrowMunition;
 
     bool loggedMissingPlayer;
-    bool loggedMissingPlayerObjective;
+    bool loggedMissingPlayerHudState;
 
-    private void Start()
+    void Start()
     {
         BindPlayerHudState();
     }
@@ -47,13 +43,7 @@ public class DebugReference : MonoBehaviour
             PlayerHudState = Player.GetComponent<PlayerHudState>();
 
         if (PlayerHudState == null)
-            PlayerHudState = Player.gameObject.AddComponent<PlayerHudState>();
-
-        if (PlayerObjective == null)
-            PlayerObjective = Player.GetComponent<ObjectiveUI>();
-
-        if (PlayerObjective == null)
-            LogMissingReference(nameof(PlayerObjective), ref loggedMissingPlayerObjective);
+            LogMissingReference(nameof(PlayerHudState), ref loggedMissingPlayerHudState);
     }
 
     void Update()
@@ -64,18 +54,22 @@ public class DebugReference : MonoBehaviour
         if (PlayerHudState == null)
             return;
 
-        PlayerHudState.CopyFrom(Player, PlayerObjective);
+        SetText(ObjectiveText, PlayerHudState.ObjectiveText);
+        SetText(DisplayText, PlayerHudState.DebugText);
+        SetText(StaminaText, PlayerHudState.StaminaText);
+        SetText(LogCountText, PlayerHudState.LogCount);
+        SetText(CurrencyCount, PlayerHudState.Wallet);
+        SetText(HealingDisplay, PlayerHudState.HealingText);
+        SetText(SeedCount, PlayerHudState.SeedText);
+        SetText(GobletCount, PlayerHudState.GobletText);
+        SetText(AppleCount, PlayerHudState.AppleText);
+        SetText(ArrowMunition, PlayerHudState.ArrowText);
+    }
 
-        ObjectiveText.text = PlayerHudState.ObjectiveText;
-        DisplayText.text = PlayerHudState.DebugText;
-        StaminaText.text = PlayerHudState.StaminaText;
-        LogCountText.text = PlayerHudState.LogCount;
-        CurrencyCount.text = PlayerHudState.Wallet;
-        HealingDisplay.text = PlayerHudState.HealingText;
-        SeedCount.text = PlayerHudState.SeedText;
-        GobletCount.text = PlayerHudState.GobletText;
-        AppleCount.text = PlayerHudState.AppleText;
-        ArrowMunition.text = PlayerHudState.ArrowText;
+    static void SetText(TextMeshProUGUI text, string value)
+    {
+        if (text != null)
+            text.text = value;
     }
 
     void LogMissingReference(string referenceName, ref bool logged)


### PR DESCRIPTION
### Motivation
- Keep `DebugReference` assigned while introducing a dedicated `PlayerHudState` to hold formatted HUD strings next to `Behaviour` in the scene.
- Preserve existing formatted string generation in `Behaviour` and copy those values into `PlayerHudState` so consumers remain unchanged.
- Surface component references in the inspector where possible and avoid switching architecture to events before Steam integration.

### Description
- Add `public PlayerHudState PlayerHudState` and `public ObjectiveUI PlayerObjective` to `Behaviour` and call `BindHudState()`/`SyncHudState()` from `Start()` and periodically to copy existing formatted HUD strings into `PlayerHudState` via `PlayerHudState.CopyFrom(this, PlayerObjective)`.
- Keep `PlayerHudState` component as a small POCO `MonoBehaviour` with serialized string fields and `CopyFrom(Behaviour player, ObjectiveUI objective)` implemented in `Assets/Scripts/Player/PlayerHudState.cs`.
- Update `DebugReference` to use a serialized `PlayerHudState` reference (remove the stale `PlayerObjective` field), bind the HUD state at start, and set UI text using a null-safe `SetText(TextMeshProUGUI, string)` helper that reads values from `PlayerHudState`.
- Update serialized assets: add `PlayerHudState`/`PlayerObjective` references on the main player prefab and remove stale `PlayerObjective` serialization from UI prefabs/scenes so inspector-visible references remain.

### Testing
- Ran `git diff --check` with no whitespace/errors reported.
- Executed a Python static validation script that verified the HUD mapping strings exist in `Behaviour`, `PlayerHudState`, and `DebugReference` and it succeeded (`HUD text mappings verified`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0345a55c44832a8f7730e15b4e8e7c)