### PR TITLE
Cache main camera runtime lookups

### DIFF
--- a/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
+++ b/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
@@ -180,6 +180,8 @@ namespace Beavermania.Player
         [SerializeField] PlayerCheckpointRespawn checkpointRespawn;
         public float ChangeSpeech = 1F;
         Vector3 stableCameraForwardXZ = Vector3.forward;
+        Camera cachedMainCamera;
+        Transform cachedMainCameraTransform;
         const float LookRotationEpsilon = 0.0001f;
 
         public void OnCollisionEnter(Collision OBJ)
@@ -972,6 +974,7 @@ namespace Beavermania.Player
         }
         public void Start()
         {
+            CacheMainCamera();
             BindHudState();
             arrowModel.SetActive(false);
             bowAim = new Vector3(-0.33f, 20f, -0.3f);
@@ -1584,9 +1587,17 @@ namespace Beavermania.Player
             }
         }
 
+        void CacheMainCamera()
+        {
+            cachedMainCamera = Camera.main;
+            cachedMainCameraTransform = cachedMainCamera != null ? cachedMainCamera.transform : null;
+        }
+
         Transform ResolveMainCameraTransform()
         {
-            return Camera.main != null ? Camera.main.transform : transform;
+            if (cachedMainCamera == null)
+                CacheMainCamera();
+            return cachedMainCameraTransform != null ? cachedMainCameraTransform : transform;
         }
 
         void ReconcileHorizontalCameraAxes(ref Vector3 xzForward, ref Vector3 xzBack, ref Vector3 xzRight, ref Vector3 xzLeft)

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -22,10 +22,12 @@ namespace Beavermania.Player.Combat
         [SerializeField] GameObject Explosion;
         [SerializeField] int Damage;
         [SerializeField] GameObject arrowPickup;
+        Camera cachedMainCamera;
         // Start is called before the first frame update
         void Start()
         {
-            Vector3 launchDirection = Camera.main.transform.TransformDirection(Vector3.forward);
+            cachedMainCamera = Camera.main;
+            Vector3 launchDirection = cachedMainCamera.transform.TransformDirection(Vector3.forward);
             Physics.IgnoreLayerCollision(1, 3);
             Player = GameObject.FindGameObjectWithTag("Player").GetComponent<BeaverPlayer>();
             Ball.velocity = launchDirection * forwardVel + Vector3.up * upwardVel;

--- a/Assets/Scripts/Player/Testscript.cs
+++ b/Assets/Scripts/Player/Testscript.cs
@@ -9,11 +9,14 @@ public class Testscript : MonoBehaviour
     const float LookRotationEpsilon = 0.0001f;
     public Rigidbody Player;
     Quaternion rotGoal;
+    Transform cachedMainCameraTransform;
 
     // Start is called before the first frame update
     void Start()
     {
         Player = GetComponent<Rigidbody>();
+        Camera mainCamera = Camera.main;
+        cachedMainCameraTransform = mainCamera != null ? mainCamera.transform : null;
     }
     //Rotate and grant velocity to player in accordance to movement input and camera position
     public void RotatePlayer(Vector3 Target)
@@ -29,10 +32,12 @@ public class Testscript : MonoBehaviour
     void FixedUpdate()
     {
         //Camera direction vectors
-        Vector3 cameraRelativeForward = Camera.main.transform.TransformDirection(Vector3.forward);
-        Vector3 cameraRelativeBack = Camera.main.transform.TransformDirection(Vector3.back);
-        Vector3 cameraRelativeRight = Camera.main.transform.TransformDirection(Vector3.right);
-        Vector3 cameraRelativeLeft = Camera.main.transform.TransformDirection(Vector3.left);
+        if (cachedMainCameraTransform == null)
+            cachedMainCameraTransform = Camera.main.transform;
+        Vector3 cameraRelativeForward = cachedMainCameraTransform.TransformDirection(Vector3.forward);
+        Vector3 cameraRelativeBack = cachedMainCameraTransform.TransformDirection(Vector3.back);
+        Vector3 cameraRelativeRight = cachedMainCameraTransform.TransformDirection(Vector3.right);
+        Vector3 cameraRelativeLeft = cachedMainCameraTransform.TransformDirection(Vector3.left);
 
 
         //Camera vectors on horizontal plane 

--- a/Assets/Scripts/UI/WayPoint.cs
+++ b/Assets/Scripts/UI/WayPoint.cs
@@ -15,10 +15,12 @@ namespace Beavermania.UI.Objectives
         public Transform[] Locations;
         public Transform Arrow;
         public int i;
+        Camera cachedMainCamera;
 
         // Start is called before the first frame update
         void Start()
         {
+            cachedMainCamera = Camera.main;
             Arrow.gameObject.SetActive(false);
             for (int index = 0; index < Locations.Length; index++)
             {
@@ -64,7 +66,9 @@ namespace Beavermania.UI.Objectives
                 float maxX = Screen.width - minX;
                 float minY = Mark.GetPixelAdjustedRect().height / 2;
                 float maxY = Screen.height - minY;
-                Vector2 pos = Camera.main.WorldToScreenPoint(target.position + new Vector3(0, 2, 0));
+                if (cachedMainCamera == null)
+                    cachedMainCamera = Camera.main;
+                Vector2 pos = cachedMainCamera.WorldToScreenPoint(target.position + new Vector3(0, 2, 0));
 
                 if (Vector3.Dot((target.position - transform.position), transform.forward) < 0)
                 {


### PR DESCRIPTION
### Motivation
- Eliminate repeated `Camera.main` runtime lookups by caching the reference to reduce overhead.
- Preserve existing fallbacks so behavior is unchanged when no main camera is available.
- Keep projectile aim, UI placement, and player rotation math identical while preventing frequent `Camera.main` calls.

### Description
- Added cached `Camera` fields and initialized them in `Start` or a new `CacheMainCamera` helper in `BeaverPlayerBehaviour`, `Projectile`, `WayPoint`, and `Testscript`.
- `BeaverPlayerBehaviour` now stores `cachedMainCamera` and `cachedMainCameraTransform`, calls `CacheMainCamera()` from `Start`, and `ResolveMainCameraTransform()` refreshes the cache only when null while falling back to `transform`.
- `Projectile` caches `Camera.main` in `Start` and derives launch direction from the cached camera.
- `WayPoint` caches `Camera.main` in `Start` and refreshes the cache only when null before calling `WorldToScreenPoint`.
- `Testscript` caches the camera transform in `Start` and refreshes it if null in `FixedUpdate` before computing camera-relative vectors.

### Testing
- Ran `git diff --check` and confirmed no whitespace/patch errors (passed).
- Ran `rg -n "Camera\.main" Assets/Scripts/Player/Projectile.cs Assets/Scripts/UI/WayPoint.cs Assets/Scripts/Player/BeaverPlayerBehaviour.cs Assets/Scripts/Player/Testscript.cs` and verified `Camera.main` usage is limited to the cache assignments and no direct per-frame `Camera.main.transform` lookups remain in the targeted sites (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04505b6908832a8d8061b9b040de89)