### PR TITLE
Replace direct `.tag ==` checks with `CompareTag`

### DIFF
--- a/Assets/Scripts/NPC/WaspCourse.cs
+++ b/Assets/Scripts/NPC/WaspCourse.cs
@@ -54,7 +54,7 @@ namespace Beavermania.NPC
 
             if (Physics.Raycast(ray, out hit, distance, collisionLayer))
             {
-                if (hit.transform.gameObject.tag == "Isle" && Wasp.combo>=3)
+                if (hit.transform.gameObject.CompareTag("Isle") && Wasp.combo>=3)
                 {
                     contact = true;
                 }

--- a/Assets/Scripts/Objects/Newbridge/LogSpawner.cs
+++ b/Assets/Scripts/Objects/Newbridge/LogSpawner.cs
@@ -21,7 +21,7 @@ namespace Beavermania.Objects
 
         public void OnTriggerStay(Collider OBJ)
         {
-            if (OBJ.gameObject.tag=="Player")
+            if (OBJ.gameObject.CompareTag("Player"))
             {
                var isGrounded= OBJ.gameObject.GetComponent<BeaverPlayer>().grounded;
                 if (PlayerInputReader.IsPrimaryHeld() && isGrounded == false)
@@ -32,7 +32,7 @@ namespace Beavermania.Objects
         }
         public void OnCollisionStay(Collision OBJ)
         {
-            if (OBJ.gameObject.tag == "Player")
+            if (OBJ.gameObject.CompareTag("Player"))
             {
                 if (PlayerInputReader.IsPrimaryHeld())
                 {

--- a/Assets/Scripts/Objects/Newbridge/MergeCollidersOnCollision.cs
+++ b/Assets/Scripts/Objects/Newbridge/MergeCollidersOnCollision.cs
@@ -11,7 +11,7 @@ namespace Beavermania.Objects
         public GameObject FirstPart;
         void OnCollisionEnter(Collision collision)
         {
-            if (collision.gameObject.tag == "Player")
+            if (collision.gameObject.CompareTag("Player"))
             {
                 Debug.Log("Part added to bridge: " + collision.gameObject.name);
                 MergeColliders(FirstPart, collision.gameObject);

--- a/Assets/Scripts/Objects/OldBridge/BridgeConstructor.cs
+++ b/Assets/Scripts/Objects/OldBridge/BridgeConstructor.cs
@@ -12,7 +12,7 @@ namespace Beavermania.Objects
         public int i = 0;
         public void OnCollisionEnter(Collision collision)
         {
-            if(collision.gameObject.tag == "Part")
+            if(collision.gameObject.CompareTag("Part"))
             {
                 if (i < BridgeParts.Length)
                     BridgeParts[i].SetActive(true);

--- a/Assets/Scripts/Objects/OldBridge/Parts.cs
+++ b/Assets/Scripts/Objects/OldBridge/Parts.cs
@@ -11,7 +11,7 @@ namespace Beavermania.Objects
         // Start is called before the first frame update
         public void OnCollisionEnter(Collision collision)
         {
-            if (collision.gameObject.tag == "Part")
+            if (collision.gameObject.CompareTag("Part"))
             {
                 //Instantiate(transform, transform.position + transform.forward * 0.5f, transform.rotation);
                  collision.transform.position = Backwards.position + new Vector3 (0,1,0);

--- a/Assets/Scripts/Objects/StayWithLift.cs
+++ b/Assets/Scripts/Objects/StayWithLift.cs
@@ -12,7 +12,7 @@ namespace Beavermania.Objects
 
         private void OnTriggerStay(Collider OBJ)
         {
-            if (OBJ.gameObject.tag=="Bridge")
+            if (OBJ.gameObject.CompareTag("Bridge"))
             {
                 var Child = OBJ.GetComponent<Transform>();
                 Child.transform.parent = Ramp.transform;
@@ -21,7 +21,7 @@ namespace Beavermania.Objects
 
         //private void OnTriggerExit(Collider OBJ)
         //{
-        //    if (OBJ.gameObject.tag == "Player")
+        //    if (OBJ.gameObject.CompareTag("Player"))
         //    {
         //        var Child = OBJ.GetComponent<Rigidbody>();
         //        Child.transform.parent = null;

--- a/Assets/Scripts/Objects/Trees and Logs/Drawn.cs
+++ b/Assets/Scripts/Objects/Trees and Logs/Drawn.cs
@@ -17,7 +17,7 @@ namespace Beavermania.Objects
    
         private void OnCollisionEnter(Collision OBJ)
         {
-            if (OBJ.gameObject.tag == "Strike")
+            if (OBJ.gameObject.CompareTag("Strike"))
             {
                 Destroy(gameObject);
             }
@@ -26,7 +26,7 @@ namespace Beavermania.Objects
         [System.Obsolete]
         private void OnTriggerStay(Collider OBJ)
         {
-            if (OBJ.gameObject.tag == "Player")
+            if (OBJ.gameObject.CompareTag("Player"))
             {
                 var Player = OBJ.GetComponent<BeaverPlayer>();
                 var PlayerLoad = OBJ.GetComponent<Carry>();

--- a/Assets/Scripts/Objects/Trees and Logs/Grow.cs
+++ b/Assets/Scripts/Objects/Trees and Logs/Grow.cs
@@ -38,7 +38,7 @@ namespace Beavermania.Objects
 
         private void OnTriggerStay(Collider OBJ)
         {
-            if (OBJ.gameObject.tag == "Player")
+            if (OBJ.gameObject.CompareTag("Player"))
             {
                 if (PlayerInputReader.IsPrimaryHeld())
                 {


### PR DESCRIPTION
### Motivation
- Use Unity-recommended `CompareTag` for tag checks to avoid pitfalls of string comparison while preserving existing tag names and runtime behavior. 
- Change scope targeted collision/tag checks affecting player/tree/log/strike/part/bridge/isle interactions across object and NPC scripts. 

### Description
- Replaced direct `.tag == "..."` usages with `CompareTag("...")` without changing branch logic or tag string values. 
- Updated files: `Assets/Scripts/NPC/WaspCourse.cs`, `Assets/Scripts/Objects/Newbridge/LogSpawner.cs`, `Assets/Scripts/Objects/Newbridge/MergeCollidersOnCollision.cs`, `Assets/Scripts/Objects/OldBridge/BridgeConstructor.cs`, `Assets/Scripts/Objects/OldBridge/Parts.cs`, `Assets/Scripts/Objects/StayWithLift.cs`, `Assets/Scripts/Objects/Trees and Logs/Drawn.cs`, and `Assets/Scripts/Objects/Trees and Logs/Grow.cs`. 
- No logic merges or behavioral changes were introduced; only tag-check calls were replaced. 

### Testing
- Ran `git diff --check` and it reported no issues. 
- Verified no remaining direct comparisons with `rg -n '\.tag\s*==' Assets/Scripts`, which returned no results. 
- Confirmed presence of intended replacements using `rg -n 'CompareTag\("(Player|Strike|Part|Bridge|Isle)"\)' Assets/Scripts`, which returned the updated locations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0442f56b08832a8bb0a648292cf458)