### PR TITLE
Add GivingTree terrain auto-fix and harden pooled VFX teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ crashlytics-build.properties
 !.ci/*.csproj
 .ci/bin/
 .ci/obj/
+
+# Agent debug session logs
+debug-*.log

--- a/Assets/Editor/FixLevel1ConsoleWarnings.cs
+++ b/Assets/Editor/FixLevel1ConsoleWarnings.cs
@@ -62,7 +62,7 @@ namespace Beavermania.EditorTools
             log.AppendLine("[FixLevel1ConsoleWarnings] Starting…");
 
             FixGivingTreeMaterials(log);
-            FixGivingTreeTerrainPrototypes(log);
+            GivingTreeTerrainAutoFix.RemoveGivingTreeTerrainPrototypes(log);
 
             var scene = EditorSceneManager.OpenScene(TargetScenePath, OpenSceneMode.Single);
             FixSceneTerrains(scene, log);
@@ -122,67 +122,6 @@ namespace Beavermania.EditorTools
             {
                 log.AppendLine("TheGivingTree prefab materials already use Nature/Soft Occlusion shaders.");
             }
-        }
-
-        static void FixGivingTreeTerrainPrototypes(StringBuilder log)
-        {
-            var givingTreePrefab = AssetDatabase.LoadAssetAtPath<GameObject>(GivingTreePrefabPath);
-            if (givingTreePrefab == null)
-                return;
-
-            var terrainDataPaths = AssetDatabase.FindAssets("t:TerrainData", new[] { "Assets" });
-            var removedPrototypes = 0;
-            var clearedInstances = 0;
-
-            foreach (var guid in terrainDataPaths)
-            {
-                var path = AssetDatabase.GUIDToAssetPath(guid);
-                var terrainData = AssetDatabase.LoadAssetAtPath<TerrainData>(path);
-                if (terrainData == null || terrainData.treePrototypes == null || terrainData.treePrototypes.Length == 0)
-                    continue;
-
-                var prototypes = terrainData.treePrototypes.ToList();
-                var indicesToRemove = new List<int>();
-                for (var i = 0; i < prototypes.Count; i++)
-                {
-                    var prototype = prototypes[i];
-                    if (prototype.prefab == null)
-                        continue;
-
-                    var isGivingTree = prototype.prefab == givingTreePrefab
-                        || string.Equals(prototype.prefab.name, "TheGivingTree", StringComparison.OrdinalIgnoreCase)
-                        || prototype.prefab.name.StartsWith("TheGivingTree", StringComparison.OrdinalIgnoreCase);
-
-                    if (!isGivingTree)
-                        continue;
-
-                    indicesToRemove.Add(i);
-                }
-
-                if (indicesToRemove.Count == 0)
-                    continue;
-
-                var removeSet = new HashSet<int>(indicesToRemove);
-                var keptPrototypes = new List<TreePrototype>(prototypes.Count - indicesToRemove.Count);
-                for (var i = 0; i < prototypes.Count; i++)
-                {
-                    if (removeSet.Contains(i))
-                        continue;
-
-                    keptPrototypes.Add(prototypes[i]);
-                }
-
-                terrainData.treePrototypes = keptPrototypes.ToArray();
-                terrainData.treeInstances = Array.Empty<TreeInstance>();
-                terrainData.RefreshPrototypes();
-                removedPrototypes += indicesToRemove.Count;
-                clearedInstances++;
-                EditorUtility.SetDirty(terrainData);
-                log.AppendLine("Removed TheGivingTree terrain prototype(s) from " + path + " (use scene prefab instances instead).");
-            }
-
-            if (removedPrototypes == 0)
-                log.AppendLine("No terrain tree prototypes named TheGivingTree found in TerrainData assets.");
         }
 
         static void FixSceneTerrains(Scene scene, StringBuilder log)

--- a/Assets/Editor/GivingTreeTerrainAutoFix.cs
+++ b/Assets/Editor/GivingTreeTerrainAutoFix.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+namespace Beavermania.EditorTools
+{
+    /// <summary>
+    /// Removes TheGivingTree from terrain tree prototypes (use scene prefab instances instead).
+    /// </summary>
+    public static class GivingTreeTerrainAutoFix
+    {
+        const string GivingTreePrefabPath = "Assets/Prefabs/Objects/Interactable/TheGivingTree.prefab";
+
+        [MenuItem("Beavermania/Fix/TheGivingTree — remove terrain tree prototypes")]
+        public static void ExecuteFromMenu()
+        {
+            if (!EditorUtility.DisplayDialog(
+                    "Remove GivingTree terrain prototypes",
+                    "Remove TheGivingTree from all TerrainData tree prototypes and clear painted tree instances?\n\nSave assets first.",
+                    "Run",
+                    "Cancel"))
+                return;
+
+            var log = new StringBuilder();
+            RemoveGivingTreeTerrainPrototypes(log);
+            AssetDatabase.SaveAssets();
+            Debug.Log(log.ToString());
+            EditorUtility.DisplayDialog("Terrain prototypes", "Done. Check the Console log.", "OK");
+        }
+
+        public static void RemoveGivingTreeTerrainPrototypes(StringBuilder log)
+        {
+            var givingTreePrefab = AssetDatabase.LoadAssetAtPath<GameObject>(GivingTreePrefabPath);
+            if (givingTreePrefab == null)
+            {
+                log.AppendLine("WARNING: Missing prefab at " + GivingTreePrefabPath);
+                return;
+            }
+
+            var terrainDataPaths = AssetDatabase.FindAssets("t:TerrainData", new[] { "Assets" });
+            var removedPrototypes = 0;
+            var clearedInstances = 0;
+
+            foreach (var guid in terrainDataPaths)
+            {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                var terrainData = AssetDatabase.LoadAssetAtPath<TerrainData>(path);
+                if (terrainData == null || terrainData.treePrototypes == null || terrainData.treePrototypes.Length == 0)
+                    continue;
+
+                var prototypes = terrainData.treePrototypes.ToList();
+                var indicesToRemove = new List<int>();
+                for (var i = 0; i < prototypes.Count; i++)
+                {
+                    var prototype = prototypes[i];
+                    if (prototype.prefab == null)
+                        continue;
+
+                    var isGivingTree = prototype.prefab == givingTreePrefab
+                        || string.Equals(prototype.prefab.name, "TheGivingTree", StringComparison.OrdinalIgnoreCase)
+                        || prototype.prefab.name.StartsWith("TheGivingTree", StringComparison.OrdinalIgnoreCase);
+
+                    if (!isGivingTree)
+                        continue;
+
+                    indicesToRemove.Add(i);
+                }
+
+                if (indicesToRemove.Count == 0)
+                    continue;
+
+                var removeSet = new HashSet<int>(indicesToRemove);
+                var keptPrototypes = new List<TreePrototype>(prototypes.Count - indicesToRemove.Count);
+                for (var i = 0; i < prototypes.Count; i++)
+                {
+                    if (removeSet.Contains(i))
+                        continue;
+
+                    keptPrototypes.Add(prototypes[i]);
+                }
+
+                terrainData.treePrototypes = keptPrototypes.ToArray();
+                terrainData.treeInstances = Array.Empty<TreeInstance>();
+                terrainData.RefreshPrototypes();
+                removedPrototypes += indicesToRemove.Count;
+                clearedInstances++;
+                EditorUtility.SetDirty(terrainData);
+                log.AppendLine("Removed TheGivingTree terrain prototype(s) from " + path + " (use scene prefab instances instead).");
+            }
+
+            if (removedPrototypes == 0)
+                log.AppendLine("No terrain tree prototypes named TheGivingTree found in TerrainData assets.");
+        }
+    }
+}

--- a/Assets/Editor/GivingTreeTerrainAutoFix.cs.meta
+++ b/Assets/Editor/GivingTreeTerrainAutoFix.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8f4a2e19b3d4c5a6e7f8091a2b3c4d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Wasp/WaspRemains/Destroy.cs
+++ b/Assets/Prefabs/Wasp/WaspRemains/Destroy.cs
@@ -15,6 +15,12 @@ public class Destroy : MonoBehaviour
         destroySelfSuppressed = suppressed;
     }
 
+    public void PrepareForPool()
+    {
+        destroySelfSuppressed = true;
+        enabled = false;
+    }
+
     // Start is called before the first frame update
     void Start()
     {

--- a/Assets/Scripts/Display/PooledOneShotVfx.cs
+++ b/Assets/Scripts/Display/PooledOneShotVfx.cs
@@ -141,6 +141,26 @@ namespace Beavermania.Display
                 effectObjects[i].enabled = false;
                 Destroy(effectObjects[i]);
             }
+
+            var monoBehaviours = instance.GetComponentsInChildren<MonoBehaviour>(true);
+            for (var i = 0; i < monoBehaviours.Length; i++)
+            {
+                var behaviour = monoBehaviours[i];
+                if (behaviour == null || behaviour is EffectObject || behaviour is PooledOneShotVfx)
+                    continue;
+
+                if (behaviour.GetType().Name != "CFX_AutoDestructShuriken")
+                    continue;
+
+                behaviour.enabled = false;
+                Destroy(behaviour);
+            }
+
+            var destroyScripts = instance.GetComponentsInChildren<global::Destroy>(true);
+            for (var i = 0; i < destroyScripts.Length; i++)
+            {
+                destroyScripts[i].PrepareForPool();
+            }
         }
 
         void Bind(ObjectPool<PooledOneShotVfx> sourcePool)

--- a/Assets/Scripts/NPC/Wasp/PooledDeathDebris.cs
+++ b/Assets/Scripts/NPC/Wasp/PooledDeathDebris.cs
@@ -154,8 +154,7 @@ namespace Beavermania.NPC
                 if (selfDestroyScripts[i] == null)
                     continue;
 
-                selfDestroyScripts[i].SetDestroySelfSuppressed(true);
-                selfDestroyScripts[i].enabled = false;
+                selfDestroyScripts[i].PrepareForPool();
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Tracks the GivingTree terrain prototype cleanup and pooled VFX/debris hardening work from local changes.

## Files touched
- `Assets/Editor/GivingTreeTerrainAutoFix.cs` (new) — standalone menu to strip TheGivingTree from TerrainData prototypes
- `Assets/Editor/FixLevel1ConsoleWarnings.cs` — delegates terrain prototype cleanup to the new tool
- `Assets/Scripts/Display/PooledOneShotVfx.cs` — disables Cartoon FX auto-destruct and `Destroy` scripts on pooled instances
- `Assets/Prefabs/Wasp/WaspRemains/Destroy.cs` — adds `PrepareForPool()`
- `Assets/Scripts/NPC/Wasp/PooledDeathDebris.cs` — uses `PrepareForPool()`
- `.gitignore` — ignores `debug-*.log` (e.g. `debug-79336b.log`)

## Risk level
**Medium** — editor tooling + pooling behavior; no scene edits in this PR.

## Verification performed
- `dotnet build` on `.ci/BeaverMania.CI.csproj` — **0 errors, 0 warnings**

## Not included (already on `main` or local-only)
- `TheGivingTree.prefab`, `LogSpawner.cs`, `GameplayAudio.cs` — no diff vs `main` in cloud workspace; merge any extra local edits manually if needed.
- `debug-79336b.log` — intentionally excluded via `.gitignore`.

## Unity manual checks required
- [ ] Run **Beavermania → Fix → TheGivingTree — remove terrain tree prototypes** on a copy of project assets; confirm Console log and no terrain paint regressions.
- [ ] Chop a Giving Tree / spawn TreeDeath VFX repeatedly; confirm pooled effect returns to pool (no early `Destroy` from CFX auto-destruct).
- [ ] Kill several wasps; confirm debris still despawns and pools without duplicate destroy callbacks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea920330-86f8-4395-9d75-0964302f6ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea920330-86f8-4395-9d75-0964302f6ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

