### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,3 +173,32 @@ For repo-local workflow detail, read:
 - [AI_CONTEXT/UNITY_SAFETY_RULES.md](AI_CONTEXT/UNITY_SAFETY_RULES.md)
 - [AI_CONTEXT/CODEX_WORKFLOW.md](AI_CONTEXT/CODEX_WORKFLOW.md)
 - [AI_CONTEXT/REVIEW_CHECKLIST.md](AI_CONTEXT/REVIEW_CHECKLIST.md)
+
+## Cursor Cloud specific instructions
+
+### Environment summary
+
+- **.NET SDK 8.0** is pre-installed. The update script runs `dotnet restore .ci/BeaverMania.CI.csproj` on startup.
+- **Unity Editor 2021.3.3f1** is at `/opt/unity/Editor/Unity`. It can report its version and run batch-mode commands, but Play Mode / GUI testing requires a valid Unity license (not present by default in the Cloud VM).
+- **Unity managed DLLs** are at `/opt/unity/Editor/Data/Managed/UnityEngine/`.
+- **Cinemachine source** is at `/opt/unity-packages/cinemachine/`.
+
+### Compilation check (primary verification)
+
+```bash
+cd /workspace/.ci && dotnet build BeaverMania.CI.csproj
+```
+
+This validates C# syntax, type references, and namespaces across all scripts in `Assets/Scripts/` and `Assets/Prefabs/`. It does **not** verify Inspector assignments, runtime gameplay, or serialized references.
+
+### What you cannot do in Cloud without a Unity license
+
+- Open the Unity Editor GUI or enter Play Mode.
+- Run Unity Test Runner (EditMode/PlayMode tests).
+- Build the game executable.
+
+These require a user-activated Unity license on the VM.
+
+### No other services or dependencies
+
+This is a standalone Unity game project. There are no backend services, databases, Docker containers, npm/pip packages, or web servers to start.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting the Cloud VM development environment for future agents.

## Changes

- Documents pre-installed .NET SDK 8.0 and Unity Editor 2021.3.3f1 paths
- Adds the primary compilation check command (`dotnet build .ci/BeaverMania.CI.csproj`)
- Notes Unity license limitations in the Cloud VM (no Play Mode, no GUI, no builds)
- Clarifies that no external services, databases, or containers are needed

## Verification

Build succeeds with 0 warnings and 0 errors:

[build_output.log](https://cursor.com/agents/bc-625de97a-5642-475f-8a64-782b60a0f601/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-625de97a-5642-475f-8a64-782b60a0f601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-625de97a-5642-475f-8a64-782b60a0f601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

