### PR TITLE
Enable GPU instancing on repeated non-skinned level materials

### DIFF
--- a/Assets/Materials/OtherObjects/WoodSimple.mat
+++ b/Assets/Materials/OtherObjects/WoodSimple.mat
@@ -16,7 +16,7 @@ Material:
   - _NORMALMAP
   - _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
   m_LightmapFlags: 1
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/Materials/Seed/SeedSynthi.mat
+++ b/Assets/Materials/Seed/SeedSynthi.mat
@@ -13,7 +13,7 @@ Material:
   - LOD_FADE_CROSSFADE
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Assets/Materials/WoodLog/Materials/Wood_Log_albedo.mat
+++ b/Assets/Materials/WoodLog/Materials/Wood_Log_albedo.mat
@@ -13,7 +13,7 @@ Material:
   - _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}


### PR DESCRIPTION
### Motivation
- Reduce SetPass/batch overhead for highly repeated, non-skinned materials used on the Level 1 traversal path.  
- Only alter materials that meet safety criteria: same mesh repeated many times, non-skinned, no per-renderer material mutations, and shader supports instancing.

### Description
- Enabled GPU instancing by setting `m_EnableInstancingVariants: 1` in three materials: `Assets/Materials/WoodLog/Materials/Wood_Log_albedo.mat`, `Assets/Materials/OtherObjects/WoodSimple.mat`, and `Assets/Materials/Seed/SeedSynthi.mat`.  
- Chose these three as top repeated safe candidates (counts: 226, 131, and 5 non-skinned renderers respectively) and limited scope to avoid mass changes.  
- Verified target shaders are Unity surface/Standard-style shaders that accept instancing (surface shader `#pragma surface` observed for Synty shader).

### Testing
- Ran a static renderer audit via `python3` to enumerate mesh/material pairs in `Assets/Scenes/Level 1.unity` which produced repeat counts `226`, `131`, and `5` for the selected materials, and that check succeeded.  
- Ran `rg` checks for shader features and `m_EnableInstancingVariants` to confirm shaders support instancing and the flag was set, and those checks succeeded.  
- Scanned `Assets/Scripts` and `Assets/Prefabs` for `MaterialPropertyBlock` / per-renderer `.material` usage to ensure no per-renderer mutations, and that check succeeded.  
- Ran `git diff --check` to validate repository file formatting, and it succeeded; Unity Editor / Frame Debugger profiling and visual verification were not available in this CLI environment and must be run in-editor to confirm SetPass/batch delta and visual parity.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0472a5e728832aa7f434e5ce743505)