### PR TITLE
Add pooled one-shot VFX wrapper and route pickup/pop VFX through pool

### DIFF
--- a/Assets/Scripts/Display/PooledOneShotVfx.cs
+++ b/Assets/Scripts/Display/PooledOneShotVfx.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Beavermania.NPC;
 using UnityEngine;
 using UnityEngine.Pool;
 
@@ -76,6 +77,8 @@ namespace Beavermania.Display
         static PooledOneShotVfx CreateInstance(GameObject prefab, ObjectPool<PooledOneShotVfx> pool)
         {
             var instance = Instantiate(prefab);
+            DisableSelfDestroyComponents(instance);
+
             var vfx = instance.GetComponent<PooledOneShotVfx>();
             if (vfx == null)
                 vfx = instance.AddComponent<PooledOneShotVfx>();
@@ -83,6 +86,16 @@ namespace Beavermania.Display
             vfx.Bind(pool);
             instance.SetActive(false);
             return vfx;
+        }
+
+        static void DisableSelfDestroyComponents(GameObject instance)
+        {
+            var effectObjects = instance.GetComponentsInChildren<EffectObject>(true);
+            for (var i = 0; i < effectObjects.Length; i++)
+            {
+                effectObjects[i].enabled = false;
+                Destroy(effectObjects[i]);
+            }
         }
 
         void Bind(ObjectPool<PooledOneShotVfx> sourcePool)

--- a/Assets/Scripts/Display/PooledOneShotVfx.cs
+++ b/Assets/Scripts/Display/PooledOneShotVfx.cs
@@ -1,0 +1,195 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Pool;
+
+namespace Beavermania.Display
+{
+    public sealed class PooledOneShotVfx : MonoBehaviour
+    {
+        static readonly Dictionary<GameObject, ObjectPool<PooledOneShotVfx>> Pools = new Dictionary<GameObject, ObjectPool<PooledOneShotVfx>>();
+
+        ObjectPool<PooledOneShotVfx> pool;
+        ParticleSystem[] particleSystems;
+        float cachedLifetime;
+        Coroutine returnRoutine;
+        bool released;
+        bool suppressStopCallback;
+
+        public static GameObject Spawn(GameObject prefab, Vector3 position, Quaternion rotation)
+        {
+            if (prefab == null)
+                return null;
+
+            if (!Pools.TryGetValue(prefab, out var pool))
+            {
+                pool = CreatePool(prefab);
+                Pools.Add(prefab, pool);
+            }
+
+            var vfx = pool.Get();
+            vfx.Spawn(position, rotation, prefab.transform.localScale);
+            return vfx.gameObject;
+        }
+
+        public static GameObject Spawn(GameObject prefab, Vector3 position, Quaternion rotation, Vector3 scale)
+        {
+            if (prefab == null)
+                return null;
+
+            if (!Pools.TryGetValue(prefab, out var pool))
+            {
+                pool = CreatePool(prefab);
+                Pools.Add(prefab, pool);
+            }
+
+            var vfx = pool.Get();
+            vfx.Spawn(position, rotation, scale);
+            return vfx.gameObject;
+        }
+
+        static ObjectPool<PooledOneShotVfx> CreatePool(GameObject prefab)
+        {
+            ObjectPool<PooledOneShotVfx> pool = null;
+            pool = new ObjectPool<PooledOneShotVfx>(
+                () => CreateInstance(prefab, pool),
+                vfx =>
+                {
+                    vfx.released = false;
+                    vfx.StopReturnRoutine();
+                    vfx.StopAndClear();
+                    vfx.gameObject.SetActive(true);
+                },
+                vfx =>
+                {
+                    vfx.released = true;
+                    vfx.StopReturnRoutine();
+                    vfx.StopAndClear();
+                    vfx.gameObject.SetActive(false);
+                },
+                vfx => Destroy(vfx.gameObject),
+                true);
+
+            return pool;
+        }
+
+        static PooledOneShotVfx CreateInstance(GameObject prefab, ObjectPool<PooledOneShotVfx> pool)
+        {
+            var instance = Instantiate(prefab);
+            var vfx = instance.GetComponent<PooledOneShotVfx>();
+            if (vfx == null)
+                vfx = instance.AddComponent<PooledOneShotVfx>();
+
+            vfx.Bind(pool);
+            instance.SetActive(false);
+            return vfx;
+        }
+
+        void Bind(ObjectPool<PooledOneShotVfx> sourcePool)
+        {
+            pool = sourcePool;
+            particleSystems = GetComponentsInChildren<ParticleSystem>(true);
+            cachedLifetime = GetLifetime(particleSystems);
+
+            var rootParticles = GetComponent<ParticleSystem>();
+            if (rootParticles != null)
+            {
+                var main = rootParticles.main;
+                main.stopAction = ParticleSystemStopAction.Callback;
+            }
+        }
+
+        void Spawn(Vector3 position, Quaternion rotation, Vector3 scale)
+        {
+            transform.SetPositionAndRotation(position, rotation);
+            transform.localScale = scale;
+
+            for (var i = 0; i < particleSystems.Length; i++)
+                particleSystems[i].Play(true);
+
+            if (cachedLifetime > 0)
+                returnRoutine = StartCoroutine(ReturnAfterLifetime(cachedLifetime));
+        }
+
+        void OnParticleSystemStopped()
+        {
+            if (!suppressStopCallback)
+                Release();
+        }
+
+        IEnumerator ReturnAfterLifetime(float lifetime)
+        {
+            yield return new WaitForSeconds(lifetime);
+            Release();
+        }
+
+        void Release()
+        {
+            if (released || pool == null)
+                return;
+
+            pool.Release(this);
+        }
+
+        void StopReturnRoutine()
+        {
+            if (returnRoutine == null)
+                return;
+
+            StopCoroutine(returnRoutine);
+            returnRoutine = null;
+        }
+
+        void StopAndClear()
+        {
+            suppressStopCallback = true;
+            for (var i = 0; i < particleSystems.Length; i++)
+                particleSystems[i].Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+            suppressStopCallback = false;
+        }
+
+        static float GetLifetime(ParticleSystem[] systems)
+        {
+            var lifetime = 0f;
+            for (var i = 0; i < systems.Length; i++)
+            {
+                var main = systems[i].main;
+                if (main.loop)
+                    continue;
+
+                lifetime = Mathf.Max(lifetime, Max(main.startDelay) + main.duration + Max(main.startLifetime));
+            }
+
+            return lifetime;
+        }
+
+        static float Max(ParticleSystem.MinMaxCurve curve)
+        {
+            switch (curve.mode)
+            {
+                case ParticleSystemCurveMode.Constant:
+                    return curve.constant;
+                case ParticleSystemCurveMode.TwoConstants:
+                    return curve.constantMax;
+                case ParticleSystemCurveMode.Curve:
+                    return MaxCurve(curve.curve) * curve.curveMultiplier;
+                case ParticleSystemCurveMode.TwoCurves:
+                    return MaxCurve(curve.curveMax) * curve.curveMultiplier;
+                default:
+                    return 0f;
+            }
+        }
+
+        static float MaxCurve(AnimationCurve curve)
+        {
+            if (curve == null || curve.length == 0)
+                return 0f;
+
+            var max = 0f;
+            for (var i = 0; i < curve.length; i++)
+                max = Mathf.Max(max, curve.keys[i].value);
+
+            return max;
+        }
+    }
+}

--- a/Assets/Scripts/Display/PooledOneShotVfx.cs.meta
+++ b/Assets/Scripts/Display/PooledOneShotVfx.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 777c4870b7c64ef58222e26bb76f87bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
+++ b/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
@@ -188,13 +188,13 @@ namespace Beavermania.Player
             {
                 Otter.Play("Crouch");
                 Sound.PickItem();
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                 Destroy(OBJ.gameObject);
             }
             if ( OBJ.gameObject.CompareTag("Seed") || OBJ.gameObject.CompareTag("Apple") || OBJ.gameObject.CompareTag("GobletKey"))
             {
                 Otter.Play("Crouch");
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                 Destroy(OBJ.gameObject);
 
                 if (OBJ.gameObject.CompareTag("Seed"))
@@ -211,7 +211,7 @@ namespace Beavermania.Player
                 {
                     Sound.PickUp2();
                     GobletPickup++;
-                    Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                    SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                     Destroy(OBJ.gameObject);
                 }
 
@@ -230,7 +230,7 @@ namespace Beavermania.Player
             }
             if (OBJ.gameObject.CompareTag("Coin"))
             {
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                 Sound.Coin();
             }
             if (arrowMunition<Arrows.Length && bowEquipped==true)
@@ -240,7 +240,7 @@ namespace Beavermania.Player
                     Otter.Play("Crouch");
                     Sound.PickUp2();
                     arrowMunition++;
-                    Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                    SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                     if (bowEquipped == true)
                     {
                         CountArrows();
@@ -251,7 +251,7 @@ namespace Beavermania.Player
                 {
                     Otter.Play("Crouch");
                     Sound.PickUp2();
-                    Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                    SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                     if (arrowMunition + 10 < Arrows.Length)
                     {
                         arrowMunition += 10;
@@ -293,7 +293,7 @@ namespace Beavermania.Player
                 Arsenal.Add("Hammers");
                 ArsenalCounter++;
                 Sound.PickItem();
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                 Destroy(OBJ.gameObject);
             }
             if (OBJ.gameObject.CompareTag("Bow"))
@@ -306,7 +306,7 @@ namespace Beavermania.Player
                 Sound.PickItem();
                 arrowMunition = 5;
                 CountArrows();
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                 Destroy(OBJ.gameObject);
             }
             if (OBJ.gameObject.CompareTag("Armor"))
@@ -317,7 +317,7 @@ namespace Beavermania.Player
                 Arsenal.Add("ArmorSet");
                 ArsenalCounter++;
                 Sound.PickItem();
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                 Destroy(OBJ.gameObject);
             }
             if (OBJ.gameObject.CompareTag("Honey") && Honeypicked == false)
@@ -325,7 +325,7 @@ namespace Beavermania.Player
                 Otter.Play("Crouch");
                 HoneyON();
                 Sound.PickItem();
-                Instantiate(PickUpEffect, OBJ.transform.position + new Vector3(0, 0.3f, 0), Quaternion.identity);
+                SpawnPickUpEffect(OBJ.transform.position + new Vector3(0, 0.3f, 0));
                 Destroy(OBJ.gameObject);
             }
             if (OBJ.gameObject.CompareTag("Gold") && GoldPicked == false)
@@ -351,7 +351,7 @@ namespace Beavermania.Player
                 if (Lives > 0)
                 {
                     transform.position = GM.lastCheckPointPos + new Vector3(1, 1, 1);
-                    Instantiate(PopUpEffect, transform.position, Quaternion.identity);
+                    SpawnPopUpEffect(transform.position);
                     Lives--;
                 }
                 if (Lives == 0)
@@ -689,7 +689,11 @@ namespace Beavermania.Player
                 i++;
             }
         }
-        public GameObject CheckpointPopUpEffect => PopUpEffect;
+        public void SpawnCheckpointPopUpEffect(Vector3 position) => SpawnPopUpEffect(position);
+
+        void SpawnPickUpEffect(Vector3 position) => PooledOneShotVfx.Spawn(PickUpEffect, position, Quaternion.identity);
+
+        void SpawnPopUpEffect(Vector3 position) => PooledOneShotVfx.Spawn(PopUpEffect, position, Quaternion.identity);
 
         public void ShowCursor()
         {
@@ -973,7 +977,7 @@ namespace Beavermania.Player
             bowAim = new Vector3(-0.33f, 20f, -0.3f);
             if (CamForTraders != null)
                 CamForTraders.enabled = false;
-            Instantiate(PopUpEffect, Root.position, Quaternion.identity);
+            SpawnPopUpEffect(Root.position);
             HideCursor();
             AimIcon.SetActive(false);
             MunitionDisplay.SetActive(false);

--- a/Assets/Scripts/Player/Components/PlayerCheckpointRespawn.cs
+++ b/Assets/Scripts/Player/Components/PlayerCheckpointRespawn.cs
@@ -22,7 +22,7 @@ public class PlayerCheckpointRespawn : MonoBehaviour
         player.HealthBar.SetHealth(player.MaxHealth);
         player.CurrentHealth = player.MaxHealth;
         player.transform.position = player.GM.lastCheckPointPos;
-        Instantiate(player.CheckpointPopUpEffect, player.transform.position, Quaternion.identity);
+        player.SpawnCheckpointPopUpEffect(player.transform.position);
         player.Lives--;
     }
 }

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Beavermania.Display;
 using Beavermania.NPC;
 using Beavermania.Objects;
 using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
@@ -46,8 +47,7 @@ namespace Beavermania.Player.Combat
 
         public void Explode()
         {
-            var explode = Instantiate(Explosion, transform.position, transform.rotation);
-            explode.transform.localScale += new Vector3(1, 1, 1);
+            PooledOneShotVfx.Spawn(Explosion, transform.position, transform.rotation, Explosion.transform.localScale + Vector3.one);
             Destroy(transform.gameObject);
         }
 


### PR DESCRIPTION
### Motivation
- Reduce allocations and churn from transient VFX by pooling visual-only one-shot prefabs such as pickup/pop effects and explosion VFX.
- Ensure pooled VFX are safely reset on reuse to avoid visual or gameplay side-effects.

### Description
- Add `Beavermania.Display.PooledOneShotVfx` which creates per-prefab `ObjectPool<PooledOneShotVfx>` and exposes `Spawn` overloads that accept `prefab`, `position`, `rotation` and optional `scale`.
- Implement required reset behavior: call `ParticleSystem.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear)` on pool callbacks, reset `transform` position/rotation/scale on spawn, toggle `gameObject.active` via pool callbacks, and return instances on `OnParticleSystemStopped` or after a cached lifetime timer.
- Replace `Instantiate(PickUpEffect...)` / `Instantiate(PopUpEffect...)` sites in `Assets/Scripts/Player/BeaverPlayerBehaviour.cs` with `SpawnPickUpEffect` / `SpawnPopUpEffect` wrappers that call `PooledOneShotVfx.Spawn`, and expose `SpawnCheckpointPopUpEffect` for checkpoints.
- Update `Assets/Scripts/Player/Components/PlayerCheckpointRespawn.cs` to use `player.SpawnCheckpointPopUpEffect(...)` and `Assets/Scripts/Player/Projectile.cs` to use `PooledOneShotVfx.Spawn` for visual-only `Explosion` while preserving spawned scale; gameplay items remain unpooled.

### Testing
- Ran `git diff --check` and it returned no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041a3d0598832a8c62d2d90f39d774)