### PR TITLE
Extend pooled VFX for destruction effects

### DIFF
--- a/Assets/Scripts/Display/PooledOneShotVfx.cs
+++ b/Assets/Scripts/Display/PooledOneShotVfx.cs
@@ -18,6 +18,7 @@ namespace Beavermania.Display
         AudioSource[] audioSources;
         float[] defaultVolumes;
         float[] defaultPitches;
+        bool[] defaultPlayOnAwake;
         float cachedLifetime;
         Coroutine returnRoutine;
         bool released;
@@ -137,14 +138,16 @@ namespace Beavermania.Display
             audioSources = GetComponentsInChildren<AudioSource>(true);
             defaultVolumes = new float[audioSources.Length];
             defaultPitches = new float[audioSources.Length];
+            defaultPlayOnAwake = new bool[audioSources.Length];
 
             for (var i = 0; i < audioSources.Length; i++)
             {
                 defaultVolumes[i] = audioSources[i].volume;
                 defaultPitches[i] = audioSources[i].pitch;
+                defaultPlayOnAwake[i] = audioSources[i].playOnAwake;
             }
 
-            cachedLifetime = Mathf.Max(GetLifetime(particleSystems), GetLifetime(audioSources));
+            cachedLifetime = Mathf.Max(GetLifetime(particleSystems), GetLifetime(audioSources, defaultPlayOnAwake));
 
             var rootParticles = GetComponent<ParticleSystem>();
             if (rootParticles != null)
@@ -161,7 +164,7 @@ namespace Beavermania.Display
 
             Replay(particleSystems);
             ResetAudioSources();
-            Replay(audioSources);
+            Replay(audioSources, defaultPlayOnAwake);
 
             returnRoutine = StartCoroutine(ReturnAfterLifetime(cachedLifetime));
         }
@@ -216,6 +219,7 @@ namespace Beavermania.Display
                 audioSources[i].Stop();
                 audioSources[i].volume = defaultVolumes[i];
                 audioSources[i].pitch = defaultPitches[i];
+                audioSources[i].playOnAwake = defaultPlayOnAwake[i];
             }
         }
 
@@ -233,7 +237,17 @@ namespace Beavermania.Display
             for (var i = 0; i < sources.Length; i++)
             {
                 sources[i].Stop();
-                if (sources[i].isActiveAndEnabled && sources[i].clip != null)
+                if (sources[i].playOnAwake && sources[i].isActiveAndEnabled && sources[i].clip != null)
+                    sources[i].Play();
+            }
+        }
+
+        static void Replay(AudioSource[] sources, bool[] playOnAwake)
+        {
+            for (var i = 0; i < sources.Length; i++)
+            {
+                sources[i].Stop();
+                if (playOnAwake[i] && sources[i].isActiveAndEnabled && sources[i].clip != null)
                     sources[i].Play();
             }
         }
@@ -258,7 +272,21 @@ namespace Beavermania.Display
             var lifetime = 0f;
             for (var i = 0; i < sources.Length; i++)
             {
-                if (sources[i].loop || sources[i].clip == null)
+                if (!sources[i].playOnAwake || sources[i].loop || sources[i].clip == null)
+                    continue;
+
+                lifetime = Mathf.Max(lifetime, sources[i].clip.length / Mathf.Max(Mathf.Abs(sources[i].pitch), 0.01f));
+            }
+
+            return lifetime;
+        }
+
+        static float GetLifetime(AudioSource[] sources, bool[] playOnAwake)
+        {
+            var lifetime = 0f;
+            for (var i = 0; i < sources.Length; i++)
+            {
+                if (!playOnAwake[i] || sources[i].loop || sources[i].clip == null)
                     continue;
 
                 lifetime = Mathf.Max(lifetime, sources[i].clip.length / Mathf.Max(Mathf.Abs(sources[i].pitch), 0.01f));

--- a/Assets/Scripts/Display/PooledOneShotVfx.cs
+++ b/Assets/Scripts/Display/PooledOneShotVfx.cs
@@ -8,10 +8,16 @@ namespace Beavermania.Display
 {
     public sealed class PooledOneShotVfx : MonoBehaviour
     {
+        const int DefaultPoolCapacity = 8;
+        const int MaxActiveInstances = 64;
+
         static readonly Dictionary<GameObject, ObjectPool<PooledOneShotVfx>> Pools = new Dictionary<GameObject, ObjectPool<PooledOneShotVfx>>();
 
         ObjectPool<PooledOneShotVfx> pool;
         ParticleSystem[] particleSystems;
+        AudioSource[] audioSources;
+        float[] defaultVolumes;
+        float[] defaultPitches;
         float cachedLifetime;
         Coroutine returnRoutine;
         bool released;
@@ -28,6 +34,9 @@ namespace Beavermania.Display
                 Pools.Add(prefab, pool);
             }
 
+            if (pool.CountActive >= MaxActiveInstances)
+                return SpawnOverflow(prefab, position, rotation, prefab.transform.localScale);
+
             var vfx = pool.Get();
             vfx.Spawn(position, rotation, prefab.transform.localScale);
             return vfx.gameObject;
@@ -43,6 +52,9 @@ namespace Beavermania.Display
                 pool = CreatePool(prefab);
                 Pools.Add(prefab, pool);
             }
+
+            if (pool.CountActive >= MaxActiveInstances)
+                return SpawnOverflow(prefab, position, rotation, scale);
 
             var vfx = pool.Get();
             vfx.Spawn(position, rotation, scale);
@@ -69,9 +81,29 @@ namespace Beavermania.Display
                     vfx.gameObject.SetActive(false);
                 },
                 vfx => Destroy(vfx.gameObject),
-                true);
+                true,
+                DefaultPoolCapacity,
+                MaxActiveInstances);
 
             return pool;
+        }
+
+        static GameObject SpawnOverflow(GameObject prefab, Vector3 position, Quaternion rotation, Vector3 scale)
+        {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            var instance = Instantiate(prefab, position, rotation);
+            instance.transform.localScale = scale;
+            var particleSystems = instance.GetComponentsInChildren<ParticleSystem>(true);
+            var audioSources = instance.GetComponentsInChildren<AudioSource>(true);
+            var lifetime = Mathf.Max(GetLifetime(particleSystems), GetLifetime(audioSources));
+
+            Replay(particleSystems);
+            Replay(audioSources);
+            Destroy(instance, lifetime);
+            return instance;
+#else
+            return null;
+#endif
         }
 
         static PooledOneShotVfx CreateInstance(GameObject prefab, ObjectPool<PooledOneShotVfx> pool)
@@ -102,7 +134,17 @@ namespace Beavermania.Display
         {
             pool = sourcePool;
             particleSystems = GetComponentsInChildren<ParticleSystem>(true);
-            cachedLifetime = GetLifetime(particleSystems);
+            audioSources = GetComponentsInChildren<AudioSource>(true);
+            defaultVolumes = new float[audioSources.Length];
+            defaultPitches = new float[audioSources.Length];
+
+            for (var i = 0; i < audioSources.Length; i++)
+            {
+                defaultVolumes[i] = audioSources[i].volume;
+                defaultPitches[i] = audioSources[i].pitch;
+            }
+
+            cachedLifetime = Mathf.Max(GetLifetime(particleSystems), GetLifetime(audioSources));
 
             var rootParticles = GetComponent<ParticleSystem>();
             if (rootParticles != null)
@@ -117,22 +159,23 @@ namespace Beavermania.Display
             transform.SetPositionAndRotation(position, rotation);
             transform.localScale = scale;
 
-            for (var i = 0; i < particleSystems.Length; i++)
-                particleSystems[i].Play(true);
+            Replay(particleSystems);
+            ResetAudioSources();
+            Replay(audioSources);
 
-            if (cachedLifetime > 0)
-                returnRoutine = StartCoroutine(ReturnAfterLifetime(cachedLifetime));
+            returnRoutine = StartCoroutine(ReturnAfterLifetime(cachedLifetime));
         }
 
         void OnParticleSystemStopped()
         {
-            if (!suppressStopCallback)
+            if (!suppressStopCallback && returnRoutine == null)
                 Release();
         }
 
         IEnumerator ReturnAfterLifetime(float lifetime)
         {
             yield return new WaitForSeconds(lifetime);
+            returnRoutine = null;
             Release();
         }
 
@@ -158,7 +201,41 @@ namespace Beavermania.Display
             suppressStopCallback = true;
             for (var i = 0; i < particleSystems.Length; i++)
                 particleSystems[i].Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+
+            ResetAudioSources();
             suppressStopCallback = false;
+        }
+
+        void ResetAudioSources()
+        {
+            if (audioSources == null)
+                return;
+
+            for (var i = 0; i < audioSources.Length; i++)
+            {
+                audioSources[i].Stop();
+                audioSources[i].volume = defaultVolumes[i];
+                audioSources[i].pitch = defaultPitches[i];
+            }
+        }
+
+        static void Replay(ParticleSystem[] systems)
+        {
+            for (var i = 0; i < systems.Length; i++)
+            {
+                systems[i].Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                systems[i].Play(true);
+            }
+        }
+
+        static void Replay(AudioSource[] sources)
+        {
+            for (var i = 0; i < sources.Length; i++)
+            {
+                sources[i].Stop();
+                if (sources[i].isActiveAndEnabled && sources[i].clip != null)
+                    sources[i].Play();
+            }
         }
 
         static float GetLifetime(ParticleSystem[] systems)
@@ -171,6 +248,20 @@ namespace Beavermania.Display
                     continue;
 
                 lifetime = Mathf.Max(lifetime, Max(main.startDelay) + main.duration + Max(main.startLifetime));
+            }
+
+            return lifetime;
+        }
+
+        static float GetLifetime(AudioSource[] sources)
+        {
+            var lifetime = 0f;
+            for (var i = 0; i < sources.Length; i++)
+            {
+                if (sources[i].loop || sources[i].clip == null)
+                    continue;
+
+                lifetime = Mathf.Max(lifetime, sources[i].clip.length / Mathf.Max(Mathf.Abs(sources[i].pitch), 0.01f));
             }
 
             return lifetime;

--- a/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
+++ b/Assets/Scripts/NPC/Wasp/NPC_Basic.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Beavermania.Core.Input;
+using Beavermania.Display;
 using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
 using UnityEngine;
 
@@ -218,7 +219,7 @@ namespace Beavermania.NPC
         {
             PlayerHealth.Plattering = ("HA! gotcha");
             PlayerHealth.ChangeSpeech = 1;
-            Instantiate(Explosion, transform.position + new Vector3(0, 1, 0), transform.rotation);
+            PooledOneShotVfx.Spawn(Explosion, transform.position + new Vector3(0, 1, 0), transform.rotation);
             Instantiate(Body, transform.position + new Vector3(0, 1, 0), transform.rotation);
             Instantiate(Head, transform.position + new Vector3(0, 1, 0), transform.rotation);
             Instantiate(Wing, transform.position + new Vector3(0, 1, 0), transform.rotation);

--- a/Assets/Scripts/Objects/Newbridge/LogSpawner.cs
+++ b/Assets/Scripts/Objects/Newbridge/LogSpawner.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Beavermania.Display;
 using Beavermania.Core.Input;
 using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
 
@@ -42,7 +43,7 @@ namespace Beavermania.Objects
 
         public void DestroyTree(Transform OBJ)
         {
-            Instantiate(TreeDeath, new Vector3(SpawnPoint.position.x, OBJ.transform.position.y, SpawnPoint.position.z), Quaternion.identity);
+            PooledOneShotVfx.Spawn(TreeDeath, new Vector3(SpawnPoint.position.x, OBJ.transform.position.y, SpawnPoint.position.z), Quaternion.identity);
             var counter = 0;
             foreach (var item in Prefab)
             {

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -47,7 +47,7 @@ namespace Beavermania.Player.Combat
 
         public void Explode()
         {
-            PooledOneShotVfx.Spawn(Explosion, transform.position, transform.rotation, Explosion.transform.localScale + Vector3.one);
+            PooledOneShotVfx.Spawn(Explosion, transform.position, transform.rotation);
             Destroy(transform.gameObject);
         }
 


### PR DESCRIPTION
### Motivation
- Support explosion/destruction prefabs via the pooled one-shot VFX utility and satisfy required reset/return behavior.
- Ensure particle and audio lifetimes drive return, audio sources are reset, and transform scale does not accumulate.
- Provide safe fallback when pool capacity is exceeded (instantiate in editor/development builds, skip in release).

### Description
- `Assets/Scripts/Display/PooledOneShotVfx.cs`: added audio tracking (`AudioSource[]`, `defaultVolumes`, `defaultPitches`), `Replay` helpers, `ResetAudioSources`, lifetime calculation including audio, `SpawnOverflow` fallback for dev/editor, pool capacity controls (`DefaultPoolCapacity`, `MaxActiveInstances`), and stronger return logic to avoid double-release.
- `Assets/Scripts/Player/Projectile.cs`: changed `Explode()` to use pooled spawn without additive `localScale` to avoid cumulative scaling.
- `Assets/Scripts/NPC/Wasp/NPC_Basic.cs`: routed death explosion through `PooledOneShotVfx.Spawn(Explosion, ...)` instead of `Instantiate`.
- `Assets/Scripts/Objects/Newbridge/LogSpawner.cs`: routed `TreeDeath` effect through `PooledOneShotVfx.Spawn(...)` instead of `Instantiate`.

### Testing
- Ran `git diff --check` with no index errors reported.
- Verified presence/absence of C# project files with `rg` which returned no `.sln`/`.csproj`, so no automatic build/test run was performed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04296a9b74832a8cfb19159637a50c)