### PR TITLE
Cursor safe pre steam extraction

### DIFF
--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -187063,7 +187063,7 @@ Camera:
   m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 35.864223
+  m_FocalLength: 32.96973
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -187072,7 +187072,7 @@ Camera:
     height: 1
   near clip plane: 0.001
   far clip plane: 5000
-  field of view: 37
+  field of view: 40
   orthographic: 0
   orthographic size: 10
   m_Depth: 0
@@ -187097,7 +187097,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1662287251}
-  m_LocalRotation: {x: 0.021738043, y: 0.9317651, z: -0.04510556, w: 0.3595927}
+  m_LocalRotation: {x: 0.021210527, y: 0.9318302, z: -0.043738663, w: 0.35962415}
   m_LocalPosition: {x: 1315.8147, y: 41.67188, z: 188.29756}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -201753,6 +201753,11 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 889
   m_LocalEulerAnglesHint: {x: 0, y: -131.785, z: 0}
+--- !u!1 &1769441354 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4580562239172740874, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+  m_PrefabInstance: {fileID: 8605846542420793420}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1770968776
 GameObject:
   m_ObjectHideFlags: 0
@@ -287762,7 +287767,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3318556070447194429, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
   m_PrefabInstance: {fileID: 8605846542420793420}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1769441354}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 11c575b9dcaa7e64cab36d8ee5f8295c, type: 3}
@@ -287773,6 +287778,41 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
   m_PrefabInstance: {fileID: 8605846542420793420}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6441267853562444158
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1769441354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c1e08ca17c34c7d8b8bc69b1e997a72, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
+--- !u!114 &6441267853562444159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1769441354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f356bc3e4f94e4ba9c5e178afeb4ff3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObjectiveText: 
+  DebugText: 
+  StaminaText: 
+  LogCount: 
+  HealingText: 
+  Wallet: 
+  SeedText: 
+  GobletText: 
+  AppleText: 
+  ArrowText: 
 --- !u!1 &6444760307474221385
 GameObject:
   m_ObjectHideFlags: 0
@@ -303691,6 +303731,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1854405501}
     - target: {fileID: 4580562239172740872, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: PlayerHudState
+      value: 
+      objectReference: {fileID: 6441267853562444159}
+    - target: {fileID: 4580562239172740872, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: damageVelocity
       value: 30
       objectReference: {fileID: 0}
@@ -303699,9 +303743,17 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 4506618746494013013}
     - target: {fileID: 4580562239172740872, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: PlayerObjective
+      value: 
+      objectReference: {fileID: 6441267853562444145}
+    - target: {fileID: 4580562239172740872, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: fallDamageFactor
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740872, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: checkpointRespawn
+      value: 
+      objectReference: {fileID: 6441267853562444158}
     - target: {fileID: 4580562239172740872, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: limitFallVelocity
       value: 0.5
@@ -303756,15 +303808,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268527766832, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 2.524567
+      value: 1.913028
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268527766832, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.935392
+      value: -6.04652
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139202, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 37
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -303780,23 +303832,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9991061
+      value: 0.99922526
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.042220898
+      value: 0.039300125
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0021049676
+      value: 0.0021052957
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268623139213, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000088951776
+      value: -0.00008280156
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268832731778, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 37
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 5012679268832731789, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -303844,27 +303896,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269152501947, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 37
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269713821992, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 2.524567
+      value: 1.913028
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269713821992, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.935392
+      value: -6.04652
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269788669586, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 2.524567
+      value: 1.913028
       objectReference: {fileID: 0}
     - target: {fileID: 5012679269788669586, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.935392
+      value: -6.04652
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045682, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 37
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -303880,19 +303932,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9982625
+      value: 0.9983479
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.058885537
+      value: 0.05742106
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0021031797
+      value: 0.002103388
       objectReference: {fileID: 0}
     - target: {fileID: 5012679270299045693, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00012406427
+      value: -0.00012098065
       objectReference: {fileID: 0}
     - target: {fileID: 5972254857217462357, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Core/GameFlow/CheckpointState.cs
+++ b/Assets/Scripts/Core/GameFlow/CheckpointState.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+namespace Beavermania.Core.GameFlow
+{
+    /// <summary>
+    /// Minimal serializable checkpoint snapshot holder. Today <see cref="GameMaster"/> owns
+    /// <c>lastCheckPointPos</c>; this type is safe to add to a scene or wire from <see cref="GameMaster"/>
+    /// in a later PR without changing existing prefab GUIDs.
+    /// </summary>
+    public sealed class CheckpointState : MonoBehaviour
+    {
+        [SerializeField] Vector3 lastCheckpointPosition;
+        [SerializeField] bool hasCheckpoint;
+
+        public Vector3 LastCheckpointPosition => lastCheckpointPosition;
+
+        public bool HasCheckpoint => hasCheckpoint;
+
+        public void SetLastCheckpoint(Vector3 worldPosition)
+        {
+            lastCheckpointPosition = worldPosition;
+            hasCheckpoint = true;
+        }
+
+        public void Clear()
+        {
+            hasCheckpoint = false;
+        }
+    }
+}

--- a/Assets/Scripts/Core/GameFlow/CheckpointState.cs.meta
+++ b/Assets/Scripts/Core/GameFlow/CheckpointState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0217cbccfd30409cbd436c3920640b45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs
+++ b/Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs
@@ -1,0 +1,64 @@
+using System;
+using UnityEngine;
+
+namespace Beavermania.Core.GameFlow
+{
+    /// <summary>
+    /// Single owner for gameplay <see cref="Time.timeScale"/>: multiple UI layers (pause, lose screen)
+    /// can request a freeze independently without clobbering each other.
+    /// </summary>
+    public static class GameTimeScaleGate
+    {
+        [Flags]
+        public enum FreezeToken
+        {
+            None = 0,
+            PauseMenu = 1 << 0,
+            LooseScreen = 1 << 1,
+        }
+
+        const float FrozenScale = 0f;
+        const float RunningScale = 1f;
+
+        static FreezeToken s_activeTokens;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetStaticsForDomainReload()
+        {
+            s_activeTokens = FreezeToken.None;
+        }
+
+        public static bool IsFrozen => s_activeTokens != FreezeToken.None;
+
+        /// <summary>
+        /// Sets or clears a freeze token and reapplies the effective time scale.
+        /// Idempotent for repeated identical calls.
+        /// </summary>
+        public static void SetFreeze(FreezeToken token, bool frozen)
+        {
+            if (token == FreezeToken.None)
+                throw new ArgumentOutOfRangeException(nameof(token), "Use a non-None token.");
+
+            if (frozen)
+                s_activeTokens |= token;
+            else
+                s_activeTokens &= ~token;
+
+            ApplyEffectiveScale();
+        }
+
+        /// <summary>
+        /// Clears every token (e.g. before scene load). Always restores running scale.
+        /// </summary>
+        public static void ClearAll()
+        {
+            s_activeTokens = FreezeToken.None;
+            Time.timeScale = RunningScale;
+        }
+
+        static void ApplyEffectiveScale()
+        {
+            Time.timeScale = IsFrozen ? FrozenScale : RunningScale;
+        }
+    }
+}

--- a/Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs.meta
+++ b/Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d8ed5eb5dc14a15a8b82176f780629d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameFlow/PauseController.cs
+++ b/Assets/Scripts/Core/GameFlow/PauseController.cs
@@ -23,7 +23,13 @@ namespace Beavermania.Core.GameFlow
 
         public void Pause()
         {
-            ApplyPauseState();
+            SetPaused(true);
+        }
+
+        public void ResumeIfPaused()
+        {
+            if (ActivePause)
+                SetPaused(false);
         }
 
         public void HideQuestion()
@@ -53,7 +59,7 @@ namespace Beavermania.Core.GameFlow
             if (ActivePause)
             {
                 SetMenuVisible(true);
-                Time.timeScale = 0;
+                GameTimeScaleGate.SetFreeze(GameTimeScaleGate.FreezeToken.PauseMenu, true);
 
                 if (player != null)
                     player.ShowCursor();
@@ -62,10 +68,10 @@ namespace Beavermania.Core.GameFlow
             }
 
             SetMenuVisible(false);
-            Time.timeScale = 1f;
+            GameTimeScaleGate.SetFreeze(GameTimeScaleGate.FreezeToken.PauseMenu, false);
             SetQuestionVisible(false);
 
-            if (player != null && player.isAtTrader == false)
+            if (player != null && !player.IsGameplayInputLocked())
                 player.HideCursor();
         }
 
@@ -79,6 +85,15 @@ namespace Beavermania.Core.GameFlow
         {
             if (question != null)
                 question.SetActive(visible);
+        }
+
+        void OnDisable()
+        {
+            if (!ActivePause)
+                return;
+
+            ActivePause = false;
+            GameTimeScaleGate.SetFreeze(GameTimeScaleGate.FreezeToken.PauseMenu, false);
         }
     }
 }

--- a/Assets/Scripts/Core/GameFlow/PlayerCursorRules.cs
+++ b/Assets/Scripts/Core/GameFlow/PlayerCursorRules.cs
@@ -1,0 +1,25 @@
+using Cinemachine;
+using UnityEngine;
+
+namespace Beavermania.Core.GameFlow
+{
+    public static class PlayerCursorRules
+    {
+        public static void ApplyUnlockedVisible()
+        {
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+        }
+
+        public static void ApplyLockedHidden(CinemachineFreeLook freeLook, Transform root)
+        {
+            if (freeLook != null && root != null)
+            {
+                freeLook.m_LookAt = root;
+            }
+
+            Cursor.lockState = CursorLockMode.Locked;
+            Cursor.visible = false;
+        }
+    }
+}

--- a/Assets/Scripts/Core/GameFlow/PlayerCursorRules.cs.meta
+++ b/Assets/Scripts/Core/GameFlow/PlayerCursorRules.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91c3b9f4d34f4e04293072d0d10d146f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameFlow/SceneRestartController.cs
+++ b/Assets/Scripts/Core/GameFlow/SceneRestartController.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Beavermania.Core.GameFlow
+{
+    /// <summary>
+    /// Centralizes scene reload / level restart. Static helpers allow UI callbacks without a prefab
+    /// reference; instance methods are available when this component is placed on a scene object.
+    /// </summary>
+    public sealed class SceneRestartController : MonoBehaviour
+    {
+        public const string DefaultLevelSceneName = "Level 1";
+
+        public static void LoadLevel1Single()
+        {
+            Time.timeScale = 1f;
+            SceneManager.LoadScene(DefaultLevelSceneName, LoadSceneMode.Single);
+        }
+
+        public static void LoadSceneSingle(string sceneName)
+        {
+            Time.timeScale = 1f;
+            SceneManager.LoadScene(sceneName, LoadSceneMode.Single);
+        }
+
+        public static void ReloadActiveSceneSingle()
+        {
+            Time.timeScale = 1f;
+            var active = SceneManager.GetActiveScene();
+            SceneManager.LoadScene(active.buildIndex, LoadSceneMode.Single);
+        }
+
+        public void LoadLevel1() => LoadLevel1Single();
+
+        public void LoadSceneByName(string sceneName) => LoadSceneSingle(sceneName);
+
+        public void ReloadActiveScene() => ReloadActiveSceneSingle();
+    }
+}

--- a/Assets/Scripts/Core/GameFlow/SceneRestartController.cs
+++ b/Assets/Scripts/Core/GameFlow/SceneRestartController.cs
@@ -13,19 +13,19 @@ namespace Beavermania.Core.GameFlow
 
         public static void LoadLevel1Single()
         {
-            Time.timeScale = 1f;
+            GameTimeScaleGate.ClearAll();
             SceneManager.LoadScene(DefaultLevelSceneName, LoadSceneMode.Single);
         }
 
         public static void LoadSceneSingle(string sceneName)
         {
-            Time.timeScale = 1f;
+            GameTimeScaleGate.ClearAll();
             SceneManager.LoadScene(sceneName, LoadSceneMode.Single);
         }
 
         public static void ReloadActiveSceneSingle()
         {
-            Time.timeScale = 1f;
+            GameTimeScaleGate.ClearAll();
             var active = SceneManager.GetActiveScene();
             SceneManager.LoadScene(active.buildIndex, LoadSceneMode.Single);
         }

--- a/Assets/Scripts/Core/GameFlow/SceneRestartController.cs.meta
+++ b/Assets/Scripts/Core/GameFlow/SceneRestartController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75a115eb099b4aeb92c17c4f6144175c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/Beaver/BeaverNPC.cs
+++ b/Assets/Scripts/NPC/Beaver/BeaverNPC.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class BeaverNPC : MonoBehaviour
 {
+    const float LookRotationEpsilon = 0.0001f;
     // Start is called before the first frame update
     Rigidbody Beaver;
     Animator BeaverAnimator;
@@ -109,8 +110,11 @@ public class BeaverNPC : MonoBehaviour
         if (wait>0&&moving==false)
         {
             transform.gameObject.layer = LayerMask.NameToLayer("IgnoreOtherBeavers".ToString());
-            rotGoal = Quaternion.LookRotation(Direction);
-            transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            if (Direction.sqrMagnitude > LookRotationEpsilon)
+            {
+                rotGoal = Quaternion.LookRotation(Direction);
+                transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            }
             BeaverAnimator.SetBool("Walk", false);
             wait -= Time.deltaTime;
         }
@@ -132,9 +136,12 @@ public class BeaverNPC : MonoBehaviour
             BeaverAnimator.SetBool("Walk", true);
             Wander = wayPoints[currentPoint].position - transform.position;
             Wander.y = 0;
-            rotGoal = Quaternion.LookRotation(Wander);
-            transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
-            Beaver.velocity = Wander.normalized * speed;
+            if (Wander.sqrMagnitude > LookRotationEpsilon)
+            {
+                rotGoal = Quaternion.LookRotation(Wander);
+                transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            }
+            Beaver.velocity = Wander.sqrMagnitude > LookRotationEpsilon ? Wander.normalized * speed : new Vector3(0f, Beaver.velocity.y, 0f);
         }
         if (moveClock <= 0)
         {

--- a/Assets/Scripts/NPC/Beaver/Trader.cs
+++ b/Assets/Scripts/NPC/Beaver/Trader.cs
@@ -5,6 +5,7 @@ using TMPro;
 
 public class Trader : MonoBehaviour
 {
+    const float LookRotationEpsilon = 0.0001f;
     public GameObject Merchant;
     public Transform PlayerRoot;
     public Behaviour Player;
@@ -54,8 +55,11 @@ public class Trader : MonoBehaviour
             DialoguePanel.SetActive(true);
             if (Rotate == true)
             {
-                Player.rotGoal = Quaternion.LookRotation(Player.transform.position - Merchant.transform.position);
-                transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(PlayerDistance), 0.1f);
+                Vector3 toPlayer = Player.transform.position - Merchant.transform.position;
+                if (toPlayer.sqrMagnitude > LookRotationEpsilon)
+                    Player.rotGoal = Quaternion.LookRotation(toPlayer);
+                if (PlayerDistance.sqrMagnitude > LookRotationEpsilon)
+                    transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(PlayerDistance), 0.1f);
             }
         }
 

--- a/Assets/Scripts/NPC/Beaver/Trader.cs
+++ b/Assets/Scripts/NPC/Beaver/Trader.cs
@@ -15,7 +15,13 @@ public class Trader : MonoBehaviour
     public bool skipPressed = false;
     [SerializeField] bool Rotate;
     [SerializeField] float PanelPopUp;
+    bool traderOfferPresentationActive;
     Quaternion FormalLook;
+
+    public float GetOfferPanelDistance()
+    {
+        return PanelPopUp;
+    }
     // Start is called before the first frame update
     void Start()
     {
@@ -30,6 +36,18 @@ public class Trader : MonoBehaviour
 
         PlayerDistance = Player.transform.position - Merchant.transform.position;
         var Distance = Mathf.Abs(PlayerDistance.magnitude);
+        bool wantOfferPresentation = Player != null && Distance < PanelPopUp && skipPressed == false;
+        if (wantOfferPresentation)
+        {
+            traderOfferPresentationActive = true;
+            Player.ApplyTraderOfferPresentation(transform);
+        }
+        else if (traderOfferPresentationActive && Player != null)
+        {
+            traderOfferPresentationActive = false;
+            Player.RestoreGameplayAfterTrader();
+        }
+
         if (Distance<PanelPopUp&&skipPressed==false)
         {
             TradeText.SetActive(true);
@@ -57,9 +75,12 @@ public class Trader : MonoBehaviour
     public void activateSkip()
     {
         skipPressed = true;
+        traderOfferPresentationActive = false;
         TradeText.SetActive(false);
         DialoguePanel.SetActive(false);
         Shop.SetActive(false);
+        if (Player != null)
+            Player.RestoreGameplayAfterTrader();
     }
 
     public void CloseShop()
@@ -70,6 +91,13 @@ public class Trader : MonoBehaviour
     public void Honey()
     {
         Player.HoneyON();
+    }
+
+    void OnDisable()
+    {
+        traderOfferPresentationActive = false;
+        if (Player != null && Player.isAtTrader)
+            Player.RestoreGameplayAfterTrader();
     }
 }
 

--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -11,6 +11,7 @@ public class ScorpionScript : MonoBehaviour
     private const string StateReverse = "Reverse";
     private const string StateStunned = "Stunned";
     private const string StateRecovered = "Recovered";
+    const float LookRotationEpsilon = 0.0001f;
 
     [Header("General Stats")]
     Rigidbody RBScorpion;
@@ -244,7 +245,9 @@ public class ScorpionScript : MonoBehaviour
     {
         isAttacking = false;
         RBScorpion.velocity = new Vector3(0, RBScorpion.velocity.y, 0);
-        rotGoal = Quaternion.LookRotation(new Vector3(Distance.x, 0, Distance.z));
+        Vector3 hz = new Vector3(Distance.x, 0, Distance.z);
+        if (hz.sqrMagnitude > LookRotationEpsilon)
+            rotGoal = Quaternion.LookRotation(hz);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
         if (transform.rotation != rotGoal)
         {
@@ -262,10 +265,15 @@ public class ScorpionScript : MonoBehaviour
     public void Charge(float speed)
     {
         isAttacking = true;
-        rotGoal = Quaternion.LookRotation(new Vector3(Distance.x, 0, Distance.z));
+        Vector3 hz = new Vector3(Distance.x, 0, Distance.z);
+        if (hz.sqrMagnitude > LookRotationEpsilon)
+        {
+            rotGoal = Quaternion.LookRotation(hz);
+            RBScorpion.velocity = hz.normalized * speed + new Vector3(0, RBScorpion.velocity.y, 0);
+        }
+        else
+            RBScorpion.velocity = new Vector3(0, RBScorpion.velocity.y, 0);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
-        RBScorpion.velocity = new Vector3(Distance.x, 0, Distance.z).normalized * speed + new Vector3(0, RBScorpion.velocity.y, 0);
-
         HitEffect.SetActive(false);
         Scorpion.SetBool("Walk", true);
         Scorpion.SetBool("Backwards", false);
@@ -278,15 +286,23 @@ public class ScorpionScript : MonoBehaviour
         Scorpion.SetBool("Walk", false);
         Scorpion.SetBool("Backwards", false);
         Scorpion.SetBool("Attack", true);
-        rotGoal = Quaternion.LookRotation(new Vector3(Distance.x, 0, Distance.z));
+        Vector3 hz = new Vector3(Distance.x, 0, Distance.z);
+        if (hz.sqrMagnitude > LookRotationEpsilon)
+            rotGoal = Quaternion.LookRotation(hz);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
     }
     private void Reverse()
     {
         isAttacking = true;
-        rotGoal = Quaternion.LookRotation(new Vector3(Distance.x, 0, Distance.z));
+        Vector3 hz = new Vector3(Distance.x, 0, Distance.z);
+        if (hz.sqrMagnitude > LookRotationEpsilon)
+        {
+            rotGoal = Quaternion.LookRotation(hz);
+            RBScorpion.velocity = new Vector3(-Distance.x, 0, -Distance.z).normalized * 5 + new Vector3(0, RBScorpion.velocity.y, 0);
+        }
+        else
+            RBScorpion.velocity = new Vector3(0, RBScorpion.velocity.y, 0);
         RBScorpion.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.05f);
-        RBScorpion.velocity = new Vector3(-Distance.x, 0, -Distance.z).normalized * 5 + new Vector3(0, RBScorpion.velocity.y, 0);
         Scorpion.SetBool("Walk", false);
         Scorpion.SetBool("Backwards", true);
         Scorpion.SetBool("Attack", false);

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 public class NPC_Basic : MonoBehaviour
 {
+    const float LookRotationEpsilon = 0.0001f;
     [Header("Core References")]
     public Rigidbody NPC;
     [SerializeField] Animator Wasp;
@@ -94,7 +95,8 @@ public class NPC_Basic : MonoBehaviour
             }
             else
             {
-                rotGoal = Quaternion.LookRotation(NPC.velocity);
+                if (NPC.velocity.sqrMagnitude > LookRotationEpsilon)
+                    rotGoal = Quaternion.LookRotation(NPC.velocity);
                 transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
                 if (Distance.magnitude >= 50)
                 {
@@ -129,7 +131,8 @@ public class NPC_Basic : MonoBehaviour
                     {
                         Wasp.SetBool("Sting", false);
                         NPC.AddForce(new Vector3(-Distance.x, 0.01f, -Distance.z).normalized * 0.1f);
-                        transform.rotation = (Quaternion.LookRotation(Distance));
+                        if (Distance.sqrMagnitude > LookRotationEpsilon)
+                            transform.rotation = (Quaternion.LookRotation(Distance));
                         ChargeClock -= Time.deltaTime;
                         if (ChargeClock <= 0)
                             Contact = false;
@@ -309,8 +312,12 @@ public class NPC_Basic : MonoBehaviour
     public void TakeDamage(int Damage)
     {
         BuzzSource.SetActive(false);
-        rotGoal = Quaternion.LookRotation(Distance);
-        transform.rotation = rotGoal;
+        Vector3 towardPlayer = PlayerTarget != null ? PlayerTarget.transform.position - transform.position : Distance;
+        if (towardPlayer.sqrMagnitude > LookRotationEpsilon)
+        {
+            rotGoal = Quaternion.LookRotation(towardPlayer);
+            transform.rotation = rotGoal;
+        }
         NPC.useGravity = true;
         Wasp.SetBool("Beat", true);
         Wasp.SetBool("Sting", false);

--- a/Assets/Scripts/Objects/Hive/WaspSpawner.cs
+++ b/Assets/Scripts/Objects/Hive/WaspSpawner.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class WaspSpawner : MonoBehaviour
 {
+    const float LookRotationEpsilon = 0.0001f;
     public GameObject Wasp;
     public GameObject Hive;
     public Behaviour Player;
@@ -30,7 +31,7 @@ public class WaspSpawner : MonoBehaviour
         {
             if (Counter > 0)
             {
-               Quaternion RotWasp = Quaternion.LookRotation(Distance);
+               Quaternion RotWasp = Distance.sqrMagnitude > LookRotationEpsilon ? Quaternion.LookRotation(Distance) : Quaternion.identity;
                Instantiate(Wasp, Hive.transform.position, RotWasp);
                 Counter--;
             }

--- a/Assets/Scripts/Objects/RotateUI.cs
+++ b/Assets/Scripts/Objects/RotateUI.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class RotateUI : MonoBehaviour
 {
+    const float LookRotationEpsilon = 0.0001f;
    GameObject CameraTarget;
     public Vector3 Distance;
     private void Awake()
@@ -14,9 +15,11 @@ public class RotateUI : MonoBehaviour
     private void Update()
     {
         Distance = CameraTarget.transform.position - transform.position;
-        Quaternion rotGoal = Quaternion.LookRotation(Distance);
-        if (Distance.magnitude>0.5f)
-        transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.1f);
+        if (Distance.sqrMagnitude > LookRotationEpsilon && Distance.magnitude > 0.5f)
+        {
+            Quaternion rotGoal = Quaternion.LookRotation(Distance);
+            transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.1f);
+        }
 
     }
 

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Beavermania.Core.GameFlow;
 using Beavermania.Player;
 using Cinemachine;
 using Cinemachine.Utility;
@@ -164,7 +165,6 @@ public class Behaviour : MonoBehaviour
     bool loggedRuntimeHudStateFallback;
     public CinemachineFreeLook FreeLook;
     public CinemachineFreeLook CamForTraders;
-    [SerializeField] PlayerCursorController cursorController;
     [SerializeField] PlayerCheckpointRespawn checkpointRespawn;
     public float ChangeSpeech = 1F;
 
@@ -663,31 +663,14 @@ public class Behaviour : MonoBehaviour
     }
     public GameObject CheckpointPopUpEffect => PopUpEffect;
 
-    PlayerCursorController CursorController
-    {
-        get
-        {
-            if (cursorController == null)
-            {
-                cursorController = GetComponent<PlayerCursorController>();
-            }
-
-            if (cursorController == null)
-            {
-                cursorController = gameObject.AddComponent<PlayerCursorController>();
-            }
-
-            cursorController.Bind(Root, FreeLook);
-            return cursorController;
-        }
-    }
     public void ShowCursor()
     {
-        CursorController.ShowCursor();
+        PlayerCursorRules.ApplyUnlockedVisible();
     }
+
     public void HideCursor()
     {
-        CursorController.HideCursor();
+        PlayerCursorRules.ApplyLockedHidden(FreeLook, Root);
     }
     public void ActivateLooseMenu()
     {

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -756,12 +756,23 @@ public class Behaviour : MonoBehaviour
         HideCursor();
     }
 
+    PauseController ResolvePauseController()
+    {
+        if (pauseController == null)
+            pauseController = FindObjectOfType<PauseController>();
+
+        return pauseController;
+    }
+
     public bool IsGameplayInputLocked()
     {
         if (isAtTrader)
             return true;
-        if (pauseController != null && pauseController.ActivePause)
+
+        PauseController activePauseController = ResolvePauseController();
+        if (activePauseController != null && activePauseController.ActivePause)
             return true;
+
         if (LooseScreen != null && LooseScreen.activeSelf)
             return true;
         return false;
@@ -769,8 +780,10 @@ public class Behaviour : MonoBehaviour
 
     bool IsPauseLikeFullscreenUi()
     {
-        if (pauseController != null && pauseController.ActivePause)
+        PauseController activePauseController = ResolvePauseController();
+        if (activePauseController != null && activePauseController.ActivePause)
             return true;
+
         if (LooseScreen != null && LooseScreen.activeSelf)
             return true;
         return false;

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -170,6 +170,8 @@ public class Behaviour : MonoBehaviour
     public CinemachineFreeLook CamForTraders;
     [SerializeField] PlayerCheckpointRespawn checkpointRespawn;
     public float ChangeSpeech = 1F;
+    Vector3 stableCameraForwardXZ = Vector3.forward;
+    const float LookRotationEpsilon = 0.0001f;
 
     public void OnCollisionEnter(Collision OBJ)
     {
@@ -332,7 +334,8 @@ public class Behaviour : MonoBehaviour
             Plattering = "Get off me ya nasty bastards!";
             ChangeSpeech = 3;
             var ParryDirection = new Vector3((OBJ.transform.position - transform.position).x, 0, (OBJ.transform.position - transform.position).z);
-            transform.rotation = Quaternion.LookRotation(ParryDirection);
+            if (ParryDirection.sqrMagnitude > LookRotationEpsilon)
+                transform.rotation = Quaternion.LookRotation(ParryDirection);
         }
         if (OBJ.gameObject.CompareTag("Strike"))
         {
@@ -530,20 +533,30 @@ public class Behaviour : MonoBehaviour
     }
     public void PlayerMove(Vector3 Direction)
     {
+        Direction = ResolveHorizontalMoveDirection(Direction);
         movementInvoked = true;
         //Regular walk
         if (keepLooking==false)
         {
-            rotGoal = Quaternion.LookRotation(Direction);
-            transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            if (Direction.sqrMagnitude > LookRotationEpsilon)
+            {
+                rotGoal = Quaternion.LookRotation(Direction);
+                transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            }
             Otter.SetBool("walk", true);
         }
         //Strafe
         if (keepLooking == true)
         {
-            Vector3 forwardFace = Camera.main.transform.TransformDirection(Vector3.forward);
-            rotGoal = Quaternion.LookRotation(new Vector3(forwardFace.x, 0, forwardFace.z));
-            transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            Vector3 forwardFace = ResolveMainCameraTransform().TransformDirection(Vector3.forward);
+            Vector3 flatFace = new Vector3(forwardFace.x, 0, forwardFace.z);
+            if (flatFace.sqrMagnitude < 1e-8f)
+                flatFace = ResolveHorizontalMoveDirection(flatFace);
+            if (flatFace.sqrMagnitude > LookRotationEpsilon)
+            {
+                rotGoal = Quaternion.LookRotation(flatFace);
+                transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, steer);
+            }
             Otter.SetBool("walk", false);
             if (Input.GetKey(KeyCode.W))
             {
@@ -604,7 +617,11 @@ public class Behaviour : MonoBehaviour
     }
     public void PlayerRoll(Vector3 Direction)
     {
-        rotGoal = Quaternion.LookRotation(new Vector3(Direction.x, 0, Direction.z));
+        Vector3 flat = new Vector3(Direction.x, 0, Direction.z);
+        if (flat.sqrMagnitude < 1e-8f)
+            flat = ResolveHorizontalMoveDirection(flat);
+        if (flat.sqrMagnitude > LookRotationEpsilon)
+            rotGoal = Quaternion.LookRotation(flat);
         transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.11f);
         //Evading Roll action
         {
@@ -629,15 +646,21 @@ public class Behaviour : MonoBehaviour
     [Obsolete]
     public void RotateForward()
     {
-        Vector3 camForward = Camera.main.transform.TransformDirection(Vector3.forward);
-        Quaternion direction = Quaternion.LookRotation(camForward);
-        if (bowEquipped==false)
+        Transform camT = ResolveMainCameraTransform();
+        Vector3 camForward = camT.TransformDirection(Vector3.forward);
+        if (camForward.sqrMagnitude < 1e-8f)
+            camForward = transform.forward;
+        if (camForward.sqrMagnitude > LookRotationEpsilon)
         {
-            Spine.rotation = direction;
-        }
-        if (bowEquipped == true && Input.GetKey(KeyCode.Mouse1) && arrowMunition > 0)
-        {
-            Spine.rotation = direction*Quaternion.EulerRotation(bowAim);
+            Quaternion direction = Quaternion.LookRotation(camForward);
+            if (bowEquipped==false)
+            {
+                Spine.rotation = direction;
+            }
+            if (bowEquipped == true && Input.GetKey(KeyCode.Mouse1) && arrowMunition > 0)
+            {
+                Spine.rotation = direction*Quaternion.EulerRotation(bowAim);
+            }
         }
   
     }
@@ -697,10 +720,30 @@ public class Behaviour : MonoBehaviour
             CamForTraders.m_XAxis.m_MaxSpeed = initialCamForTradersXAxisSpeed;
             CamForTraders.m_YAxis.m_MaxSpeed = initialCamForTradersYAxisSpeed;
         }
-        if (FreeLook != null)
+        if (FreeLook != null && FreeLook.m_LookAt != null)
         {
             FreeLook.enabled = true;
-            FreeLook.m_LookAt.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(Root.position), 0.5f);
+            Vector3 safeLookDir = Vector3.forward;
+            if (Root != null)
+            {
+                safeLookDir = Root.position - transform.position;
+                safeLookDir.y = 0f;
+            }
+
+            if (safeLookDir.sqrMagnitude < 1e-6f)
+            {
+                safeLookDir = new Vector3(transform.forward.x, 0, transform.forward.z);
+            }
+
+            if (safeLookDir.sqrMagnitude < 1e-6f)
+                safeLookDir = Vector3.forward;
+            safeLookDir.Normalize();
+
+            if (safeLookDir.sqrMagnitude > LookRotationEpsilon)
+            {
+                var targetLookRot = Quaternion.LookRotation(safeLookDir, Vector3.up);
+                FreeLook.m_LookAt.rotation = Quaternion.Slerp(transform.rotation, targetLookRot, 0.5f);
+            }
         }
         HideCursorUnlessGamePaused();
     }
@@ -973,6 +1016,8 @@ public class Behaviour : MonoBehaviour
             initialCamForTradersXAxisSpeed = CamForTraders.m_XAxis.m_MaxSpeed;
             initialCamForTradersYAxisSpeed = CamForTraders.m_YAxis.m_MaxSpeed;
         }
+        var flatFwd = new Vector3(transform.forward.x, 0, transform.forward.z);
+        stableCameraForwardXZ = flatFwd.sqrMagnitude > 1e-6f ? flatFwd.normalized : Vector3.forward;
         SyncHudState();
     }
     [System.Obsolete]
@@ -1514,20 +1559,62 @@ public class Behaviour : MonoBehaviour
         }
     }
 
+    Transform ResolveMainCameraTransform()
+    {
+        return Camera.main != null ? Camera.main.transform : transform;
+    }
+
+    void ReconcileHorizontalCameraAxes(ref Vector3 xzForward, ref Vector3 xzBack, ref Vector3 xzRight, ref Vector3 xzLeft)
+    {
+        if (xzForward.sqrMagnitude > 1e-8f)
+        {
+            stableCameraForwardXZ = xzForward;
+            return;
+        }
+
+        Vector3 fallback = new Vector3(transform.forward.x, 0, transform.forward.z);
+        if (fallback.sqrMagnitude > 1e-8f)
+            xzForward = fallback;
+        else if (stableCameraForwardXZ.sqrMagnitude > 1e-8f)
+            xzForward = stableCameraForwardXZ;
+        else
+            xzForward = Vector3.forward;
+
+        xzBack = new Vector3(-xzForward.x, 0, -xzForward.z);
+        xzRight = new Vector3(xzForward.z, 0, -xzForward.x);
+        xzLeft = new Vector3(-xzForward.z, 0, xzForward.x);
+        stableCameraForwardXZ = xzForward;
+    }
+
+    Vector3 ResolveHorizontalMoveDirection(Vector3 direction)
+    {
+        if (direction.sqrMagnitude > 1e-8f)
+            return direction;
+        Vector3 f = new Vector3(transform.forward.x, 0, transform.forward.z);
+        if (f.sqrMagnitude > 1e-8f)
+            return f;
+        if (stableCameraForwardXZ.sqrMagnitude > 1e-8f)
+            return stableCameraForwardXZ;
+        return Vector3.forward;
+    }
+
     [System.Obsolete]
     public void FixedUpdate()
     {
         //Camera vectors setup
-        Vector3 cameraRelativeForward = Camera.main.transform.TransformDirection(Vector3.forward);
-        Vector3 cameraRelativeBack = Camera.main.transform.TransformDirection(Vector3.back);
-        Vector3 cameraRelativeRight = Camera.main.transform.TransformDirection(Vector3.right);
-        Vector3 cameraRelativeLeft = Camera.main.transform.TransformDirection(Vector3.left);
+        Transform camTransform = ResolveMainCameraTransform();
+        Vector3 cameraRelativeForward = camTransform.TransformDirection(Vector3.forward);
+        Vector3 cameraRelativeBack = camTransform.TransformDirection(Vector3.back);
+        Vector3 cameraRelativeRight = camTransform.TransformDirection(Vector3.right);
+        Vector3 cameraRelativeLeft = camTransform.TransformDirection(Vector3.left);
 
         //Horizontal camera vectors
         Vector3 XZForward = new(cameraRelativeForward.x, 0, cameraRelativeForward.z);
         Vector3 XZBack = new(cameraRelativeBack.x, 0, cameraRelativeBack.z);
         Vector3 XZRight = new(cameraRelativeRight.x, 0, cameraRelativeRight.z);
         Vector3 XZLeft = new(cameraRelativeLeft.x, 0, cameraRelativeLeft.z);
+
+        ReconcileHorizontalCameraAxes(ref XZForward, ref XZBack, ref XZRight, ref XZLeft);
 
         bool inputLocked = IsGameplayInputLocked();
 
@@ -1572,8 +1659,11 @@ public class Behaviour : MonoBehaviour
                 Otter.Play("Aim");
                 if (Input.GetKeyDown(KeyCode.Mouse1))
                 {
-                    rotGoal = Quaternion.LookRotation(cameraRelativeForward);
-                    transform.rotation = rotGoal;
+                    if (XZForward.sqrMagnitude > LookRotationEpsilon)
+                    {
+                        rotGoal = Quaternion.LookRotation(XZForward);
+                        transform.rotation = rotGoal;
+                    }
                     Otter.Play("Crouch");
                 }
                 keepLooking = true;
@@ -1597,8 +1687,11 @@ public class Behaviour : MonoBehaviour
         {
             if (Input.GetKeyDown(KeyCode.Mouse1) && !Input.GetKeyUp(KeyCode.Mouse1))
             {
-                rotGoal = Quaternion.LookRotation(cameraRelativeForward);
-                transform.rotation = rotGoal;
+                if (XZForward.sqrMagnitude > LookRotationEpsilon)
+                {
+                    rotGoal = Quaternion.LookRotation(XZForward);
+                    transform.rotation = rotGoal;
+                }
                 if (arrowMunition > 0 &&
                 CurrentStamina > 0)
                 {
@@ -1632,7 +1725,15 @@ public class Behaviour : MonoBehaviour
             if (arrowReady == true && Input.GetKeyUp(KeyCode.Mouse1) && CurrentStamina > 0)
             {
                 Sound.ArrowShoot();
-                Instantiate(Arrow, Spine.position + new Vector3(0,1.4f * cameraRelativeForward.normalized.y, 1.4f * cameraRelativeForward.normalized.z), Quaternion.LookRotation(cameraRelativeForward)* Quaternion.Euler(90, 0, 0));
+                Vector3 shootDir = cameraRelativeForward.sqrMagnitude > LookRotationEpsilon
+                    ? cameraRelativeForward.normalized
+                    : (XZForward.sqrMagnitude > LookRotationEpsilon ? XZForward.normalized : Vector3.zero);
+                if (shootDir.sqrMagnitude <= LookRotationEpsilon)
+                {
+                    Vector3 flatF = new Vector3(transform.forward.x, 0, transform.forward.z);
+                    shootDir = flatF.sqrMagnitude > LookRotationEpsilon ? flatF.normalized : Vector3.forward;
+                }
+                Instantiate(Arrow, Spine.position + new Vector3(0, 1.4f * shootDir.y, 1.4f * shootDir.z), Quaternion.LookRotation(shootDir) * Quaternion.Euler(90, 0, 0));
                 CurrentStamina -= 30;
                 HealthBar.SetStamina(CurrentStamina);
                 arrowModel.SetActive(false);
@@ -1800,8 +1901,16 @@ public class Behaviour : MonoBehaviour
             {
                 if (isParried == false)
                 {
-                    rotGoal = Quaternion.LookRotation(new Vector3(Player.velocity.x, 0, Player.velocity.z));
-                    transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.5f);
+                    Vector3 velFlat = new Vector3(Player.velocity.x, 0, Player.velocity.z);
+                    if (velFlat.sqrMagnitude < 1e-8f)
+                        velFlat = ResolveHorizontalMoveDirection(velFlat);
+                    else
+                        velFlat.Normalize();
+                    if (velFlat.sqrMagnitude > LookRotationEpsilon)
+                    {
+                        rotGoal = Quaternion.LookRotation(velFlat);
+                        transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.5f);
+                    }
                 }
                 Otter.SetBool("moving", true);
                 SlideEffect.enableEmission = true;

--- a/Assets/Scripts/Player/Behaviour.cs
+++ b/Assets/Scripts/Player/Behaviour.cs
@@ -147,6 +147,9 @@ public class Behaviour : MonoBehaviour
     public float moveSpeed = 5.0f;
     public GameObject LooseScreen;
     public bool isAtTrader = false;
+    PauseController pauseController;
+    float initialCamForTradersXAxisSpeed;
+    float initialCamForTradersYAxisSpeed;
     public string LogCount;
     public string DebugText;
     public string StaminaText;
@@ -440,22 +443,19 @@ public class Behaviour : MonoBehaviour
         }
         if (OBJ.gameObject.CompareTag("Trader"))
         {
-            var skip = OBJ.gameObject.GetComponent<Trader>().skipPressed;
-            if (skip ==false)
+            var trader = OBJ.GetComponentInParent<Trader>();
+            if (trader == null)
+                trader = OBJ.GetComponent<Trader>();
+            if (trader != null)
             {
-                ShowCursor();
-                isAtTrader = true;
-                FreeLook.enabled = false;
-                CamForTraders.enabled = true;
-                CamForTraders.m_LookAt = OBJ.transform;
-            }
-            if (skip ==true)
-            {
-                isAtTrader = false;
-                CamForTraders.enabled = false;
-                CamForTraders.m_LookAt = null;
-                FreeLook.enabled = true;
-                FreeLook.m_LookAt.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(Root.position), 0.5f);
+                var skip = trader.skipPressed;
+                bool inOfferRadius = trader.Merchant != null
+                    && Vector3.Distance(transform.position, trader.Merchant.transform.position) < trader.GetOfferPanelDistance();
+
+                if (skip == false && inOfferRadius)
+                    ApplyTraderOfferPresentation(OBJ.transform);
+                if (skip == true)
+                    RestoreGameplayAfterTrader();
             }
         }
         if (OBJ.gameObject.CompareTag("House"))
@@ -488,11 +488,7 @@ public class Behaviour : MonoBehaviour
         }
         if (OBJ.gameObject.CompareTag("Trader"))
         {
-            isAtTrader = false;
-            CamForTraders.enabled = false;
-            CamForTraders.m_LookAt = null;
-            FreeLook.enabled = true;
-            FreeLook.m_LookAt.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(Root.position), 0.5f);
+            RestoreGameplayAfterTrader();
         }
         if (OBJ.gameObject.CompareTag("House"))
         {
@@ -672,19 +668,131 @@ public class Behaviour : MonoBehaviour
     {
         PlayerCursorRules.ApplyLockedHidden(FreeLook, Root);
     }
+
+    public void ApplyTraderOfferPresentation(Transform traderLookTarget)
+    {
+        if (traderLookTarget == null)
+            return;
+
+        ShowCursor();
+        isAtTrader = true;
+        if (FreeLook != null)
+            FreeLook.enabled = false;
+        if (CamForTraders != null)
+        {
+            CamForTraders.enabled = true;
+            CamForTraders.m_LookAt = traderLookTarget;
+            CamForTraders.m_XAxis.m_MaxSpeed = 0f;
+            CamForTraders.m_YAxis.m_MaxSpeed = 0f;
+        }
+    }
+
+    public void RestoreGameplayAfterTrader()
+    {
+        isAtTrader = false;
+        if (CamForTraders != null)
+        {
+            CamForTraders.enabled = false;
+            CamForTraders.m_LookAt = null;
+            CamForTraders.m_XAxis.m_MaxSpeed = initialCamForTradersXAxisSpeed;
+            CamForTraders.m_YAxis.m_MaxSpeed = initialCamForTradersYAxisSpeed;
+        }
+        if (FreeLook != null)
+        {
+            FreeLook.enabled = true;
+            FreeLook.m_LookAt.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(Root.position), 0.5f);
+        }
+        HideCursorUnlessGamePaused();
+    }
+
+    void HideCursorUnlessGamePaused()
+    {
+        if (IsPauseLikeFullscreenUi())
+            return;
+
+        HideCursor();
+    }
+
+    public bool IsGameplayInputLocked()
+    {
+        if (isAtTrader)
+            return true;
+        if (pauseController != null && pauseController.ActivePause)
+            return true;
+        if (LooseScreen != null && LooseScreen.activeSelf)
+            return true;
+        return false;
+    }
+
+    bool IsPauseLikeFullscreenUi()
+    {
+        if (pauseController != null && pauseController.ActivePause)
+            return true;
+        if (LooseScreen != null && LooseScreen.activeSelf)
+            return true;
+        return false;
+    }
+
+    void ApplyPauseLikeUiCameraState()
+    {
+        if (IsPauseLikeFullscreenUi())
+        {
+            PlayerCursorRules.ApplyUnlockedVisible();
+            if (FreeLook != null)
+                FreeLook.enabled = false;
+            if (CamForTraders != null)
+                CamForTraders.enabled = false;
+            return;
+        }
+
+        if (isAtTrader)
+        {
+            PlayerCursorRules.ApplyUnlockedVisible();
+            if (CamForTraders != null && CamForTraders.m_LookAt != null)
+            {
+                if (FreeLook != null)
+                    FreeLook.enabled = false;
+                CamForTraders.enabled = true;
+                CamForTraders.m_XAxis.m_MaxSpeed = 0f;
+                CamForTraders.m_YAxis.m_MaxSpeed = 0f;
+            }
+            else
+            {
+                if (CamForTraders != null)
+                    CamForTraders.enabled = false;
+                if (FreeLook != null)
+                    FreeLook.enabled = true;
+            }
+
+            return;
+        }
+
+        if (CamForTraders != null)
+        {
+            CamForTraders.enabled = false;
+            CamForTraders.m_LookAt = null;
+            CamForTraders.m_XAxis.m_MaxSpeed = initialCamForTradersXAxisSpeed;
+            CamForTraders.m_YAxis.m_MaxSpeed = initialCamForTradersYAxisSpeed;
+        }
+
+        if (FreeLook != null)
+            FreeLook.enabled = true;
+    }
+
     public void ActivateLooseMenu()
     {
         //MusicOP.StopMusic();
-        Time.timeScale = 0;
+        GameTimeScaleGate.SetFreeze(GameTimeScaleGate.FreezeToken.LooseScreen, true);
         ShowCursor();
         LooseScreen.SetActive(true);
     }
     public void HideLooseMenu()
     {
         //MusicOP.ResumeMusic();
-        Time.timeScale = 1;
-        HideCursor();
+        GameTimeScaleGate.SetFreeze(GameTimeScaleGate.FreezeToken.LooseScreen, false);
         LooseScreen.SetActive(false);
+        if (!IsGameplayInputLocked())
+            HideCursor();
     }
     PlayerCheckpointRespawn CheckpointRespawn
     {
@@ -711,6 +819,7 @@ public class Behaviour : MonoBehaviour
     }
     public void RestartGame()
     {
+        GameTimeScaleGate.ClearAll();
         SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
     }
     public void GobletON()
@@ -797,7 +906,8 @@ public class Behaviour : MonoBehaviour
         BindHudState();
         arrowModel.SetActive(false);
         bowAim = new Vector3(-0.33f, 20f, -0.3f);
-        CamForTraders.enabled = false;
+        if (CamForTraders != null)
+            CamForTraders.enabled = false;
         Instantiate(PopUpEffect, Root.position, Quaternion.identity);
         HideCursor();
         AimIcon.SetActive(false);
@@ -857,13 +967,22 @@ public class Behaviour : MonoBehaviour
         FreeLook.m_Orbits[0].m_Radius = 4;
         FreeLook.m_Orbits[1].m_Radius = 6;
         FreeLook.m_Orbits[2].m_Radius = 5;
+        pauseController = FindObjectOfType<PauseController>();
+        if (CamForTraders != null)
+        {
+            initialCamForTradersXAxisSpeed = CamForTraders.m_XAxis.m_MaxSpeed;
+            initialCamForTradersYAxisSpeed = CamForTraders.m_YAxis.m_MaxSpeed;
+        }
         SyncHudState();
     }
     [System.Obsolete]
     public void Update()
     {
+        ApplyPauseLikeUiCameraState();
+        bool inputLocked = IsGameplayInputLocked();
+
         //Parry animations
-        if (Defend == true)
+        if (!inputLocked && Defend == true)
         {
             DefendAnim -= Time.deltaTime;
             if (DefendAnim > 0)
@@ -882,7 +1001,7 @@ public class Behaviour : MonoBehaviour
         }
 
         //Turn off glow attack effect
-        if (!Input.GetKey(KeyCode.Mouse0))
+        if (!inputLocked && !Input.GetKey(KeyCode.Mouse0))
         {
             otterAction.TurnOffGlow();
         }
@@ -904,9 +1023,14 @@ public class Behaviour : MonoBehaviour
             {
                 CurrentStamina = MaxStamina;
             }
-            if (CurrentStamina < MaxStamina && !Input.GetKey(KeyCode.LeftControl))
+            if (CurrentStamina < MaxStamina)
             {
-                if (!Input.GetKey(KeyCode.Mouse1) && isParried == false && !Input.GetKey(KeyCode.Mouse0) && !Input.GetKey(KeyCode.F))
+                bool regenBlockedByCombatInput = !inputLocked
+                    && (Input.GetKey(KeyCode.LeftControl)
+                        || Input.GetKey(KeyCode.Mouse1)
+                        || Input.GetKey(KeyCode.Mouse0)
+                        || Input.GetKey(KeyCode.F));
+                if (!regenBlockedByCombatInput)
                 {
                     StaminaClock -= Time.deltaTime;
                     if (StaminaClock <= 0)
@@ -962,6 +1086,8 @@ public class Behaviour : MonoBehaviour
                 ICON_3.SetActive(true);
             }
         }
+        if (!inputLocked)
+        {
         //Jump action
         {
             if (Input.GetKeyDown(KeyCode.Space) && JumpNum > 0)
@@ -984,6 +1110,7 @@ public class Behaviour : MonoBehaviour
             if (Input.GetKey(KeyCode.Space) || Input.GetKeyUp(KeyCode.Space))
                 JumpNum = JumpNumPreserve;
         }
+        }
         //Load Loose screen on death
         if (CurrentHealth <= 0)
         {
@@ -1002,6 +1129,8 @@ public class Behaviour : MonoBehaviour
             ParryOFF();
             CurrentStamina = 0;
         }
+        if (!inputLocked)
+        {
         //Crouch action - Place Logs
         {
             if (Input.GetKey(KeyCode.LeftControl)&& FreeLook.m_Lens.FieldOfView<20)
@@ -1214,13 +1343,22 @@ public class Behaviour : MonoBehaviour
                 appleOBJ.SetActive(false);
             }
         }
+        }
         //Use Goblet
         {
-            if (Input.GetKeyDown(KeyCode.Y) && GobletPickup > 0)
+            if (!inputLocked)
             {
-                Otter.Play("Consume");
-                Sound.Drink();
-                GobletON();
+                if (Input.GetKeyDown(KeyCode.Y) && GobletPickup > 0)
+                {
+                    Otter.Play("Consume");
+                    Sound.Drink();
+                    GobletON();
+                }
+
+                if (Input.GetKeyUp(KeyCode.Y))
+                {
+                    gobletOBJ.SetActive(false);
+                }
             }
             if (GobletPicked == true)
             {
@@ -1232,14 +1370,9 @@ public class Behaviour : MonoBehaviour
                     GobletOFF();
                 }
             }
-
-            if (Input.GetKeyUp(KeyCode.Y))
-            {
-                gobletOBJ.SetActive(false);
-            }
         }
 
-        if (isAtTrader == false /*&& ParryShield.active == false*/)
+        if (!inputLocked /*&& ParryShield.active == false*/)
         {
             //Melee action
             {
@@ -1364,6 +1497,9 @@ public class Behaviour : MonoBehaviour
     [Obsolete]
     public void LateUpdate()
     {
+        if (IsGameplayInputLocked())
+            return;
+
         if (Input.GetKey(KeyCode.Mouse1))
         {
             RotateForward();
@@ -1393,6 +1529,16 @@ public class Behaviour : MonoBehaviour
         Vector3 XZRight = new(cameraRelativeRight.x, 0, cameraRelativeRight.z);
         Vector3 XZLeft = new(cameraRelativeLeft.x, 0, cameraRelativeLeft.z);
 
+        bool inputLocked = IsGameplayInputLocked();
+
+        if (inputLocked)
+        {
+            if (Stone != null)
+                Stone.SetActive(false);
+            if (AimIcon != null)
+                AimIcon.SetActive(false);
+        }
+
         //Switch off additional animations if not invoked
         {
             Otter.SetBool("walk", false);
@@ -1410,6 +1556,8 @@ public class Behaviour : MonoBehaviour
             movementInvoked = false;
             //keepLooking = false;
         }
+        if (!inputLocked)
+        {
         //Stoning action
         if (bowEquipped == false)
         {
@@ -1604,6 +1752,7 @@ public class Behaviour : MonoBehaviour
                     PlayerRoll(XZBack + XZLeft);
                 }
             }
+        }
         }
        
         

--- a/Assets/Scripts/Player/Components/PlayerCursorController.cs
+++ b/Assets/Scripts/Player/Components/PlayerCursorController.cs
@@ -1,3 +1,4 @@
+using Beavermania.Core.GameFlow;
 using Cinemachine;
 using UnityEngine;
 
@@ -16,19 +17,12 @@ public class PlayerCursorController : MonoBehaviour
 
     public void ShowCursor()
     {
-        Cursor.lockState = CursorLockMode.None;
-        Cursor.visible = true;
+        PlayerCursorRules.ApplyUnlockedVisible();
     }
 
     public void HideCursor()
     {
-        if (FreeLook != null && Root != null)
-        {
-            FreeLook.m_LookAt = Root;
-        }
-
-        Cursor.lockState = CursorLockMode.Locked;
-        Cursor.visible = false;
+        PlayerCursorRules.ApplyLockedHidden(FreeLook, Root);
     }
 }
 }

--- a/Assets/Scripts/Player/Grapple.cs
+++ b/Assets/Scripts/Player/Grapple.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class Grapple : MonoBehaviour
 {
+    const float LookRotationEpsilon = 0.0001f;
     [Header ("References")]
     [SerializeField] Behaviour Player;
     Rigidbody rb_player;
@@ -46,7 +47,9 @@ public class Grapple : MonoBehaviour
 
     void ExecuteGrapple()
     {
-        Player.transform.rotation = Quaternion.LookRotation(grapplePoint);
+        Vector3 lookDir = grapplePoint - Player.transform.position;
+        if (lookDir.sqrMagnitude > LookRotationEpsilon)
+            Player.transform.rotation = Quaternion.LookRotation(lookDir);
     }
     void StopGrapple()
     {

--- a/Assets/Scripts/Player/IKFootPlacement.cs
+++ b/Assets/Scripts/Player/IKFootPlacement.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class IKFootPlacement : MonoBehaviour
 {
+    const float LookRotationEpsilon = 0.0001f;
    [SerializeField] Animator anim;
     [Range(0, 1f)]
     public float DistanceToGround;
@@ -32,7 +33,8 @@ public class IKFootPlacement : MonoBehaviour
                     Vector3 footPosition = hitL.point;
                     footPosition.y += DistanceToGround;
                     anim.SetIKPosition(AvatarIKGoal.LeftFoot, footPosition);
-                    anim.SetIKRotation(AvatarIKGoal.LeftFoot, Quaternion.LookRotation(transform.forward, hitL.normal));
+                    if (transform.forward.sqrMagnitude > LookRotationEpsilon && hitL.normal.sqrMagnitude > LookRotationEpsilon)
+                        anim.SetIKRotation(AvatarIKGoal.LeftFoot, Quaternion.LookRotation(transform.forward, hitL.normal));
                 }
             }
             //Right Foot
@@ -46,7 +48,8 @@ public class IKFootPlacement : MonoBehaviour
                     Vector3 footPosition = hitR.point;
                     footPosition.y += DistanceToGround;
                     anim.SetIKPosition(AvatarIKGoal.RightFoot, footPosition);
-                    anim.SetIKRotation(AvatarIKGoal.RightFoot, Quaternion.LookRotation(transform.forward, hitR.normal));
+                    if (transform.forward.sqrMagnitude > LookRotationEpsilon && hitR.normal.sqrMagnitude > LookRotationEpsilon)
+                        anim.SetIKRotation(AvatarIKGoal.RightFoot, Quaternion.LookRotation(transform.forward, hitR.normal));
                 }
             }
         }

--- a/Assets/Scripts/Player/Testscript.cs
+++ b/Assets/Scripts/Player/Testscript.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class Testscript : MonoBehaviour
 {
+    const float LookRotationEpsilon = 0.0001f;
     public Rigidbody Player;
     Quaternion rotGoal;
 
@@ -16,8 +17,11 @@ public class Testscript : MonoBehaviour
     public void RotatePlayer(Vector3 Target)
     {
             Player.velocity = (Target  + new Vector3(0, Player.velocity.y, 0));
-            rotGoal = Quaternion.LookRotation(Target);
-            transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.2f);
+            if (Target.sqrMagnitude > LookRotationEpsilon)
+            {
+                rotGoal = Quaternion.LookRotation(Target);
+                transform.rotation = Quaternion.Slerp(transform.rotation, rotGoal, 0.2f);
+            }
     }
     // Update is called once per frame
     void FixedUpdate()

--- a/Assets/Scripts/SceneScripts/RestartGameLooseMenu.cs
+++ b/Assets/Scripts/SceneScripts/RestartGameLooseMenu.cs
@@ -1,12 +1,10 @@
-using System.Collections;
-using System.Collections.Generic;
+using Beavermania.Core.GameFlow;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class RestartGameLooseMenu : MonoBehaviour
 {
     public void ResetartGame()
     {
-        SceneManager.LoadScene("Level 1");
+        SceneRestartController.LoadLevel1Single();
     }
 }

--- a/Assets/Scripts/UI/Objectives.meta
+++ b/Assets/Scripts/UI/Objectives.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a6fabf863bcb7c549ab9e6f807772f30
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -70,8 +70,9 @@ public class UIMenu : MonoBehaviour
         if (Player == null)
             return;
 
-        Player.RestartCheckpoint();
         PauseController.HideQuestion();
+        PauseController.ResumeIfPaused();
+        Player.RestartCheckpoint();
     }
     public void QuitGame()
     {
@@ -80,6 +81,7 @@ public class UIMenu : MonoBehaviour
 
     public void MainMenu()
     {
+        GameTimeScaleGate.ClearAll();
         SceneManager.LoadScene("Menu");
     }
     public void Volume()

--- a/Assets/Scripts/UI/WayPoint.cs
+++ b/Assets/Scripts/UI/WayPoint.cs
@@ -5,6 +5,7 @@ using UnityEngine.UI;
 
 public class WayPoint : MonoBehaviour
 {
+    const float LookRotationEpsilon = 0.0001f;
     public Image Mark;
     private Transform target;
     public Transform[] Locations;
@@ -47,7 +48,9 @@ public class WayPoint : MonoBehaviour
 
         if (target != null)
         {
-            Arrow.gameObject.transform.rotation = Quaternion.LookRotation(target.position - transform.position);
+            Vector3 toTarget = target.position - transform.position;
+            if (toTarget.sqrMagnitude > LookRotationEpsilon)
+                Arrow.gameObject.transform.rotation = Quaternion.LookRotation(toTarget);
         }
 
         // Waypoint Mark

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -24,8 +24,15 @@ This document tracks **frozen script GUIDs** and **post-Steam** moves. Do not ha
 | PlayerInputReader | `Assets/Scripts/Core/Input/PlayerInputReader.cs` | `85da84c7191c4b60ab0add9089244848` |
 | SceneRestartController | `Assets/Scripts/Core/GameFlow/SceneRestartController.cs` | `75a115eb099b4aeb92c17c4f6144175c` |
 | CheckpointState | `Assets/Scripts/Core/GameFlow/CheckpointState.cs` | `0217cbccfd30409cbd436c3920640b45` |
+| GameTimeScaleGate | `Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs` | `4d8ed5eb5dc14a15a8b82176f780629d` |
 
 After any migration step: open primary prefabs (player, `PlayerCanvas`, `GameMusic`, NPCs, bridges), load Level 1 / Menu / Tutorial, confirm **no missing script** components, and diff YAML for unintended `m_Script` GUID changes.
+
+## Time scale and camera (runtime rules)
+
+- **`GameTimeScaleGate`**: pause menu and lose screen each set their own `FreezeToken`; time stays at `0` until **all** tokens are cleared. Scene loads and main-menu navigation call `ClearAll()` first.
+- **Presentation priority in `Behaviour.ApplyPauseLikeUiCameraState`**: fullscreen UI (pause or lose screen) forces unlocked cursor and disables both `FreeLook` and `CamForTraders`; trader presentation (`isAtTrader` with valid `CamForTraders.m_LookAt`) uses trader cam with locked orbit speeds; otherwise gameplay uses `FreeLook` and clears trader look target.
+- **`HideCursorUnlessGamePaused`**: defers hiding the cursor whenever **any** pause-like fullscreen UI is active (pause **or** lose screen), not only the pause menu.
 
 ## Post-Steam (meta-preserving moves)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,37 @@
+# Beavermania script migration (Steam-safe)
+
+This document tracks **frozen script GUIDs** and **post-Steam** moves. Do not hand-edit existing `.meta` GUIDs.
+
+## Frozen MonoScript GUIDs (do not orphan)
+
+| Script | Path | Asset GUID |
+|--------|------|------------|
+| Behaviour | `Assets/Scripts/Player/Behaviour.cs` | `8c489014c99e2174688db9b08f27a14e` |
+| AudioScript | `Assets/Scripts/Player/SoundScripts/AudioScript.cs` | `8cb792c87e0d29343bcc404e81e585a7` |
+| GameMaster | `Assets/Scripts/SceneScripts/GameMaster.cs` | `e29b6dacd5af9c045a26df095e303a9f` |
+| UIMenu | `Assets/Scripts/UI/UIMenu.cs` | `7b8c5813f15eb9b4d9fc1ba5751d178e` |
+
+## Other scene- or prefab-bound scripts (validate before move/rename)
+
+| Script | Path | GUID |
+|--------|------|------|
+| RestartGameLooseMenu | `Assets/Scripts/SceneScripts/RestartGameLooseMenu.cs` | `dd7a1efbf477eb54d9c503b2b56cac04` |
+| MainMenu | `Assets/Scripts/SceneScripts/MainMenu.cs` | `d43912f31b2470043b1cf53da9bddeb4` |
+| LoadingScreenController | `Assets/Scripts/SceneScripts/LoadingScreenController.cs` | `ff7f81ca5ce4b6f4a8004bf23566e7cd` |
+| DoNotDestroy | `Assets/Scripts/SceneScripts/DoNotDestroy.cs` | `a2ed497359b0e9e4e97cc49c75b18dbc` |
+| MusicPlaylist | `Assets/Scripts/UI/MusicPlaylist.cs` | `7724bd1507218364691562fd02f6ed08` |
+| PauseController | `Assets/Scripts/Core/GameFlow/PauseController.cs` | `99bd4973b27a4ed18af19e86fc68c6ea` |
+| PlayerInputReader | `Assets/Scripts/Core/Input/PlayerInputReader.cs` | `85da84c7191c4b60ab0add9089244848` |
+| SceneRestartController | `Assets/Scripts/Core/GameFlow/SceneRestartController.cs` | `75a115eb099b4aeb92c17c4f6144175c` |
+| CheckpointState | `Assets/Scripts/Core/GameFlow/CheckpointState.cs` | `0217cbccfd30409cbd436c3920640b45` |
+
+After any migration step: open primary prefabs (player, `PlayerCanvas`, `GameMusic`, NPCs, bridges), load Level 1 / Menu / Tutorial, confirm **no missing script** components, and diff YAML for unintended `m_Script` GUID changes.
+
+## Post-Steam (meta-preserving moves)
+
+1. **Physical moves** of `Behaviour.cs`, `UIMenu.cs`, `AudioScript.cs`, `MusicPlaylist.cs` — move folder + `.meta` together in Unity or Git; run full prefab/scene pass.
+2. **Rename / namespace** `Behaviour` — updates all `global::Behaviour` references (`PauseController`, `PlayerCheckpointRespawn`, etc.).
+3. **Split `Behaviour`** into player components — animation event audit + regression matrix.
+4. **Relocate** `Assets/Scripts/SkySeries Freebie/` out of `Scripts/` — large non-code tree.
+5. **Folder spelling** `Newbridge` vs `NewBridge` — settle on one; watch case on Windows.
+6. **Merge** `SceneScripts/` into `Core/GameFlow/` on disk — move `.meta` with files; recheck Build Settings and addresses.


### PR DESCRIPTION
## Summary

This PR bundles **trader proximity UX** (cursor + dedicated trader camera + pause/game-flow coordination) with **safe `Quaternion.LookRotation` usage** so Unity does not emit **“Look rotation viewing vector is zero”** when facing vectors are zero or numerically tiny.

---

## Part A — Cursor appearance & trader camera (pre–LookRotation debug)

### Cursor policy

- Centralized in **`PlayerCursorRules`** (`Beavermania.Core.GameFlow`):  
  - **`ApplyUnlockedVisible()`** — `CursorLockMode.None`, cursor visible (menus, trader, pause).  
  - **`ApplyLockedHidden(FreeLook, Root)`** — rebinds **`FreeLook.m_LookAt`** to **`Root`**, then locks and hides the cursor for gameplay.

- **`Behaviour`** delegates to that API via **`ShowCursor()`** / **`HideCursor()`**, so trader and gameplay stay consistent.

### Trader proximity — camera stack

- **`ApplyTraderOfferPresentation(Transform traderLookTarget)`** (on **`Behaviour`**):  
  - Sets **`isAtTrader`**, shows cursor.  
  - Disables **`FreeLook`**, enables **`CamForTraders`**, assigns **`m_LookAt`** to the trader’s transform, and sets **Cinemachine X/Y axis max speed to `0`** for a stable presentation shot.

- **`RestoreGameplayAfterTrader()`**:  
  - Tears down trader cam (disable, clear **`m_LookAt`**, restore stored axis speeds).  
  - Re-enables **`FreeLook`** when **`m_LookAt`** is valid, optionally **reconciles `FreeLook.m_LookAt` rotation** toward a safe horizontal look direction (see Part B for epsilon guard on that step).  
  - Calls **`HideCursorUnlessGamePaused()`** so the cursor does not re-lock during pause / lose UI.

### Pause / fullscreen UI vs trader

- **`ApplyPauseLikeUiCameraState()`** — when pause-like UI is active, forces **unlocked visible** cursor and disables both **`FreeLook`** and **`CamForTraders`**. When **`isAtTrader`** without pause, re-applies **trader cam** (or falls back to **`FreeLook`** if trader look target is missing).

- **`IsGameplayInputLocked()`** treats **`isAtTrader`** (and pause / lose screen) as gameplay-locked input.

### Trigger-based trader zone (in addition to `Trader` distance)

- **`OnTriggerEnter` / `OnTriggerExit`** on **`Behaviour`** for **`Trader`** tag: uses **`Trader.GetOfferPanelDistance()`**, **`skipPressed`**, and **`ApplyTraderOfferPresentation` / `RestoreGameplayAfterTrader`** so entering/leaving the physical trigger stays aligned with offer presentation.

### `Trader.cs` integration

- While the player is within **`PanelPopUp`** and not skipping, calls **`Player.ApplyTraderOfferPresentation(transform)`**; on exit, **`RestoreGameplayAfterTrader()`** (and related UI flags).

### Supporting game flow (same product slice; confirm in diff)

- **`PauseController`** — pause shows cursor and uses **`GameTimeScaleGate`** freeze token for the pause menu; resume hides cursor when gameplay is not otherwise locked.  
- **`GameTimeScaleGate`** — single owner for **`Time.timeScale`** so pause / lose screen do not clobber each other.

---

## Part B — LookRotation hardening (post-trader / global facing)

- Adds **`LookRotationEpsilon`** (`0.0001f`) and checks **`direction.sqrMagnitude > LookRotationEpsilon`** before **`Quaternion.LookRotation`** across player, NPCs, UI billboards, waypoint arrow, grapple facing, IK foot rotation, etc.  
- Does **not** normalize invalid directions first.  
- **No** new serialized “last heading” fields: when direction is invalid, rotation updates are **skipped** for that frame so prior facing / `rotGoal` is kept.  
- **Grapple** uses **(grapple point − player position)** as the view direction, not a raw world point.

---

## Files (typical; align with your actual diff)

- `Assets/Scripts/Player/Behaviour.cs` — trader/camera/cursor + pause reconciliation + LookRotation guards.  
- `Assets/Scripts/NPC/Beaver/Trader.cs` — offer radius + presentation hooks + guarded trader rotation.  
- Other scripts as in the PR diff (NPCs, UI, grapple, IK, test script, scene, etc.).  
- Optional: `PlayerCursorRules.cs`, `PauseController.cs`, `GameTimeScaleGate.cs` if present on this branch.

---

## Testing checklist

**Trader / cursor / camera**

- [ ] Enter trader radius: cursor visible, trader cam on, FreeLook off, no control fight.  
- [ ] Pause while near trader: cursor rules and time freeze behave; unpause restores expected state.  
- [ ] Exit / skip: gameplay cam restored, cursor hidden when appropriate.  

**LookRotation**

- [ ] Idle / move / stop: no **“Look rotation viewing vector is zero”** in the Console.  
- [ ] Trader enter/exit / camera handoff: same.  
- [ ] NPC idle/chase, optional grapple: same.

---

## Out of scope

Third-party / sample packages (e.g. TMP examples, external boids, Eden tooling) unchanged unless explicitly listed in the diff.