### PR TITLE
Fix pooled wasp debris destroy callbacks

### DIFF
--- a/Assets/Prefabs/Wasp/WaspRemains/Destroy.cs
+++ b/Assets/Prefabs/Wasp/WaspRemains/Destroy.cs
@@ -7,6 +7,14 @@ public class Destroy : MonoBehaviour
     [SerializeField] float Clock;
     public GameObject effect;
     public bool saveAfterKill;
+
+    bool destroySelfSuppressed;
+
+    public void SetDestroySelfSuppressed(bool suppressed)
+    {
+        destroySelfSuppressed = suppressed;
+    }
+
     // Start is called before the first frame update
     void Start()
     {
@@ -14,6 +22,9 @@ public class Destroy : MonoBehaviour
     }
     public void DestroySelf()
     {
+        if (destroySelfSuppressed)
+            return;
+
         if (effect!=null)
         {
             Instantiate(effect, gameObject.transform.position, Quaternion.identity);
@@ -31,6 +42,9 @@ public class Destroy : MonoBehaviour
     }
     private void OnCollisionEnter(Collision OBJ)
     {
+        if (destroySelfSuppressed)
+            return;
+
         if (OBJ.gameObject.CompareTag("Player"))
             DestroySelf();
     }

--- a/Assets/Scripts/NPC/Wasp/PooledDeathDebris.cs
+++ b/Assets/Scripts/NPC/Wasp/PooledDeathDebris.cs
@@ -150,7 +150,10 @@ namespace Beavermania.NPC
         void DisableSelfDestroyScripts()
         {
             for (var i = 0; i < selfDestroyScripts.Length; i++)
+            {
+                selfDestroyScripts[i].SetDestroySelfSuppressed(true);
                 selfDestroyScripts[i].enabled = false;
+            }
         }
 
         void OnCollisionEnter(Collision collision)


### PR DESCRIPTION
### Motivation
- Prevent pooled wasp debris instances from being destroyed by legacy collision callbacks on disabled `MonoBehaviour`s, which can break the pool by destroying pooled objects out from under the pool manager.

### Description
- Add a `destroySelfSuppressed` flag and `SetDestroySelfSuppressed` to the legacy `Destroy` component and guard `DestroySelf` and `OnCollisionEnter`, and have `PooledDeathDebris.DisableSelfDestroyScripts()` call `SetDestroySelfSuppressed(true)` before disabling those components so the pool owns the lifecycle.

### Testing
- Ran `git diff --check` which returned clean results.
- Verified the new symbol usages with `rg "SetDestroySelfSuppressed|destroySelfSuppressed|DisableSelfDestroyScripts"` and found the expected matches in `Destroy.cs` and `PooledDeathDebris.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ea54c6c4832a90377f1e9d1e7da2)