### PR TITLE
Cache repeated GetComponent calls in collision/update handlers

### DIFF
--- a/Assets/Scripts/NPC/Beaver/BeaverNPC.cs
+++ b/Assets/Scripts/NPC/Beaver/BeaverNPC.cs
@@ -168,7 +168,8 @@ namespace Beavermania.NPC
             }
             for (int i = 0; i < beavers.Length; i++)
             {
-                if (beavers[i].gameObject.GetComponent<BeaverNPC>().currentPoint != currentPoint)
+                var beaver = beavers[i].gameObject.GetComponent<BeaverNPC>();
+                if (beaver.currentPoint != currentPoint)
                 {
                     transform.gameObject.layer = LayerMask.NameToLayer("IgnoreOtherBeavers".ToString());
                 }

--- a/Assets/Scripts/Objects/OldBridge/PickUp.cs
+++ b/Assets/Scripts/Objects/OldBridge/PickUp.cs
@@ -25,11 +25,13 @@ namespace Beavermania.Objects
             }
 
 
+            var logRigidbody = Log.GetComponent<Rigidbody>();
+
             //Check if IsHolding
             if (IsHolding == true)
             {
-                Log.GetComponent<Rigidbody>().velocity = Vector3.zero;
-                Log.GetComponent<Rigidbody>().angularVelocity = Vector3.zero;
+                logRigidbody.velocity = Vector3.zero;
+                logRigidbody.angularVelocity = Vector3.zero;
                 Log.transform.SetParent(tempParent.transform);
                 if (PlayerInputReader.WasInteractPressed())
                 {
@@ -40,7 +42,7 @@ namespace Beavermania.Objects
             {
                 objectPos = Log.transform.position;
                 Log.transform.SetParent(null);
-                Log.GetComponent<Rigidbody>().useGravity = true;
+                logRigidbody.useGravity = true;
                 Log.transform.position = objectPos;
             }
 
@@ -51,8 +53,9 @@ namespace Beavermania.Objects
             if (distance <= 2.5f && PlayerInputReader.IsSecondaryHeld())
             {
                 IsHolding = true;
-                Log.GetComponent<Rigidbody>().useGravity = false;
-                Log.GetComponent<Rigidbody>().detectCollisions = true;
+                var logRigidbody = Log.GetComponent<Rigidbody>();
+                logRigidbody.useGravity = false;
+                logRigidbody.detectCollisions = true;
             }
 
             else

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -61,8 +61,11 @@ namespace Beavermania.Player.Combat
         {
             if (OBJ.gameObject.CompareTag("NPC"))
             {
-                OBJ.gameObject.GetComponent<NPC_Basic>().TakeDamage(Damage);
-                OBJ.gameObject.GetComponent<NPC_Basic>().combo += OBJ.gameObject.GetComponent<NPC_Basic>().hit2stun;
+                if (OBJ.gameObject.TryGetComponent(out NPC_Basic npc))
+                {
+                    npc.TakeDamage(Damage);
+                    npc.combo += npc.hit2stun;
+                }
                 if (isFireBall == true)
                 {
                     Explode();
@@ -76,8 +79,11 @@ namespace Beavermania.Player.Combat
             }
             if (OBJ.gameObject.CompareTag("Scorpion"))
             {
-                OBJ.gameObject.GetComponent<ScorpionScript>().TakeDamage(Damage);
-                OBJ.gameObject.GetComponent<ScorpionScript>().combo += 3;
+                if (OBJ.gameObject.TryGetComponent(out ScorpionScript scorpion))
+                {
+                    scorpion.TakeDamage(Damage);
+                    scorpion.combo += 3;
+                }
                 if (isFireBall == true)
                 {
                     Explode();
@@ -89,7 +95,10 @@ namespace Beavermania.Player.Combat
             }
             if (OBJ.gameObject.CompareTag("Hive"))
             {
-                OBJ.gameObject.GetComponent<Static_Hive>().TakeDamage(Damage);
+                if (OBJ.gameObject.TryGetComponent(out Static_Hive hive))
+                {
+                    hive.TakeDamage(Damage);
+                }
                 if (isFireBall == true)
                 {
                     Explode();


### PR DESCRIPTION
### Motivation
- Remove repeated `GetComponent<T>` calls inside per-frame and physics callbacks to reduce allocation/lookup overhead.
- Preserve all existing tag checks and gameplay effects (damage, combo, stun, pickup, movement) while improving readability.

### Description
- In `Assets/Scripts/Player/Projectile.cs` replaced repeated lookups with `if (OBJ.gameObject.TryGetComponent(out NPC_Basic npc)) { ... }`, `TryGetComponent(out ScorpionScript scorpion)` and `TryGetComponent(out Static_Hive hive)` and applied mutations via the local variables. 
- In `Assets/Scripts/Objects/OldBridge/PickUp.cs` cached `Log.GetComponent<Rigidbody()` into a local `logRigidbody` in `Update`/`FixedUpdate` and reused it for velocity, gravity and collision flag changes. 
- In `Assets/Scripts/NPC/Beaver/BeaverNPC.cs` cached `beavers[i].gameObject.GetComponent<BeaverNPC>()` into a local `beaver` before reading `currentPoint` in the update loop.

### Testing
- Ran `git diff --check` with no issues reported. 
- Executed a repository scan script to detect repeated `GetComponent<T>` calls within the target callbacks and confirmed duplicates were removed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04371e0e8c832a8c4e4362751e34e0)