### PR TITLE
[codex] Add Beavermania Codex guidance and safety skills

### DIFF
--- a/.agents/skills/beavermania-pr-reviewer/SKILL.md
+++ b/.agents/skills/beavermania-pr-reviewer/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: beavermania-pr-reviewer
+description: Use this skill to review a Beavermania branch or PR before merge. Checks scope, changed files, regression risk, commit quality, and prepares a concise PR summary.
+---
+
+# Beavermania PR Reviewer
+
+Review the branch or diff before merge.
+
+## Check
+
+- Does the diff match the requested task?
+- Were unrelated files changed?
+- Were scene or prefab files changed unexpectedly?
+- Are there regression risks?
+- Are manual Unity checks required?
+- Is the change small enough to merge safely?
+
+## Output
+
+## PR Summary
+
+Short summary of the change.
+
+## Changed Files
+
+List important files and why they changed.
+
+## Risk Assessment
+
+Low / Medium / High with explanation.
+
+## Required Verification
+
+List Play Mode or build checks.
+
+## Merge Recommendation
+
+Merge / Do not merge / Needs manual Unity verification first.

--- a/.agents/skills/beavermania-script-fixer/SKILL.md
+++ b/.agents/skills/beavermania-script-fixer/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: beavermania-script-fixer
+description: Use this skill for small, isolated Beavermania Unity C# bug fixes, null checks, guard clauses, state logic fixes, and minimal script-level changes. Do not use for prefab, scene, animation, or UI hierarchy edits.
+---
+
+# Beavermania Script Fixer
+
+## Allowed
+
+- C# script changes.
+- Small state logic corrections.
+- Null guards and defensive checks.
+- Minimal method edits.
+- Local helper methods when useful.
+
+## Not Allowed
+
+- Prefab edits.
+- Scene edits.
+- Animation clip edits.
+- UI hierarchy edits.
+- Broad refactors.
+- Unrelated cleanup.
+- Renaming serialized fields.
+- Changing public APIs unless required by the scoped fix.
+
+## Process
+
+1. Identify the smallest set of files involved.
+2. Explain the likely cause.
+3. Make the minimal code change.
+4. Avoid changing unrelated behavior.
+5. Summarize changed files.
+6. Provide Unity Play Mode verification steps.
+
+## Unity Risk Rules
+
+- Preserve serialized fields.
+- Do not remove public fields.
+- Do not rename `MonoBehaviour` classes.
+- Do not rename files containing `MonoBehaviour` classes.
+- Do not assume Inspector references are assigned.
+- Add clear warnings or null guards when references may be missing.
+
+## Output Required
+
+- Files changed.
+- Behavior changed.
+- Risk level.
+- Manual Unity verification steps.
+- Any Inspector assignment required.

--- a/.agents/skills/beavermania-unity-safety-reviewer/SKILL.md
+++ b/.agents/skills/beavermania-unity-safety-reviewer/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: beavermania-unity-safety-reviewer
+description: Use this skill to review Beavermania Unity changes for prefab, scene, serialized reference, Inspector, animation, and gameplay regression risks. Prefer this before committing Unity-heavy changes.
+---
+
+# Beavermania Unity Safety Reviewer
+
+Review the current diff as a Unity safety reviewer.
+
+## Check For
+
+- Accidental prefab changes.
+- Accidental scene changes.
+- Broken serialized references.
+- Renamed serialized fields.
+- Renamed `MonoBehaviour` classes.
+- Deleted public or serialized fields.
+- Changes to PlayerCanvas, Trader, Dialogue, Shop, Player, or Level scenes.
+- Logic that depends on missing Inspector references.
+- Risky changes in `Update`, `FixedUpdate`, or `LateUpdate`.
+
+## Required Output
+
+1. Safe to commit? Yes/No.
+2. High-risk files changed.
+3. Potential Unity serialization issues.
+4. Potential gameplay regressions.
+5. Required manual Play Mode checks.
+6. Recommended rollback or split if needed.
+
+## Behavior
+
+- Do not implement changes unless explicitly asked.
+- Focus on review and risk detection.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,235 +1,175 @@
-# BeaverMania — Agent Instructions
+# Beavermania — Codex Agent Instructions
 
-## Cursor Cloud specific instructions
+## 1. Project Identity
 
-### Environment Overview
+Beavermania is a Unity 2021.3.3f1 3D cartoon action/platformer targeting a Steam-ready Windows PC release. The game includes player movement and combat, NPC and trader dialogue/shop interactions, audio systems, checkpoints and game-flow, menus, enemies, pickups, and performance-sensitive levels.
 
-This is a Unity 2021.3.3f1 C# game project (3D action-platformer). It has **no backend services, no databases, no Docker dependencies**. The entire product runs as a standalone Unity game.
+This is a Unity project with fragile serialized references. Treat scene, prefab, UI, Animator, and Inspector wiring as runtime assets rather than ordinary editable source files.
 
-### Available Tools
+Useful project constraints:
 
-| Tool | Location | Purpose |
-|------|----------|---------|
-| Unity Editor | `/opt/unity/Editor/Unity` | Batch-mode builds, tests, scene loading (requires license) |
-| .NET SDK 8.0 | `dotnet` | C# compilation checking via `.ci/BeaverMania.CI.csproj` |
-| Cinemachine source | `/opt/unity-packages/cinemachine/` | Package source for compilation |
+- The product is a standalone Unity game with no backend service, database, or Docker dependency.
+- Use `Beavermania.*` namespaces for migrated or new game code, following [README.md](README.md) and [MIGRATION.md](MIGRATION.md).
+- Unity 2021.3 supports C# 9; `.ci/BeaverMania.CI.csproj` uses `LangVersion 9.0`.
+- Do not change `.meta` GUIDs for frozen or prefab-bound scripts. See [MIGRATION.md](MIGRATION.md).
 
-### Compilation / Lint Check
+## 2. Default Codex Role
 
-```bash
-cd /workspace/BeaverMania/.ci && dotnet build BeaverMania.CI.csproj
-```
+Codex should default to cautious script-level assistance and review.
 
-This compiles all 88 game scripts (`Assets/Scripts/`) plus prefab scripts (`Assets/Prefabs/`) against Unity's managed DLLs and Cinemachine source. Zero warnings/errors means the code is valid C# that will compile in Unity.
+Codex may:
 
-**Suppressed warnings** (via `NoWarn` in the csproj): CS0649 (unassigned serialized fields — normal for Unity inspector-assigned fields), CS0414 (fields used by Unity serialization), CS0169, CS0108, CS0114, CS0162.
+- Inspect code and explain systems.
+- Fix small, isolated C# bugs.
+- Add defensive guards and null-reference protection.
+- Improve local state logic with minimal behavior impact.
+- Review diffs and identify regression, compilation, and Unity serialization risks.
+- Prepare commit summaries and PR summaries.
+- Perform code-level performance and audio routing review.
+- Use worktrees for isolated experiments.
 
-### Unity Editor Batch Mode (requires license)
+Codex should avoid unless explicitly requested:
 
-If a Unity license file (`.ulf`) is placed at `~/.local/share/unity3d/Unity/Unity_lic.ulf`, the editor can be used:
+- Broad refactors or architecture changes.
+- Gameplay behavior changes outside the stated scope.
+- Scene, prefab, animation clip, Animator, or UI hierarchy edits.
+- Serialized Inspector reference changes.
+- Unrelated cleanup.
+- Unity integration claims that have not been verified in the Editor.
 
-```bash
-/opt/unity/Editor/Unity -batchmode -nographics -projectPath /workspace -logFile - -quit
-```
+## 3. Tool Division
 
-Without a license, the editor will exit with code 1 and a "Missing or bad username or password" message. This is expected.
+| Tool | Use For | Do Not Rely On It For |
+| --- | --- | --- |
+| Codex Desktop | Isolated C# fixes, null guards, local state fixes, diff review, summaries, worktree experiments, code-level performance/audio review | Prefab/scene/UI hierarchy/animation wiring or visual validation |
+| Cursor + Unity Editor | Prefab and scene hierarchy editing, UI wiring, animation work, serialized Inspector assignments, Play Mode and visual debugging, complex Unity integration | Replacing independent code review |
+| Codex Web / GitHub | PR review, second-opinion regression review, pre-merge risk checks | Editing or validating local Unity runtime wiring |
 
-### Tests
+Existing Cursor workflow guidance remains relevant: use planning/review for multi-system work, and only use focused implementation for a small, known script bug with a specific expected outcome.
 
-No automated unit/integration tests exist in this project. The `com.unity.test-framework` package is referenced but no test assemblies have been created.
+## 4. High-Risk Files and Areas
 
-### Key Caveats
+Treat these as high risk:
 
-- **No `Library/` folder**: This is gitignored. Unity resolves packages on first open. The `.ci/` compilation project uses pre-extracted DLLs as a workaround.
-- **Scene files are binary YAML**: Do not hand-edit `.unity` or `.prefab` files unless you understand Unity YAML serialization.
-- **GUID preservation**: See `MIGRATION.md` — never change `.meta` file GUIDs for frozen scripts.
-- **Namespace conventions**: See `README.md` and user rules — use `Beavermania.*` namespaces (e.g., `Beavermania.Player`, `Beavermania.Core.GameFlow`).
-- **C# version**: Unity 2021.3 supports C# 9. The CI project uses `LangVersion 9.0`.
+- `PlayerCanvas.prefab`
+- `Trader.prefab`
+- `TraderPanel.prefab`
+- Level 1 scenes, including Level 1 Remastered scenes
+- Player prefabs
+- Animation clips and Animator-bound changes
+- Dialogue and shop UI panels
+- Checkpoint and game-flow scripts
+- Audio routing scripts
+- Player combat scripts
 
----
+Examples present in this repository include:
 
-## AI Development Workflow
+- `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
+- `Assets/Prefabs/BeaverNPC/Trader.prefab`
+- `Assets/Prefabs/Objects/UI/TraderPanel.prefab`
+- `Assets/Scenes/Level 1.unity`
+- `Assets/Scenes/Level 1 - Remastered - Steam.unity`
+- `Assets/Prefabs/OtterPlayer/Player Updated.prefab`
+- `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab`
 
-### Tool / Agent Roles
+Do not edit Unity YAML scene or prefab files casually. Never touch multiple prefabs or scenes in one pass unless explicitly requested.
 
-| Tool | Use For | Avoid |
-|------|---------|-------|
-| **Cursor Plan** | Architecture, refactors, multi-system bug analysis, risky Unity changes | Direct implementation without review |
-| **Cursor Agent** | Focused implementation of one clear task | Broad refactors or unrelated cleanup |
-| **Cursor Multitask** | Independent parallel tasks that don't share files | Player/Input/Camera/Trader/Audio systems with shared dependencies |
-| **Codex** | PR review, code review, regression analysis, compile-risk review, summarizing completed changes | Unity PlayMode validation without video/context |
-| **Unity Editor** | Final source of truth for runtime behavior, serialized references, prefabs, scenes, UI bindings, PlayMode behavior | Not a replacement for code review |
+## 5. Unity Safety Rules
 
-### Mode Selection Rules
+- Prefer script-level fixes before prefab-level changes.
+- Do not casually edit `.unity`, `.prefab`, animation, or other serialized asset files.
+- Do not rename serialized fields unless migration is handled.
+- Do not remove public or serialized fields without checking prefab and scene usage.
+- Do not rename or move `MonoBehaviour` files/classes without checking GUID and serialized binding consequences.
+- Do not assume Inspector references exist; add null checks where missing references are plausible.
+- If an Inspector assignment is required, list it clearly as manual work instead of guessing or changing YAML.
+- Preserve `.meta` files and GUIDs, especially the frozen and prefab-bound scripts listed in [MIGRATION.md](MIGRATION.md).
+- Any requested prefab, scene, Animator, UI binding, ScriptableObject, or runtime object-wiring change requires Unity Play Mode verification.
 
-**Use Cursor Plan** when the task touches:
-- Player movement, combat, or input
-- Trader, dialogue, or shop integration
-- Camera switching
-- Pause, restart, checkpoint, win/lose flow
-- Audio manager, music persistence, volume sliders
-- Scene/prefab wiring
-- Any refactor across multiple scripts
+System-specific constraints retained from existing project guidance:
 
-**Use Cursor Agent** when:
-- The bug is isolated
-- The target scripts are known
-- The expected behavior is specific
-- The change can be verified with `dotnet build` and one Unity PlayMode test
+- `PlayerInputReader` owns input events and action-map switching. Gameplay scripts subscribe to it; do not add raw duplicate input paths or hand-edit generated input files unless specifically required.
+- Game-flow code must not implement player movement or combat. Pause/resume must restore `Time.timeScale` and cursor state correctly; restart/checkpoint work requires Play Mode checks.
+- Player work must account for input, animation, camera, and Inspector references; avoid growing a god script.
+- Trader proximity should only show interaction prompts. Dialogue/shop opening and closing must correctly restore UI, camera, cursor, and player control.
+- Audio work must verify correct music/SFX routing and volume behavior in Play Mode; do not duplicate `AudioSource` components as a shortcut.
 
-**Use Cursor Multitask** only when:
-- Tasks are independent
-- Files do not depend on each other
-- No shared serialized references are involved
-- No scene/prefab integration is required
+## 6. Coding Style
 
-**Use Codex** for:
-- Reviewing a finished branch or PR
-- Finding risky regressions
-- Checking whether a proposed fix is safe
-- Summarizing what changed
-- Verifying whether additional commits are still relevant
-
----
-
-## Unity Runtime Safety Rules
-
-The `.ci/BeaverMania.CI.csproj` build is **only a C# sanity check**.
-
-**It validates:**
-- C# syntax
-- Compile errors
-- Missing `using` statements
-- Broken type references
-- Some namespace/class conflicts
-
-**It does NOT validate:**
-- Inspector-assigned references
-- Missing scripts on prefabs
-- Scene object references
-- Animator controller parameters
-- UI Button OnClick bindings
-- ScriptableObject assignments
-- Camera transitions
-- Cursor lock/visibility state
-- PlayMode-only behavior
-
-**Rule:** Any change involving Unity serialization, prefabs, scenes, Animator, UI buttons, ScriptableObjects, or runtime object wiring **must** include a manual Unity verification checklist in the agent's response.
-
----
-
-## System Ownership Map
-
-### Input
-
-**Primary files:** `PlayerInputReader`, BeaverInputSystem generated files, player/controller scripts subscribing to input events.
-
-**Rules:**
-- `PlayerInputReader` owns input events and action map switching.
-- Gameplay scripts subscribe to `PlayerInputReader` events — do not read raw input directly.
-- Do not add duplicate input pathways unless explicitly required.
-- Do not hand-edit generated input system files unless the task explicitly asks for it.
-
-### Game Flow
-
-**Primary systems:** GameMaster, pause menu, restart/checkpoint flow, win/lose flow, cursor visibility and lock state.
-
-**Rules:**
-- Game flow code should not directly implement player movement or combat.
-- Pause/resume must restore `Time.timeScale` and cursor state correctly.
-- Restart/checkpoint changes must be verified in Unity PlayMode.
-
-### Player
-
-**Primary systems:** Movement, jump, sprint, combat, health, animation driver, inventory/pickups.
-
-**Rules:**
-- Avoid growing a single god script.
-- Prefer small components with clear responsibilities when refactoring is explicitly requested.
-- Do not broadly refactor player systems unless the task explicitly asks for it.
-- Any player change must consider input, animation, camera, and inspector references.
-
-### NPC / Trader
-
-**Primary systems:** Trader interaction trigger, dialogue UI, shop UI, camera switch, ObjectiveText prompt.
-
-**Rules:**
-- Trader proximity should only show the interaction prompt.
-- Dialogue/shop should open only after player input.
-- Closing shop/dialogue must restore UI state, camera state, cursor state, and player control.
-- Do not solve trader UI bugs by duplicating panels or creating parallel state flows.
-
-### Audio
-
-**Primary systems:** Music playlist, SFX, UI volume sliders, music/SFX balance.
-
-**Rules:**
-- Music should persist across scene transitions if the current design requires it.
-- UI sliders must control the correct audio sources or mixers.
-- Do not solve audio bugs by blindly duplicating AudioSources.
-- Volume changes must be tested in PlayMode.
-
----
-
-## Change Policy
-
-### Before Changing Code
-
-Agents must:
-- Identify the exact files involved.
-- State whether prefabs, scenes, or inspector references are affected.
+- Make minimal, focused changes.
 - Avoid unrelated cleanup.
-- Avoid broad rewrites unless explicitly requested.
-- Prefer small, reviewable changes.
+- Preserve existing gameplay feel unless the request explicitly changes it.
+- Prefer small components or helpers only when they solve the stated issue without broadening scope.
+- Avoid allocations in `Update`, `FixedUpdate`, `LateUpdate`, and other hot loops.
+- Avoid repeated `GetComponent` calls in hot paths when a stable reference can be cached safely.
+- Use `Beavermania.*` namespaces where the current migration conventions require them.
+- Keep changes compatible with Unity 2021.3 and C# 9.
 
-### After Changing Code
+## 7. Verification Expectations
 
-Run:
+For C# changes, run the compilation check when the environment supports it:
+
+```bash
+dotnet build .ci/BeaverMania.CI.csproj
+```
+
+In the Cursor Cloud environment, the equivalent documented command is:
 
 ```bash
 cd /workspace/BeaverMania/.ci && dotnet build BeaverMania.CI.csproj
 ```
 
-Then report:
-- Files changed
-- What behavior changed
-- What the CI build confirms
-- What still requires Unity Editor verification
-- Any assumptions made
-- Any risks or limitations
+Environment notes retained from existing project guidance:
 
-### Definition of Done
+- `Library/` is gitignored; Unity resolves packages when the project first opens.
+- The `.ci/` project is a compilation workaround that references Unity managed assemblies and Cinemachine source; its normal Unity serialization warnings are suppressed in the project file.
+- In the documented Cursor Cloud environment, Unity Editor is at `/opt/unity/Editor/Unity` and can only perform batch-mode checks when a valid Unity license is present.
 
-A task is **not complete** until:
-- C# compilation passes, or the failure is clearly explained.
-- No unrelated systems were modified.
-- Unity-specific manual checks are listed.
-- Known limitations are stated.
-- The agent clearly separates what was verified by CI from what still requires Unity PlayMode testing.
+This build checks syntax, type references, namespaces, and other C# compilation issues. It does not verify Inspector assignments, missing prefab scripts, scene references, Animator parameters, UI Button bindings, camera transitions, cursor state, audio behavior, or runtime gameplay.
 
----
+No automated Unity unit/integration tests are currently documented for this project. Unity Editor/Play Mode remains the source of truth for serialized and runtime behavior.
 
-## Refactor Safety Rules
+After any change, report:
 
-- Do not perform large architecture refactors during bug fixes.
-- Do not rename scripts/classes without considering Unity serialization and `.meta` GUIDs.
-- Do not move scripts unless necessary.
-- Do not delete old scripts unless references have been checked.
-- Prefer adding safe adapter code over breaking existing serialized references.
-- If a refactor is necessary, first produce a plan and list affected systems.
+- Changed files.
+- Behavior changed.
+- Risk level.
+- Verification performed and what it proves.
+- Manual Unity verification steps.
+- Whether Inspector or prefab assignments are required.
+- Assumptions, risks, and limitations.
 
----
+Do not claim a bug is fully fixed without an available build/test/run verification that demonstrates it. When runtime Unity behavior remains untested, state: "Needs Unity Play Mode verification."
 
-## Prompting / Reporting Standard
+## 8. Branch and Worktree Policy
 
-Agents should structure responses as:
+- Risky tasks should use a separate branch or worktree.
+- Never work directly on `main` for agent-driven changes.
+- Keep a branch focused on one bug or one review objective.
+- Do not allow Codex and Cursor/Unity to edit the same prefab, scene, animation, or UI hierarchy files concurrently.
 
-1. **Summary** — Short description of the task.
-2. **Files touched** — List of files expected to change.
-3. **Risk level:**
-   - **Low** — pure C# isolated change
-   - **Medium** — touches multiple scripts
-   - **High** — touches prefabs/scenes/inspector/UI/Animator/player/trader/game flow
-4. **Implementation summary** — What was done.
-5. **Verification performed** — CI build result, tests run.
-6. **Unity manual checks required** — What must be verified in the editor.
+Recommended branch names:
+
+- `fix/trader-shop-close`
+- `fix/audio-slider-sfx`
+- `fix/lookrotation-zero-vector`
+- `review/performance-gc`
+- `refactor/player-combat-safe`
+
+## 9. Current Project Priorities
+
+- Steam release candidate stability.
+- Level 1 Remastered integration.
+- Trader, dialogue, and shop stability.
+- Player combat polish.
+- Audio balance and routing.
+- FPS and rendering stability.
+- Avoid large architecture work unless it directly supports Steam release stability.
+
+For repo-local workflow detail, read:
+
+- [AI_CONTEXT/PROJECT_OVERVIEW.md](AI_CONTEXT/PROJECT_OVERVIEW.md)
+- [AI_CONTEXT/CURRENT_STATUS.md](AI_CONTEXT/CURRENT_STATUS.md)
+- [AI_CONTEXT/UNITY_SAFETY_RULES.md](AI_CONTEXT/UNITY_SAFETY_RULES.md)
+- [AI_CONTEXT/CODEX_WORKFLOW.md](AI_CONTEXT/CODEX_WORKFLOW.md)
+- [AI_CONTEXT/REVIEW_CHECKLIST.md](AI_CONTEXT/REVIEW_CHECKLIST.md)

--- a/AI_CONTEXT/CODEX_WORKFLOW.md
+++ b/AI_CONTEXT/CODEX_WORKFLOW.md
@@ -1,0 +1,16 @@
+# Codex Workflow
+
+1. Use Codex for a small isolated C# script change or a focused review.
+2. Use a branch or worktree for risky tasks.
+3. Keep each Codex task focused on one bug or one review.
+4. Do not let Codex and Cursor edit the same prefab, scene, animation, or UI files at the same time.
+5. Use Cursor with Unity Editor for prefab, UI hierarchy, animation, scene, serialized Inspector, and visual/Play Mode work.
+6. Use Codex to review the result after Cursor implementation.
+7. Before merge, run the `beavermania-pr-reviewer` skill.
+8. After any changes, require a short report containing:
+   - Changed files.
+   - Risk level.
+   - Verification steps performed.
+   - Whether Unity Play Mode verification is still required.
+
+For script fixes, prefer `beavermania-script-fixer`. For Unity asset/serialization risk review, prefer `beavermania-unity-safety-reviewer`.

--- a/AI_CONTEXT/CURRENT_STATUS.md
+++ b/AI_CONTEXT/CURRENT_STATUS.md
@@ -1,0 +1,16 @@
+# Current Status
+
+## Main Current Goal
+
+Steam release candidate stability.
+
+## Current Focus Areas
+
+- Level 1 Remastered integration and stability.
+- Trader UI, dialogue, and shop flow.
+- Player combat polish.
+- FireBreath, SwordGlare, Bow, and Stoning regression risks.
+- Audio balance and SFX/music routing.
+- FPS and rendering optimization.
+
+Large architecture work should be deferred unless it directly stabilizes the Steam release candidate.

--- a/AI_CONTEXT/PROJECT_OVERVIEW.md
+++ b/AI_CONTEXT/PROJECT_OVERVIEW.md
@@ -1,0 +1,13 @@
+# Beavermania Project Overview
+
+Beavermania is a Unity 3D cartoon action/platformer aimed at a Steam-ready Windows PC release. Its tone combines cartoon action and comedy with exploration and combat.
+
+Core systems include:
+
+- Player movement and combat systems.
+- NPCs plus trader, dialogue, and shop interactions.
+- Music, sound effects, audio balance, and routing.
+- Checkpoints, pause/menu behavior, and win/lose game-flow.
+- Enemies, pickups, and moment-to-moment gameplay feedback.
+
+The current release effort is sensitive to performance and integration quality in Level 1 and Level 1 Remastered content. Prefab, scene, animation, UI, and Inspector wiring changes must be treated as Unity integration work, not ordinary code edits.

--- a/AI_CONTEXT/REVIEW_CHECKLIST.md
+++ b/AI_CONTEXT/REVIEW_CHECKLIST.md
@@ -1,0 +1,12 @@
+# Review Checklist
+
+- [ ] Does the diff match the requested task?
+- [ ] Were unrelated files changed?
+- [ ] Were prefabs or scenes changed unexpectedly?
+- [ ] Were serialized fields renamed or removed?
+- [ ] Were public fields changed?
+- [ ] Are plausible missing Inspector references protected with appropriate null checks?
+- [ ] Are `Update`, `FixedUpdate`, `LateUpdate`, or other hot loops affected?
+- [ ] Is manual Inspector assignment required?
+- [ ] Is Unity Play Mode verification required?
+- [ ] Is this safe to commit or merge?

--- a/AI_CONTEXT/UNITY_SAFETY_RULES.md
+++ b/AI_CONTEXT/UNITY_SAFETY_RULES.md
@@ -1,0 +1,13 @@
+# Unity Safety Rules
+
+- Do not casually edit scenes, prefabs, animation clips, Animator assets, or UI hierarchy assets.
+- Avoid hand-editing Unity YAML unless a task explicitly scopes the asset edit and Unity validation is available.
+- Preserve serialized fields and existing `.meta` GUIDs.
+- Avoid renaming or moving `MonoBehaviour` classes and their files.
+- Avoid changing or removing public fields used by the Inspector without checking every serialized use and planning migration.
+- Prefer C# guards and local script fixes over prefab edits where possible.
+- Do not assume Inspector references are assigned. Handle plausible missing references defensively.
+- If an Inspector assignment is required, list it as manual Unity work rather than attempting to infer asset wiring.
+- Any scene or prefab change requires Unity Play Mode verification.
+
+See [../MIGRATION.md](../MIGRATION.md) for frozen script GUIDs and migration-sensitive bindings.


### PR DESCRIPTION
## Summary

- establish a Codex-focused `AGENTS.md` policy for small script-level changes and review work
- add `AI_CONTEXT` documentation for project scope, current priorities, Unity safety, workflow, and reviews
- add three local Beavermania skills for script fixing, Unity safety review, and PR review

## Why

Beavermania has fragile Unity serialization, prefab, scene, UI, animation, and Inspector wiring surfaces. These repository instructions keep Codex scoped to focused C# and review work by default, while directing Unity-heavy integration to Cursor and Unity Editor.

## Verification

- confirmed the PR scope is limited to the nine requested Markdown guidance files
- confirmed exactly three repo-local skill directories are included
- confirmed no `.cs`, `.unity`, `.prefab`, `.anim`, `.controller`, or `.meta` files are changed
- ran `git diff --check origin/main...HEAD`

## Notes

- This is documentation-only; no Unity Play Mode validation is required for the PR content itself.
- The branch is currently one commit behind `main`; update it before merge if GitHub reports a conflict or branch update is required.