### PR TITLE
Follow-up: align CI compile symbols and drop UnityEditor reference

### DIFF
--- a/.ci/BeaverMania.CI.csproj
+++ b/.ci/BeaverMania.CI.csproj
@@ -5,6 +5,7 @@
     <LangVersion>9.0</LangVersion>
     <Nullable>disable</Nullable>
     <NoWarn>CS0649;CS0414;CS0169;CS0108;CS0114;CS0162</NoWarn>
+    <DefineConstants>TRACE;DEBUG;DEVELOPMENT_BUILD;UNITY_2021;UNITY_2021_3;UNITY_2021_3_OR_NEWER</DefineConstants>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <OutputType>Library</OutputType>
     <RootNamespace>BeaverMania</RootNamespace>
@@ -64,9 +65,6 @@
     </Reference>
     <Reference Include="UnityEngine.SubsystemsModule">
       <HintPath>/opt/unity/Editor/Data/Managed/UnityEngine/UnityEngine.SubsystemsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEditor">
-      <HintPath>/opt/unity/Editor/Data/Managed/UnityEditor.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule">
       <HintPath>/opt/unity/Editor/Data/Managed/UnityEngine/UnityEngine.Physics2DModule.dll</HintPath>


### PR DESCRIPTION
### Motivation
- Make the .NET CI compile check better match Unity’s player compilation by compiling symbol-guarded code paths and preventing runtime scripts from compiling against editor-only APIs.

### Description
- Add explicit preprocessor constants in `.ci/BeaverMania.CI.csproj` by inserting `<DefineConstants>TRACE;DEBUG;DEVELOPMENT_BUILD;UNITY_2021;UNITY_2021_3;UNITY_2021_3_OR_NEWER</DefineConstants>` so blocks behind `DEVELOPMENT_BUILD` and Unity version symbols are compiled during CI.
- Remove the global `UnityEditor.dll` `<Reference>` from `.ci/BeaverMania.CI.csproj` so runtime scripts are not allowed to compile against editor-only APIs.

### Testing
- Attempted to run `dotnet build .ci/BeaverMania.CI.csproj` in this environment and the command failed because the `dotnet` binary is not installed here (`/bin/bash: dotnet: command not found`), so compilation could not be validated in this runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13769145a4832a9196d3d5c7b5403c)