### PR TITLE
Add Shadow Revenant enemy scripts

### DIFF
--- a/Assets/Scenes/ShadowRevenantTestArena.unity
+++ b/Assets/Scenes/ShadowRevenantTestArena.unity
@@ -1,0 +1,552 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 1
+  m_FogColor: {r: 0.12, g: 0.11, b: 0.16, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.012
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.18, g: 0.19, b: 0.23, a: 1}
+  m_AmbientEquatorColor: {r: 0.11, g: 0.12, b: 0.14, a: 1}
+  m_AmbientGroundColor: {r: 0.05, g: 0.05, b: 0.06, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 600003}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 1
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &100000
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740855, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580562239172740874, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+--- !u!1001 &100100
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917452, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6569126030801917456, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+      propertyPath: m_Name
+      value: PlayerCanvas
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e33166206a9c19842a1fdd668271b2f5, type: 3}
+--- !u!1 &200000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 200001}
+  - component: {fileID: 200002}
+  m_Layer: 0
+  m_Name: ShadowRevenantTestSceneBinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &200001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 200000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &200002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 200000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af3fe8a0b8684ce1b4ac7cbdcd56a0bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &300000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 300001}
+  - component: {fileID: 300002}
+  - component: {fileID: 300003}
+  - component: {fileID: 300004}
+  - component: {fileID: 300005}
+  m_Layer: 0
+  m_Name: ShadowRevenantTestArenaFloor
+  m_TagString: Isle
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &300001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.05, z: 8}
+  m_LocalScale: {x: 38, y: 0.1, z: 38}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &300002
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300000}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &300003
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300000}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10302, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &300004
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300000}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!64 &300005
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300000}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 0
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}
+--- !u!1 &400000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 400001}
+  - component: {fileID: 400002}
+  - component: {fileID: 400003}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 400000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &400002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 400000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!114 &400003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 400000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!1 &600000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 600001}
+  - component: {fileID: 600003}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &600001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 600000}
+  m_LocalRotation: {x: 0.4619398, y: -0.1913417, z: 0.3314136, w: 0.8001032}
+  m_LocalPosition: {x: 0, y: 8, z: -6}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!108 &600003
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 600000}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.88, b: 0.7, a: 1}
+  m_Intensity: 1.2
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0

--- a/Assets/Scenes/ShadowRevenantTestArena.unity.meta
+++ b/Assets/Scenes/ShadowRevenantTestArena.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7c0f9d7a82bb4e1a8fde821cc282ea8f
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Data/NPC.meta
+++ b/Assets/Scripts/Data/NPC.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0fccd8ef347e489dbd5c1c2ce3673271
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Data/NPC/ShadowRevenant.meta
+++ b/Assets/Scripts/Data/NPC/ShadowRevenant.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98ba322007c440fdb2b24017716f96c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Data/NPC/ShadowRevenant/ShadowRevenantConfig.cs
+++ b/Assets/Scripts/Data/NPC/ShadowRevenant/ShadowRevenantConfig.cs
@@ -1,0 +1,107 @@
+using Beavermania.NPC;
+using UnityEngine;
+
+namespace Beavermania.Data.NPC
+{
+    [CreateAssetMenu(fileName = "ShadowRevenantConfig", menuName = "Beavermania/NPC/Shadow Revenant Config")]
+    public sealed class ShadowRevenantConfig : ScriptableObject
+    {
+        [Header("Health")]
+        public int maxHealth = 3200;
+        [Range(0f, 2f)] public float normalDamageMultiplier = 1f;
+        [Range(0f, 1f)] public float phasedDamageMultiplier = 0f;
+        [Range(1f, 4f)] public float lightBrokenDamageMultiplier = 1.5f;
+
+        [Header("Detection")]
+        public float aggroRange = 42f;
+        public float leashRange = 70f;
+        public float faceTurnSpeed = 8f;
+        public float strafeSpeed = 4f;
+
+        [Header("Phase Shift")]
+        public float phaseCooldown = 8f;
+        public float phaseDuration = 2.4f;
+        public float phaseWindup = 0.35f;
+        public float phaseTriggerRange = 18f;
+        public float teleportMinRadius = 9f;
+        public float teleportMaxRadius = 17f;
+        public float teleportRaycastHeight = 12f;
+        public float teleportClearanceRadius = 1.2f;
+        public int teleportValidationAttempts = 12;
+        public LayerMask teleportGroundMask = ~0;
+        public LayerMask teleportObstructionMask;
+
+        [Header("Shadow Projectile")]
+        public ShadowRevenantProjectile projectilePrefab;
+        public int projectileDamage = 24;
+        public float projectileSpeed = 24f;
+        public float projectileLifetime = 5f;
+        public float projectileCooldown = 2.2f;
+        public float projectileWindup = 0.45f;
+        public float projectileRecover = 0.45f;
+        public float projectileRange = 36f;
+
+        [Header("Dread Fog")]
+        public ShadowRevenantDreadFogZone fogPrefab;
+        public float fogRadius = 5f;
+        public float fogDuration = 5f;
+        public float fogDamagePerTick = 10f;
+        public float fogTickInterval = 0.75f;
+        [Range(0f, 1f)] public float fogSlowPercent = 0.3f;
+        public float fogCooldown = 7f;
+        public float fogWindup = 0.55f;
+        public float fogRecover = 0.6f;
+        public float fogRange = 24f;
+
+        [Header("Shade Summon")]
+        public ShadowRevenantShadeMinion shadeMinionPrefab;
+        public int maxActiveMinions = 3;
+        public int summonCount = 2;
+        public float summonCooldown = 12f;
+        public float summonWindup = 0.8f;
+        public float summonRecover = 0.7f;
+        public float shadeMoveSpeed = 6f;
+        public float shadeDamage = 12f;
+        public float shadeDamageCooldown = 1.2f;
+        public float shadeLifetime = 18f;
+
+        [Header("Light Break")]
+        public float lightBreakVulnerableDuration = 4f;
+        public float lightBreakStaggerSeconds = 0.45f;
+
+        [Header("Pools")]
+        public int projectilePrewarmCount = 8;
+        public int projectileMaxActive = 24;
+        public int fogPrewarmCount = 4;
+        public int fogMaxActive = 8;
+        public int shadePrewarmCount = 3;
+        public int shadeMaxActive = 6;
+
+        [Header("Drops and VFX")]
+        public GameObject[] deathDropPrefabs;
+        public GameObject hitVfxPrefab;
+        public GameObject deathVfxPrefab;
+        public GameObject phaseVfxPrefab;
+        public GameObject lightBreakVfxPrefab;
+
+        void OnValidate()
+        {
+            WarnIf(maxHealth <= 0, "maxHealth must be > 0.");
+            WarnIf(aggroRange <= 0f, "aggroRange must be > 0.");
+            WarnIf(leashRange < aggroRange, "leashRange should be >= aggroRange.");
+            WarnIf(teleportMaxRadius < teleportMinRadius, "teleportMaxRadius must be >= teleportMinRadius.");
+            WarnIf(teleportValidationAttempts <= 0, "teleportValidationAttempts must be > 0.");
+            WarnIf(projectileSpeed <= 0f, "projectileSpeed must be > 0.");
+            WarnIf(projectileLifetime <= 0f, "projectileLifetime must be > 0.");
+            WarnIf(fogTickInterval <= 0f, "fogTickInterval must be > 0.");
+            WarnIf(maxActiveMinions < 0, "maxActiveMinions must be >= 0.");
+            WarnIf(summonCount < 0, "summonCount must be >= 0.");
+        }
+
+        void WarnIf(bool condition, string message)
+        {
+            if (condition)
+                Debug.LogWarning($"{name}: {message}", this);
+        }
+    }
+}

--- a/Assets/Scripts/Data/NPC/ShadowRevenant/ShadowRevenantConfig.cs.meta
+++ b/Assets/Scripts/Data/NPC/ShadowRevenant/ShadowRevenantConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acb0e34192624e9c8862e434012c1fab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77242a11b5fd4c5682c7ccb0d9c4cc01
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/EnemyDamageType.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/EnemyDamageType.cs
@@ -1,0 +1,9 @@
+namespace Beavermania.NPC
+{
+    public enum EnemyDamageType
+    {
+        Normal = 0,
+        Light = 1,
+        Fire = 2
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/EnemyDamageType.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/EnemyDamageType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c287e753dc0e4d6490c0bd5547ac06b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/IEnemyDamageReceiver.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/IEnemyDamageReceiver.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Beavermania.NPC
+{
+    public interface IEnemyDamageReceiver
+    {
+        bool ReceiveDamage(int damage, EnemyDamageType damageType, Transform source);
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/IEnemyDamageReceiver.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/IEnemyDamageReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d607b685d1c45c5a6667be9bd472268
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/ILightBreakReactive.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ILightBreakReactive.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Beavermania.NPC
+{
+    public interface ILightBreakReactive
+    {
+        bool ApplyLightBreak(float duration, Transform source);
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/ILightBreakReactive.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/ILightBreakReactive.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a5f5090b2b244e59f3cbb758258dbc0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/IShadowRevenantPooledItem.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/IShadowRevenantPooledItem.cs
@@ -1,0 +1,9 @@
+namespace Beavermania.NPC
+{
+    public interface IShadowRevenantPooledItem
+    {
+        bool IsPoolActive { get; }
+
+        void DeactivateToPool();
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/IShadowRevenantPooledItem.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/IShadowRevenantPooledItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d42ad8819cd4ddbaac99f1c2ce2db3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/IShadowRevenantTarget.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/IShadowRevenantTarget.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Beavermania.NPC
+{
+    public interface IShadowRevenantTarget
+    {
+        Transform TargetTransform { get; }
+        bool CanReceiveShadowDamage { get; }
+        bool IsAvoidingDamage { get; }
+        bool IsParrying { get; }
+
+        void ReceiveShadowDamage(float damage);
+        bool TryApplyDreadFogSlow(float slowPercent, float duration);
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/IShadowRevenantTarget.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/IShadowRevenantTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3252459be9d4864b317f0e5f9f13d68
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantController.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantController.cs
@@ -1,0 +1,565 @@
+using Beavermania.Data.NPC;
+using Beavermania.Display;
+using Beavermania.Objects;
+using UnityEngine;
+
+namespace Beavermania.NPC
+{
+    public sealed class ShadowRevenantController : MonoBehaviour, IEnemyDamageReceiver, ILightBreakReactive
+    {
+        const float DirectionEpsilon = 0.0001f;
+
+        static readonly int PhasedHash = Animator.StringToHash("Phased");
+        static readonly int AttackHash = Animator.StringToHash("Attack");
+        static readonly int StaggerHash = Animator.StringToHash("Stagger");
+        static readonly int SummonHash = Animator.StringToHash("Summon");
+        static readonly int DeadHash = Animator.StringToHash("Dead");
+
+        [SerializeField] ShadowRevenantConfig config;
+        [SerializeField] Transform targetTransform;
+        [SerializeField] Transform projectileMuzzle;
+        [SerializeField] Transform fogSpawnAnchor;
+        [SerializeField] Transform[] shadeSpawnPoints;
+        [SerializeField] Rigidbody body;
+        [SerializeField] Animator animator;
+        [SerializeField] NPC_Health healthBar;
+        [SerializeField] ShadowRevenantPoolHub poolHub;
+        [SerializeField] Collider[] phaseDisabledColliders;
+
+        IShadowRevenantTarget target;
+        ShadowRevenantState state = ShadowRevenantState.Dormant;
+        int currentHealth;
+        float stateTimer;
+        float projectileCooldownRemaining;
+        float fogCooldownRemaining;
+        float summonCooldownRemaining;
+        float phaseCooldownRemaining;
+        float lightBrokenRemaining;
+        bool deathHandled;
+        bool teleportApplied;
+
+        public ShadowRevenantState State => state;
+        public int CurrentHealth => currentHealth;
+
+        void Awake()
+        {
+            CacheReferences();
+            if (poolHub != null)
+                poolHub.Initialize(config);
+        }
+
+        void Start()
+        {
+            ResolveTarget();
+            ResetHealth();
+            EnterState(ShadowRevenantState.Dormant, 0f);
+        }
+
+        void OnEnable()
+        {
+            deathHandled = false;
+        }
+
+        void Update()
+        {
+            if (state == ShadowRevenantState.Dead || deathHandled)
+                return;
+
+            TickCooldowns();
+            TickState();
+        }
+
+        void FixedUpdate()
+        {
+            if (state == ShadowRevenantState.Strafe)
+                StrafeAroundTarget();
+        }
+
+        void CacheReferences()
+        {
+            if (body == null)
+                body = GetComponent<Rigidbody>();
+
+            if (animator == null)
+                animator = GetComponentInChildren<Animator>();
+
+            if (poolHub == null)
+                poolHub = GetComponent<ShadowRevenantPoolHub>();
+        }
+
+        void ResetHealth()
+        {
+            currentHealth = config != null ? Mathf.Max(1, config.maxHealth) : 1;
+            if (healthBar != null)
+                healthBar.SetMaxNPCHealth(currentHealth);
+        }
+
+        void ResolveTarget()
+        {
+            if (targetTransform == null)
+            {
+                GameObject playerObject = GameObject.FindGameObjectWithTag("Player");
+                if (playerObject != null)
+                    targetTransform = playerObject.transform;
+            }
+
+            target = targetTransform != null ? targetTransform.GetComponentInParent<IShadowRevenantTarget>() : null;
+            if (target == null && targetTransform != null)
+                target = targetTransform.GetComponentInChildren<IShadowRevenantTarget>();
+        }
+
+        void TickCooldowns()
+        {
+            projectileCooldownRemaining = Mathf.Max(0f, projectileCooldownRemaining - Time.deltaTime);
+            fogCooldownRemaining = Mathf.Max(0f, fogCooldownRemaining - Time.deltaTime);
+            summonCooldownRemaining = Mathf.Max(0f, summonCooldownRemaining - Time.deltaTime);
+            phaseCooldownRemaining = Mathf.Max(0f, phaseCooldownRemaining - Time.deltaTime);
+
+            if (lightBrokenRemaining > 0f)
+                lightBrokenRemaining = Mathf.Max(0f, lightBrokenRemaining - Time.deltaTime);
+        }
+
+        void TickState()
+        {
+            stateTimer -= Time.deltaTime;
+
+            if (currentHealth <= 0)
+            {
+                Die();
+                return;
+            }
+
+            if (config == null || target == null || target.TargetTransform == null)
+                return;
+
+            switch (state)
+            {
+                case ShadowRevenantState.Dormant:
+                    TickDormant();
+                    break;
+                case ShadowRevenantState.Idle:
+                case ShadowRevenantState.Strafe:
+                    TickDecisionState();
+                    break;
+                case ShadowRevenantState.ProjectileWindup:
+                    TickProjectileWindup();
+                    break;
+                case ShadowRevenantState.ProjectileRecover:
+                    TickRecover(ShadowRevenantState.Strafe);
+                    break;
+                case ShadowRevenantState.FogWindup:
+                    TickFogWindup();
+                    break;
+                case ShadowRevenantState.FogRecover:
+                    TickRecover(ShadowRevenantState.Strafe);
+                    break;
+                case ShadowRevenantState.SummonWindup:
+                    TickSummonWindup();
+                    break;
+                case ShadowRevenantState.SummonRecover:
+                    TickRecover(ShadowRevenantState.Strafe);
+                    break;
+                case ShadowRevenantState.PhaseShiftEnter:
+                    TickPhaseShiftEnter();
+                    break;
+                case ShadowRevenantState.Phased:
+                    TickPhased();
+                    break;
+                case ShadowRevenantState.LightBroken:
+                case ShadowRevenantState.Staggered:
+                    TickLightBroken();
+                    break;
+                case ShadowRevenantState.Teleport:
+                    EnterState(ShadowRevenantState.Phased, config.phaseDuration);
+                    break;
+            }
+        }
+
+        void TickDormant()
+        {
+            if (DistanceToTarget() <= config.aggroRange)
+                EnterState(ShadowRevenantState.Idle, 0.5f);
+        }
+
+        void TickDecisionState()
+        {
+            FaceTarget();
+
+            float distance = DistanceToTarget();
+            if (distance > config.leashRange)
+            {
+                EnterState(ShadowRevenantState.Dormant, 0f);
+                return;
+            }
+
+            if (TryStartPhase(distance))
+                return;
+
+            if (TryStartSummon())
+                return;
+
+            if (TryStartFog(distance))
+                return;
+
+            if (TryStartProjectile(distance))
+                return;
+
+            if (state != ShadowRevenantState.Strafe)
+                EnterState(ShadowRevenantState.Strafe, 0f);
+        }
+
+        bool TryStartPhase(float distance)
+        {
+            if (phaseCooldownRemaining > 0f || distance > config.phaseTriggerRange || lightBrokenRemaining > 0f)
+                return false;
+
+            EnterState(ShadowRevenantState.PhaseShiftEnter, config.phaseWindup);
+            phaseCooldownRemaining = config.phaseCooldown;
+            return true;
+        }
+
+        bool TryStartProjectile(float distance)
+        {
+            if (projectileCooldownRemaining > 0f || distance > config.projectileRange)
+                return false;
+
+            EnterState(ShadowRevenantState.ProjectileWindup, config.projectileWindup);
+            return true;
+        }
+
+        bool TryStartFog(float distance)
+        {
+            if (fogCooldownRemaining > 0f || distance > config.fogRange)
+                return false;
+
+            EnterState(ShadowRevenantState.FogWindup, config.fogWindup);
+            return true;
+        }
+
+        bool TryStartSummon()
+        {
+            if (summonCooldownRemaining > 0f || poolHub == null || config.maxActiveMinions <= 0)
+                return false;
+
+            if (poolHub.ActiveShadeCount >= config.maxActiveMinions)
+                return false;
+
+            EnterState(ShadowRevenantState.SummonWindup, config.summonWindup);
+            return true;
+        }
+
+        void TickProjectileWindup()
+        {
+            FaceTarget();
+            if (stateTimer > 0f)
+                return;
+
+            FireProjectile();
+            projectileCooldownRemaining = config.projectileCooldown;
+            EnterState(ShadowRevenantState.ProjectileRecover, config.projectileRecover);
+        }
+
+        void TickFogWindup()
+        {
+            FaceTarget();
+            if (stateTimer > 0f)
+                return;
+
+            SpawnFog();
+            fogCooldownRemaining = config.fogCooldown;
+            EnterState(ShadowRevenantState.FogRecover, config.fogRecover);
+        }
+
+        void TickSummonWindup()
+        {
+            FaceTarget();
+            if (stateTimer > 0f)
+                return;
+
+            SpawnShades();
+            summonCooldownRemaining = config.summonCooldown;
+            EnterState(ShadowRevenantState.SummonRecover, config.summonRecover);
+        }
+
+        void TickPhaseShiftEnter()
+        {
+            FaceTarget();
+            if (stateTimer > 0f)
+                return;
+
+            EnterState(ShadowRevenantState.Teleport, 0f);
+        }
+
+        void TickPhased()
+        {
+            FaceTarget();
+            if (!teleportApplied)
+            {
+                teleportApplied = true;
+                transform.position = ResolveTeleportPosition();
+                SpawnVfx(config.phaseVfxPrefab, transform.position);
+            }
+
+            if (stateTimer <= 0f)
+                EnterState(ShadowRevenantState.Strafe, 0f);
+        }
+
+        void TickLightBroken()
+        {
+            FaceTarget();
+            if (stateTimer <= 0f || lightBrokenRemaining <= 0f)
+                EnterState(ShadowRevenantState.Strafe, 0f);
+        }
+
+        void TickRecover(ShadowRevenantState nextState)
+        {
+            FaceTarget();
+            if (stateTimer <= 0f)
+                EnterState(nextState, 0f);
+        }
+
+        void FireProjectile()
+        {
+            if (poolHub == null || target == null || target.TargetTransform == null)
+                return;
+
+            Vector3 origin = projectileMuzzle != null ? projectileMuzzle.position : transform.position + Vector3.up;
+            Vector3 aimPoint = target.TargetTransform.position + Vector3.up;
+            Vector3 direction = aimPoint - origin;
+            if (direction.sqrMagnitude <= DirectionEpsilon)
+                direction = transform.forward;
+
+            Quaternion rotation = Quaternion.LookRotation(direction.normalized, Vector3.up);
+            poolHub.SpawnProjectile(origin, rotation, direction, target);
+        }
+
+        void SpawnFog()
+        {
+            if (poolHub == null || target == null || target.TargetTransform == null)
+                return;
+
+            Vector3 position = fogSpawnAnchor != null ? fogSpawnAnchor.position : target.TargetTransform.position;
+            poolHub.SpawnFog(position, target);
+        }
+
+        void SpawnShades()
+        {
+            if (poolHub == null || target == null)
+                return;
+
+            int count = Mathf.Min(config.summonCount, config.maxActiveMinions - poolHub.ActiveShadeCount);
+            for (var i = 0; i < count; i++)
+            {
+                Transform spawnPoint = ResolveShadeSpawnPoint(i);
+                Vector3 position = spawnPoint != null
+                    ? spawnPoint.position
+                    : transform.position + transform.right * (i - count * 0.5f);
+                poolHub.SpawnShade(position, target);
+            }
+        }
+
+        Transform ResolveShadeSpawnPoint(int index)
+        {
+            if (shadeSpawnPoints == null || shadeSpawnPoints.Length == 0)
+                return null;
+
+            return shadeSpawnPoints[index % shadeSpawnPoints.Length];
+        }
+
+        Vector3 ResolveTeleportPosition()
+        {
+            if (target == null || target.TargetTransform == null)
+                return transform.position;
+
+            Vector3 targetPosition = target.TargetTransform.position;
+            int attempts = Mathf.Max(1, config.teleportValidationAttempts);
+            for (var i = 0; i < attempts; i++)
+            {
+                Vector2 circle = Random.insideUnitCircle.normalized;
+                if (circle.sqrMagnitude <= DirectionEpsilon)
+                    circle = Vector2.right;
+
+                float radius = Random.Range(config.teleportMinRadius, config.teleportMaxRadius);
+                Vector3 candidate = targetPosition + new Vector3(circle.x, 0f, circle.y) * radius;
+                Vector3 rayOrigin = candidate + Vector3.up * Mathf.Max(0.1f, config.teleportRaycastHeight);
+
+                if (!Physics.Raycast(rayOrigin, Vector3.down, out RaycastHit hit, config.teleportRaycastHeight * 2f, config.teleportGroundMask, QueryTriggerInteraction.Ignore))
+                    continue;
+
+                Vector3 grounded = hit.point;
+                if (config.teleportObstructionMask.value != 0
+                    && Physics.CheckSphere(grounded + Vector3.up, config.teleportClearanceRadius, config.teleportObstructionMask, QueryTriggerInteraction.Ignore))
+                {
+                    continue;
+                }
+
+                return grounded;
+            }
+
+            return transform.position;
+        }
+
+        void StrafeAroundTarget()
+        {
+            if (config == null || body == null || target == null || target.TargetTransform == null)
+                return;
+
+            Vector3 toTarget = target.TargetTransform.position - transform.position;
+            Vector3 horizontal = new Vector3(toTarget.x, 0f, toTarget.z);
+            if (horizontal.sqrMagnitude <= DirectionEpsilon)
+                return;
+
+            Vector3 tangent = Vector3.Cross(Vector3.up, horizontal.normalized);
+            Vector3 velocity = tangent * config.strafeSpeed;
+            body.velocity = new Vector3(velocity.x, body.velocity.y, velocity.z);
+        }
+
+        void FaceTarget()
+        {
+            if (config == null || target == null || target.TargetTransform == null)
+                return;
+
+            Vector3 toTarget = target.TargetTransform.position - transform.position;
+            Vector3 horizontal = new Vector3(toTarget.x, 0f, toTarget.z);
+            if (horizontal.sqrMagnitude <= DirectionEpsilon)
+                return;
+
+            Quaternion desired = Quaternion.LookRotation(horizontal.normalized, Vector3.up);
+            transform.rotation = Quaternion.Slerp(transform.rotation, desired, config.faceTurnSpeed * Time.deltaTime);
+        }
+
+        float DistanceToTarget()
+        {
+            if (target == null || target.TargetTransform == null)
+                return float.MaxValue;
+
+            return Vector3.Distance(transform.position, target.TargetTransform.position);
+        }
+
+        public bool ReceiveDamage(int damage, EnemyDamageType damageType, Transform source)
+        {
+            if (deathHandled || currentHealth <= 0 || config == null)
+                return false;
+
+            bool isLightBreakDamage = damageType == EnemyDamageType.Light || damageType == EnemyDamageType.Fire;
+            if (isLightBreakDamage)
+                ApplyLightBreak(config.lightBreakVulnerableDuration, source);
+
+            float multiplier = ResolveDamageMultiplier(isLightBreakDamage);
+            int resolvedDamage = Mathf.RoundToInt(Mathf.Max(0, damage) * multiplier);
+            if (resolvedDamage <= 0)
+                return false;
+
+            currentHealth = Mathf.Max(0, currentHealth - resolvedDamage);
+            if (healthBar != null)
+                healthBar.SetNPCHealth(currentHealth);
+
+            SpawnVfx(config.hitVfxPrefab, transform.position + Vector3.up);
+            if (currentHealth <= 0)
+                Die();
+
+            return true;
+        }
+
+        float ResolveDamageMultiplier(bool isLightBreakDamage)
+        {
+            if (lightBrokenRemaining > 0f)
+                return config.lightBrokenDamageMultiplier;
+
+            if (state == ShadowRevenantState.Phased || state == ShadowRevenantState.PhaseShiftEnter || state == ShadowRevenantState.Teleport)
+                return isLightBreakDamage ? config.lightBrokenDamageMultiplier : config.phasedDamageMultiplier;
+
+            return config.normalDamageMultiplier;
+        }
+
+        public bool ApplyLightBreak(float duration, Transform source)
+        {
+            if (deathHandled || config == null)
+                return false;
+
+            lightBrokenRemaining = Mathf.Max(duration, config.lightBreakStaggerSeconds);
+            EnterState(ShadowRevenantState.LightBroken, lightBrokenRemaining);
+            SpawnVfx(config.lightBreakVfxPrefab, transform.position + Vector3.up);
+            return true;
+        }
+
+        void EnterState(ShadowRevenantState nextState, float duration)
+        {
+            state = nextState;
+            stateTimer = Mathf.Max(0f, duration);
+
+            bool phased = nextState == ShadowRevenantState.PhaseShiftEnter
+                || nextState == ShadowRevenantState.Phased
+                || nextState == ShadowRevenantState.Teleport;
+            SetPhaseCollision(!phased);
+
+            if (animator != null)
+            {
+                animator.SetBool(PhasedHash, phased);
+                if (nextState == ShadowRevenantState.ProjectileWindup || nextState == ShadowRevenantState.FogWindup)
+                    animator.SetTrigger(AttackHash);
+                if (nextState == ShadowRevenantState.SummonWindup)
+                    animator.SetTrigger(SummonHash);
+                if (nextState == ShadowRevenantState.LightBroken || nextState == ShadowRevenantState.Staggered)
+                    animator.SetTrigger(StaggerHash);
+            }
+
+            if (nextState != ShadowRevenantState.Phased)
+                teleportApplied = false;
+        }
+
+        void SetPhaseCollision(bool enabled)
+        {
+            if (phaseDisabledColliders == null)
+                return;
+
+            for (var i = 0; i < phaseDisabledColliders.Length; i++)
+            {
+                if (phaseDisabledColliders[i] != null)
+                    phaseDisabledColliders[i].enabled = enabled;
+            }
+        }
+
+        void Die()
+        {
+            if (deathHandled)
+                return;
+
+            deathHandled = true;
+            state = ShadowRevenantState.Dead;
+            SetPhaseCollision(true);
+
+            if (body != null)
+                body.velocity = Vector3.zero;
+
+            if (animator != null)
+                animator.SetTrigger(DeadHash);
+
+            SpawnVfx(config != null ? config.deathVfxPrefab : null, transform.position + Vector3.up);
+            SpawnDrops();
+            gameObject.SetActive(false);
+        }
+
+        void SpawnDrops()
+        {
+            if (config == null || config.deathDropPrefabs == null)
+                return;
+
+            for (var i = 0; i < config.deathDropPrefabs.Length; i++)
+            {
+                GameObject dropPrefab = config.deathDropPrefabs[i];
+                if (dropPrefab == null)
+                    continue;
+
+                GameObject drop = Instantiate(dropPrefab, transform.position + Vector3.up * 0.5f, Quaternion.identity);
+                CurrencySpin.ConfigureEnemyDrop(drop);
+            }
+        }
+
+        void SpawnVfx(GameObject prefab, Vector3 position)
+        {
+            if (prefab != null)
+                PooledOneShotVfx.Spawn(prefab, position, Quaternion.identity);
+        }
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantController.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f032a9e9716d474cb37338525cde42af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantDreadFogZone.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantDreadFogZone.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Beavermania.NPC
+{
+    public sealed class ShadowRevenantDreadFogZone : MonoBehaviour, IShadowRevenantPooledItem
+    {
+        struct TargetTick
+        {
+            public IShadowRevenantTarget Target;
+            public float NextDamageTime;
+        }
+
+        [SerializeField] SphereCollider fogCollider;
+        [SerializeField] Transform visualRoot;
+
+        readonly List<TargetTick> trackedTargets = new List<TargetTick>(4);
+        Action<ShadowRevenantDreadFogZone> releaseToPool;
+        float damagePerTick;
+        float tickInterval;
+        float slowPercent;
+        float lifetimeRemaining;
+        bool released = true;
+
+        public bool IsPoolActive => !released;
+
+        public void Bind(Action<ShadowRevenantDreadFogZone> releaseAction)
+        {
+            releaseToPool = releaseAction;
+            CacheReferences();
+        }
+
+        void Awake()
+        {
+            CacheReferences();
+        }
+
+        void CacheReferences()
+        {
+            if (fogCollider == null)
+                fogCollider = GetComponent<SphereCollider>();
+        }
+
+        public void Activate(
+            Vector3 position,
+            float radius,
+            float duration,
+            float tickDamage,
+            float damageInterval,
+            float fogSlowPercent,
+            IShadowRevenantTarget initialTarget)
+        {
+            CacheReferences();
+            released = false;
+            transform.position = position;
+            trackedTargets.Clear();
+            damagePerTick = Mathf.Max(0f, tickDamage);
+            tickInterval = Mathf.Max(0.05f, damageInterval);
+            slowPercent = Mathf.Clamp01(fogSlowPercent);
+            lifetimeRemaining = Mathf.Max(0.05f, duration);
+
+            if (fogCollider != null)
+            {
+                fogCollider.isTrigger = true;
+                fogCollider.radius = Mathf.Max(0.1f, radius);
+                fogCollider.enabled = true;
+            }
+
+            if (visualRoot != null)
+            {
+                float diameter = Mathf.Max(0.1f, radius) * 2f;
+                visualRoot.localScale = new Vector3(diameter, visualRoot.localScale.y, diameter);
+            }
+
+            if (initialTarget != null)
+                TrackTarget(initialTarget, Time.time);
+        }
+
+        void Update()
+        {
+            if (released)
+                return;
+
+            lifetimeRemaining -= Time.deltaTime;
+            if (lifetimeRemaining <= 0f)
+                DeactivateToPool();
+        }
+
+        void OnTriggerStay(Collider other)
+        {
+            if (released || other == null)
+                return;
+
+            IShadowRevenantTarget target = other.GetComponentInParent<IShadowRevenantTarget>();
+            if (target == null || !target.CanReceiveShadowDamage)
+                return;
+
+            float now = Time.time;
+            int index = TrackTarget(target, now);
+            if (index < 0 || trackedTargets[index].NextDamageTime > now)
+                return;
+
+            target.ReceiveShadowDamage(damagePerTick);
+            target.TryApplyDreadFogSlow(slowPercent, tickInterval);
+
+            TargetTick tick = trackedTargets[index];
+            tick.NextDamageTime = now + tickInterval;
+            trackedTargets[index] = tick;
+        }
+
+        int TrackTarget(IShadowRevenantTarget target, float now)
+        {
+            for (var i = 0; i < trackedTargets.Count; i++)
+            {
+                if (trackedTargets[i].Target == target)
+                    return i;
+            }
+
+            trackedTargets.Add(new TargetTick
+            {
+                Target = target,
+                NextDamageTime = now
+            });
+            return trackedTargets.Count - 1;
+        }
+
+        public void DeactivateToPool()
+        {
+            if (released)
+                return;
+
+            released = true;
+            trackedTargets.Clear();
+            lifetimeRemaining = 0f;
+
+            if (fogCollider != null)
+                fogCollider.enabled = false;
+
+            if (releaseToPool != null)
+                releaseToPool(this);
+            else
+                gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantDreadFogZone.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantDreadFogZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a19cc8cca634e12a842f1bf4bfac9d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPlayerTargetAdapter.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPlayerTargetAdapter.cs
@@ -1,0 +1,34 @@
+using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
+using UnityEngine;
+
+namespace Beavermania.NPC
+{
+    public sealed class ShadowRevenantPlayerTargetAdapter : MonoBehaviour, IShadowRevenantTarget
+    {
+        [SerializeField] BeaverPlayer player;
+
+        public Transform TargetTransform => player != null ? player.transform : transform;
+        public bool CanReceiveShadowDamage => player != null && player.isActiveAndEnabled;
+        public bool IsAvoidingDamage => player != null && player.Rolling;
+        public bool IsParrying => player != null && player.isParried;
+
+        void Awake()
+        {
+            if (player == null)
+                player = GetComponent<BeaverPlayer>();
+        }
+
+        public void ReceiveShadowDamage(float damage)
+        {
+            if (!CanReceiveShadowDamage || damage <= 0f || IsAvoidingDamage)
+                return;
+
+            player.TakeDamage(damage);
+        }
+
+        public bool TryApplyDreadFogSlow(float slowPercent, float duration)
+        {
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPlayerTargetAdapter.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPlayerTargetAdapter.cs
@@ -5,7 +5,14 @@ namespace Beavermania.NPC
 {
     public sealed class ShadowRevenantPlayerTargetAdapter : MonoBehaviour, IShadowRevenantTarget
     {
+        const float MaxSlowPercent = 0.9f;
+
         [SerializeField] BeaverPlayer player;
+
+        float cachedWalkSpeed;
+        float cachedRunSpeed;
+        float slowExpiresAt;
+        bool dreadFogSlowActive;
 
         public Transform TargetTransform => player != null ? player.transform : transform;
         public bool CanReceiveShadowDamage => player != null && player.isActiveAndEnabled;
@@ -18,6 +25,19 @@ namespace Beavermania.NPC
                 player = GetComponent<BeaverPlayer>();
         }
 
+        void Update()
+        {
+            if (!dreadFogSlowActive || Time.time < slowExpiresAt)
+                return;
+
+            RestoreDreadFogSlow();
+        }
+
+        void OnDisable()
+        {
+            RestoreDreadFogSlow();
+        }
+
         public void ReceiveShadowDamage(float damage)
         {
             if (!CanReceiveShadowDamage || damage <= 0f || IsAvoidingDamage)
@@ -28,7 +48,38 @@ namespace Beavermania.NPC
 
         public bool TryApplyDreadFogSlow(float slowPercent, float duration)
         {
-            return false;
+            if (!CanReceiveShadowDamage || slowPercent <= 0f || duration <= 0f)
+                return false;
+
+            if (!dreadFogSlowActive)
+            {
+                cachedWalkSpeed = player.Walk;
+                cachedRunSpeed = player.Run;
+                dreadFogSlowActive = true;
+            }
+
+            float speedMultiplier = 1f - Mathf.Clamp(slowPercent, 0f, MaxSlowPercent);
+            player.Walk = cachedWalkSpeed * speedMultiplier;
+            player.Run = cachedRunSpeed * speedMultiplier;
+            slowExpiresAt = Mathf.Max(slowExpiresAt, Time.time + duration);
+            return true;
+        }
+
+        void RestoreDreadFogSlow()
+        {
+            if (!dreadFogSlowActive)
+                return;
+
+            if (player != null)
+            {
+                player.Walk = cachedWalkSpeed;
+                player.Run = cachedRunSpeed;
+            }
+
+            cachedWalkSpeed = 0f;
+            cachedRunSpeed = 0f;
+            slowExpiresAt = 0f;
+            dreadFogSlowActive = false;
         }
     }
 }

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPlayerTargetAdapter.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPlayerTargetAdapter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: edd42dabf99540e2b253115bd8b516cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPoolHub.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPoolHub.cs
@@ -1,0 +1,187 @@
+using System.Collections.Generic;
+using Beavermania.Data.NPC;
+using UnityEngine;
+using UnityEngine.Pool;
+
+namespace Beavermania.NPC
+{
+    public sealed class ShadowRevenantPoolHub : MonoBehaviour
+    {
+        [SerializeField] ShadowRevenantConfig config;
+        [SerializeField] Transform poolRoot;
+
+        ObjectPool<ShadowRevenantProjectile> projectilePool;
+        ObjectPool<ShadowRevenantDreadFogZone> fogPool;
+        ObjectPool<ShadowRevenantShadeMinion> shadePool;
+
+        public int ActiveShadeCount => shadePool != null ? shadePool.CountActive : 0;
+
+        public void Initialize(ShadowRevenantConfig revenantConfig)
+        {
+            if (config == null)
+                config = revenantConfig;
+
+            EnsurePools();
+        }
+
+        void Awake()
+        {
+            EnsurePools();
+        }
+
+        public ShadowRevenantProjectile SpawnProjectile(
+            Vector3 position,
+            Quaternion rotation,
+            Vector3 direction,
+            IShadowRevenantTarget target)
+        {
+            EnsurePools();
+            if (projectilePool == null || config == null || projectilePool.CountActive >= Mathf.Max(1, config.projectileMaxActive))
+                return null;
+
+            ShadowRevenantProjectile projectile = projectilePool.Get();
+            projectile.Activate(
+                position,
+                rotation,
+                direction,
+                target,
+                config.projectileDamage,
+                config.projectileSpeed,
+                config.projectileLifetime);
+            return projectile;
+        }
+
+        public ShadowRevenantDreadFogZone SpawnFog(Vector3 position, IShadowRevenantTarget target)
+        {
+            EnsurePools();
+            if (fogPool == null || config == null || fogPool.CountActive >= Mathf.Max(1, config.fogMaxActive))
+                return null;
+
+            ShadowRevenantDreadFogZone fog = fogPool.Get();
+            fog.Activate(
+                position,
+                config.fogRadius,
+                config.fogDuration,
+                config.fogDamagePerTick,
+                config.fogTickInterval,
+                config.fogSlowPercent,
+                target);
+            return fog;
+        }
+
+        public ShadowRevenantShadeMinion SpawnShade(Vector3 position, IShadowRevenantTarget target)
+        {
+            EnsurePools();
+            if (shadePool == null || config == null || shadePool.CountActive >= Mathf.Max(1, config.shadeMaxActive))
+                return null;
+
+            ShadowRevenantShadeMinion shade = shadePool.Get();
+            shade.Activate(
+                position,
+                target,
+                config.shadeMoveSpeed,
+                config.shadeDamage,
+                config.shadeDamageCooldown,
+                config.shadeLifetime);
+            return shade;
+        }
+
+        void EnsurePools()
+        {
+            if (config == null)
+                return;
+
+            if (poolRoot == null)
+                poolRoot = transform;
+
+            if (projectilePool == null && config.projectilePrefab != null)
+            {
+                projectilePool = CreatePool(
+                    config.projectilePrefab,
+                    Mathf.Max(1, config.projectilePrewarmCount),
+                    Mathf.Max(1, config.projectileMaxActive));
+                Prewarm(projectilePool, Mathf.Max(0, config.projectilePrewarmCount));
+            }
+
+            if (fogPool == null && config.fogPrefab != null)
+            {
+                fogPool = CreatePool(
+                    config.fogPrefab,
+                    Mathf.Max(1, config.fogPrewarmCount),
+                    Mathf.Max(1, config.fogMaxActive));
+                Prewarm(fogPool, Mathf.Max(0, config.fogPrewarmCount));
+            }
+
+            if (shadePool == null && config.shadeMinionPrefab != null)
+            {
+                shadePool = CreatePool(
+                    config.shadeMinionPrefab,
+                    Mathf.Max(1, config.shadePrewarmCount),
+                    Mathf.Max(1, config.shadeMaxActive));
+                Prewarm(shadePool, Mathf.Max(0, config.shadePrewarmCount));
+            }
+        }
+
+        ObjectPool<T> CreatePool<T>(T prefab, int defaultCapacity, int maxSize) where T : Component, IShadowRevenantPooledItem
+        {
+            ObjectPool<T> pool = null;
+            pool = new ObjectPool<T>(
+                () => CreateInstance(prefab, pool),
+                item =>
+                {
+                    if (item != null)
+                        item.gameObject.SetActive(true);
+                },
+                item =>
+                {
+                    if (item == null)
+                        return;
+
+                    item.gameObject.SetActive(false);
+                },
+                item =>
+                {
+                    if (item != null)
+                        Destroy(item.gameObject);
+                },
+                true,
+                defaultCapacity,
+                maxSize);
+
+            return pool;
+        }
+
+        T CreateInstance<T>(T prefab, ObjectPool<T> pool) where T : Component, IShadowRevenantPooledItem
+        {
+            T instance = Instantiate(prefab, poolRoot);
+            switch (instance)
+            {
+                case ShadowRevenantProjectile projectile:
+                    projectile.Bind(projectilePool.Release);
+                    break;
+                case ShadowRevenantDreadFogZone fog:
+                    fog.Bind(fogPool.Release);
+                    break;
+                case ShadowRevenantShadeMinion shade:
+                    shade.Bind(shadePool.Release);
+                    break;
+            }
+
+            instance.gameObject.SetActive(false);
+            return instance;
+        }
+
+        void Prewarm<T>(ObjectPool<T> pool, int count) where T : Component, IShadowRevenantPooledItem
+        {
+            if (pool == null || count <= 0)
+                return;
+
+            var items = new List<T>(count);
+            for (var i = 0; i < count; i++)
+                items.Add(pool.Get());
+
+            for (var i = 0; i < items.Count; i++)
+                pool.Release(items[i]);
+        }
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPoolHub.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantPoolHub.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c991b98a2df4f1a852b4d87d2269a86
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantProjectile.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantProjectile.cs
@@ -1,0 +1,144 @@
+using System;
+using UnityEngine;
+
+namespace Beavermania.NPC
+{
+    public sealed class ShadowRevenantProjectile : MonoBehaviour, IShadowRevenantPooledItem
+    {
+        const float DirectionEpsilon = 0.0001f;
+
+        [SerializeField] Rigidbody projectileRigidbody;
+        [SerializeField] Collider projectileCollider;
+        [SerializeField] GameObject impactVfxPrefab;
+
+        Action<ShadowRevenantProjectile> releaseToPool;
+        IShadowRevenantTarget target;
+        float damage;
+        float lifetimeRemaining;
+        bool released = true;
+
+        public bool IsPoolActive => !released;
+
+        public void Bind(Action<ShadowRevenantProjectile> releaseAction)
+        {
+            releaseToPool = releaseAction;
+            CacheReferences();
+        }
+
+        void Awake()
+        {
+            CacheReferences();
+        }
+
+        void CacheReferences()
+        {
+            if (projectileRigidbody == null)
+                projectileRigidbody = GetComponent<Rigidbody>();
+
+            if (projectileCollider == null)
+                projectileCollider = GetComponent<Collider>();
+        }
+
+        public void Activate(
+            Vector3 position,
+            Quaternion rotation,
+            Vector3 direction,
+            IShadowRevenantTarget projectileTarget,
+            float projectileDamage,
+            float speed,
+            float lifetime)
+        {
+            CacheReferences();
+            released = false;
+            target = projectileTarget;
+            damage = Mathf.Max(0f, projectileDamage);
+            lifetimeRemaining = Mathf.Max(0.05f, lifetime);
+            transform.SetPositionAndRotation(position, rotation);
+
+            if (projectileCollider != null)
+                projectileCollider.enabled = true;
+
+            Vector3 launchDirection = direction.sqrMagnitude > DirectionEpsilon ? direction.normalized : transform.forward;
+            if (projectileRigidbody != null)
+            {
+                projectileRigidbody.isKinematic = false;
+                projectileRigidbody.useGravity = false;
+                projectileRigidbody.velocity = launchDirection * Mathf.Max(0f, speed);
+                projectileRigidbody.angularVelocity = Vector3.zero;
+            }
+        }
+
+        void Update()
+        {
+            if (released)
+                return;
+
+            lifetimeRemaining -= Time.deltaTime;
+            if (lifetimeRemaining <= 0f)
+                DeactivateToPool();
+        }
+
+        void OnTriggerEnter(Collider other)
+        {
+            TryHit(other);
+        }
+
+        void OnCollisionEnter(Collision collision)
+        {
+            TryHit(collision != null ? collision.collider : null);
+        }
+
+        void TryHit(Collider other)
+        {
+            if (released || other == null)
+                return;
+
+            IShadowRevenantTarget hitTarget = ResolveTarget(other);
+            if (hitTarget == null || !hitTarget.CanReceiveShadowDamage)
+                return;
+
+            hitTarget.ReceiveShadowDamage(damage);
+            if (impactVfxPrefab != null)
+                Beavermania.Display.PooledOneShotVfx.Spawn(impactVfxPrefab, transform.position, transform.rotation);
+
+            DeactivateToPool();
+        }
+
+        IShadowRevenantTarget ResolveTarget(Collider other)
+        {
+            IShadowRevenantTarget candidate = other.GetComponentInParent<IShadowRevenantTarget>();
+            if (candidate != null)
+                return candidate;
+
+            return target != null && target.TargetTransform != null && other.transform.IsChildOf(target.TargetTransform)
+                ? target
+                : null;
+        }
+
+        public void DeactivateToPool()
+        {
+            if (released)
+                return;
+
+            released = true;
+            target = null;
+            lifetimeRemaining = 0f;
+            damage = 0f;
+
+            if (projectileRigidbody != null)
+            {
+                projectileRigidbody.velocity = Vector3.zero;
+                projectileRigidbody.angularVelocity = Vector3.zero;
+                projectileRigidbody.isKinematic = true;
+            }
+
+            if (projectileCollider != null)
+                projectileCollider.enabled = false;
+
+            if (releaseToPool != null)
+                releaseToPool(this);
+            else
+                gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantProjectile.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantProjectile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c0ab742291a4fddb6b16673e15bdf35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantShadeMinion.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantShadeMinion.cs
@@ -1,0 +1,159 @@
+using System;
+using UnityEngine;
+
+namespace Beavermania.NPC
+{
+    public sealed class ShadowRevenantShadeMinion : MonoBehaviour, IShadowRevenantPooledItem
+    {
+        const float DirectionEpsilon = 0.0001f;
+
+        [SerializeField] Rigidbody shadeRigidbody;
+        [SerializeField] Collider damageCollider;
+        [SerializeField] Animator animator;
+
+        Action<ShadowRevenantShadeMinion> releaseToPool;
+        IShadowRevenantTarget target;
+        float moveSpeed;
+        float damage;
+        float damageCooldown;
+        float nextDamageTime;
+        float lifetimeRemaining;
+        bool released = true;
+
+        public bool IsPoolActive => !released;
+
+        public void Bind(Action<ShadowRevenantShadeMinion> releaseAction)
+        {
+            releaseToPool = releaseAction;
+            CacheReferences();
+        }
+
+        void Awake()
+        {
+            CacheReferences();
+        }
+
+        void CacheReferences()
+        {
+            if (shadeRigidbody == null)
+                shadeRigidbody = GetComponent<Rigidbody>();
+
+            if (damageCollider == null)
+                damageCollider = GetComponent<Collider>();
+
+            if (animator == null)
+                animator = GetComponentInChildren<Animator>();
+        }
+
+        public void Activate(
+            Vector3 position,
+            IShadowRevenantTarget minionTarget,
+            float speed,
+            float contactDamage,
+            float contactDamageCooldown,
+            float lifetime)
+        {
+            CacheReferences();
+            released = false;
+            target = minionTarget;
+            moveSpeed = Mathf.Max(0f, speed);
+            damage = Mathf.Max(0f, contactDamage);
+            damageCooldown = Mathf.Max(0.05f, contactDamageCooldown);
+            nextDamageTime = 0f;
+            lifetimeRemaining = Mathf.Max(0.05f, lifetime);
+            transform.position = position;
+
+            if (damageCollider != null)
+                damageCollider.enabled = true;
+
+            if (shadeRigidbody != null)
+            {
+                shadeRigidbody.isKinematic = false;
+                shadeRigidbody.velocity = Vector3.zero;
+                shadeRigidbody.angularVelocity = Vector3.zero;
+            }
+        }
+
+        void Update()
+        {
+            if (released)
+                return;
+
+            lifetimeRemaining -= Time.deltaTime;
+            if (lifetimeRemaining <= 0f || target == null || target.TargetTransform == null)
+                DeactivateToPool();
+        }
+
+        void FixedUpdate()
+        {
+            if (released || target == null || target.TargetTransform == null)
+                return;
+
+            Vector3 toTarget = target.TargetTransform.position - transform.position;
+            Vector3 horizontal = new Vector3(toTarget.x, 0f, toTarget.z);
+            if (horizontal.sqrMagnitude <= DirectionEpsilon)
+                return;
+
+            Vector3 direction = horizontal.normalized;
+            if (shadeRigidbody != null)
+            {
+                Vector3 velocity = direction * moveSpeed;
+                shadeRigidbody.velocity = new Vector3(velocity.x, shadeRigidbody.velocity.y, velocity.z);
+                shadeRigidbody.MoveRotation(Quaternion.LookRotation(direction));
+            }
+            else
+            {
+                transform.position += direction * (moveSpeed * Time.fixedDeltaTime);
+                transform.rotation = Quaternion.LookRotation(direction);
+            }
+        }
+
+        void OnTriggerStay(Collider other)
+        {
+            TryDamage(other);
+        }
+
+        void OnCollisionStay(Collision collision)
+        {
+            TryDamage(collision != null ? collision.collider : null);
+        }
+
+        void TryDamage(Collider other)
+        {
+            if (released || other == null || Time.time < nextDamageTime)
+                return;
+
+            IShadowRevenantTarget hitTarget = other.GetComponentInParent<IShadowRevenantTarget>();
+            if (hitTarget == null || !hitTarget.CanReceiveShadowDamage)
+                return;
+
+            hitTarget.ReceiveShadowDamage(damage);
+            nextDamageTime = Time.time + damageCooldown;
+        }
+
+        public void DeactivateToPool()
+        {
+            if (released)
+                return;
+
+            released = true;
+            target = null;
+            lifetimeRemaining = 0f;
+
+            if (shadeRigidbody != null)
+            {
+                shadeRigidbody.velocity = Vector3.zero;
+                shadeRigidbody.angularVelocity = Vector3.zero;
+                shadeRigidbody.isKinematic = true;
+            }
+
+            if (damageCollider != null)
+                damageCollider.enabled = false;
+
+            if (releaseToPool != null)
+                releaseToPool(this);
+            else
+                gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantShadeMinion.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantShadeMinion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c6f69621ea44936ba8c349ed1406fd3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantState.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantState.cs
@@ -1,0 +1,21 @@
+namespace Beavermania.NPC
+{
+    public enum ShadowRevenantState
+    {
+        Dormant = 0,
+        Idle = 1,
+        Strafe = 2,
+        ProjectileWindup = 3,
+        ProjectileRecover = 4,
+        FogWindup = 5,
+        FogRecover = 6,
+        SummonWindup = 7,
+        SummonRecover = 8,
+        PhaseShiftEnter = 9,
+        Phased = 10,
+        Teleport = 11,
+        LightBroken = 12,
+        Staggered = 13,
+        Dead = 14
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantState.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da18e0748f24448297b919aa48ccd872
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantTestSceneBinder.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantTestSceneBinder.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using Beavermania.Player;
+using Beavermania.UI;
+using Beavermania.UI.Hud;
+using Beavermania.UI.Menus;
+using Beavermania.UI.Objectives;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Beavermania.NPC
+{
+    [DefaultExecutionOrder(-1000)]
+    public sealed class ShadowRevenantTestSceneBinder : MonoBehaviour
+    {
+        void Awake()
+        {
+            GameObject playerObject = GameObject.FindGameObjectWithTag("Player");
+            GameObject canvasObject = GameObject.Find("PlayerCanvas");
+            if (playerObject == null || canvasObject == null)
+            {
+                Debug.LogWarning($"{nameof(ShadowRevenantTestSceneBinder)} could not find Player and PlayerCanvas scene roots.", this);
+                return;
+            }
+
+            Wire(playerObject, canvasObject);
+        }
+
+        static void Wire(GameObject playerObject, GameObject canvasObject)
+        {
+            var player = playerObject.GetComponent<BeaverPlayerBehaviour>();
+            if (player == null)
+                return;
+
+            var canvasRoot = canvasObject.transform;
+            var hudState = playerObject.GetComponent<PlayerHudState>();
+            var objective = playerObject.GetComponent<ObjectiveUI>();
+            var healthBar = playerObject.GetComponent<Health_Bar_Script>();
+
+            if (playerObject.GetComponent<ShadowRevenantPlayerTargetAdapter>() == null)
+                playerObject.AddComponent<ShadowRevenantPlayerTargetAdapter>();
+
+            if (healthBar != null)
+            {
+                healthBar.HealthSlider = FindComponentByName<Slider>(canvasRoot, "Health Bar");
+                healthBar.StaminaSlider = FindComponentByName<Slider>(canvasRoot, "StaminaBar");
+            }
+
+            player.HealthBar = healthBar;
+            player.ICON_1 = FindChildGameObject(canvasRoot, "Icon1");
+            player.ICON_2 = FindChildGameObject(canvasRoot, "Icon2");
+            player.ICON_3 = FindChildGameObject(canvasRoot, "Icon3");
+            player.LooseScreen = FindChildGameObject(canvasRoot, "Loose Menu Panel");
+            player.AimIcon = FindChildGameObject(canvasRoot, "Aim_Icon");
+            player.PlayerHudState = hudState;
+            player.PlayerObjective = objective;
+
+            var debug = canvasObject.GetComponent<DebugReference>();
+            if (debug != null)
+            {
+                debug.Player = player;
+                debug.PlayerHudState = hudState;
+                debug.ObjectiveText = FindComponentByName<TextMeshProUGUI>(canvasRoot, "ObjectiveText");
+                debug.DisplayText = FindComponentByName<TextMeshProUGUI>(canvasRoot, "HealthNum");
+                debug.StaminaText = FindComponentByName<TextMeshProUGUI>(canvasRoot, "StamiNum");
+                debug.LogCountText = FindComponentByName<TextMeshProUGUI>(canvasRoot, "LogCount");
+                debug.HealingDisplay = FindComponentByName<TextMeshProUGUI>(canvasRoot, "HealingDisplay");
+                debug.CurrencyCount = FindComponentByName<TextMeshProUGUI>(canvasRoot, "CurrencyCount");
+                debug.SeedCount = FindComponentByName<TextMeshProUGUI>(canvasRoot, "SeedCount");
+                debug.GobletCount = FindComponentByName<TextMeshProUGUI>(canvasRoot, "GobletCount");
+                debug.AppleCount = FindComponentByName<TextMeshProUGUI>(canvasRoot, "Apple Count");
+                debug.ArrowMunition = FindComponentByName<TextMeshProUGUI>(canvasRoot, "ArrowMunition");
+            }
+
+            var uiMenu = canvasObject.GetComponent<UIMenu>();
+            if (uiMenu != null)
+            {
+                uiMenu.Player = player;
+                uiMenu.PauseMenu = FindChildGameObject(canvasRoot, "Pause Menu Panel");
+                uiMenu.Question = FindChildGameObject(canvasRoot, "Quiry");
+            }
+
+            foreach (var dialogue in canvasObject.GetComponentsInChildren<Dialogue>(true))
+            {
+                dialogue.Player = player;
+                dialogue.PlayerObjective = objective;
+                if (dialogue.panel == null && dialogue.transform.parent != null)
+                    dialogue.panel = dialogue.transform.parent;
+            }
+
+            foreach (var shop in canvasObject.GetComponentsInChildren<Shop>(true))
+                shop.Player = player;
+        }
+
+        static GameObject FindChildGameObject(Transform root, string name)
+        {
+            Transform child = FindChild(root, name);
+            return child != null ? child.gameObject : null;
+        }
+
+        static T FindComponentByName<T>(Transform root, string name) where T : Component
+        {
+            Transform child = FindChild(root, name);
+            return child != null ? child.GetComponent<T>() ?? child.GetComponentInChildren<T>(true) : null;
+        }
+
+        static Transform FindChild(Transform root, string name)
+        {
+            if (root == null || string.IsNullOrEmpty(name))
+                return null;
+
+            var stack = new Stack<Transform>();
+            stack.Push(root);
+            while (stack.Count > 0)
+            {
+                Transform current = stack.Pop();
+                if (current.name == name)
+                    return current;
+
+                for (int i = current.childCount - 1; i >= 0; i--)
+                    stack.Push(current.GetChild(i));
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantTestSceneBinder.cs.meta
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantTestSceneBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af3fe8a0b8684ce1b4ac7cbdcd56a0bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Player/AnimatedAttack.cs
+++ b/Assets/Scripts/Player/AnimatedAttack.cs
@@ -77,6 +77,9 @@ namespace Beavermania.Player.Combat
                 if (enemy.name != null)
                     Debug.Log("Hit " + enemy.name);
 
+                if (TryApplyInterfaceDamage(enemy, Damage))
+                    continue;
+
                 switch (enemy.tag)
                 {
                     case "NPC":
@@ -102,6 +105,15 @@ namespace Beavermania.Player.Combat
                         }
                 }
             }
+        }
+
+        bool TryApplyInterfaceDamage(Collider enemy, int damage)
+        {
+            if (enemy == null)
+                return false;
+
+            IEnemyDamageReceiver damageReceiver = enemy.GetComponentInParent<IEnemyDamageReceiver>();
+            return damageReceiver != null && damageReceiver.ReceiveDamage(damage, EnemyDamageType.Normal, transform);
         }
 
 

--- a/Assets/Scripts/Player/Projectile.cs
+++ b/Assets/Scripts/Player/Projectile.cs
@@ -554,7 +554,8 @@ namespace Beavermania.Player.Combat
 
             return GetComponentInParentSafe<NPC_Basic>(collider) != null
                 || GetComponentInParentSafe<ScorpionScript>(collider) != null
-                || GetComponentInParentSafe<Static_Hive>(collider) != null;
+                || GetComponentInParentSafe<Static_Hive>(collider) != null
+                || GetEnemyDamageReceiver(collider) != null;
         }
 
         bool CanFireBreathExplodeFromCollision(Collision collision)
@@ -579,6 +580,16 @@ namespace Beavermania.Player.Combat
         static T GetComponentInParentSafe<T>(Collider collider) where T : Component
         {
             return collider != null ? collider.GetComponentInParent<T>() : null;
+        }
+
+        static IEnemyDamageReceiver GetEnemyDamageReceiver(Collider collider)
+        {
+            return collider != null ? collider.GetComponentInParent<IEnemyDamageReceiver>() : null;
+        }
+
+        static int GetDamageReceiverId(IEnemyDamageReceiver damageReceiver)
+        {
+            return damageReceiver is Component component ? component.GetInstanceID() : damageReceiver.GetHashCode();
         }
 
         static bool ColliderHasTag(Collider collider, string tag)
@@ -639,6 +650,13 @@ namespace Beavermania.Player.Combat
                 return;
 
             Collider hitCollider = collision.collider;
+
+            IEnemyDamageReceiver damageReceiver = GetEnemyDamageReceiver(hitCollider);
+            if (damageReceiver != null && damageReceiver.ReceiveDamage(Damage, EnemyDamageType.Normal, transform))
+            {
+                ArrowHit();
+                return;
+            }
 
             NPC_Basic npc = GetComponentInParentSafe<NPC_Basic>(hitCollider);
             if (npc != null)
@@ -852,6 +870,13 @@ namespace Beavermania.Player.Combat
                 if (!IsPriorityFireBreathTarget(hitCollider))
                     continue;
 
+                IEnemyDamageReceiver damageReceiver = GetEnemyDamageReceiver(hitCollider);
+                if (damageReceiver != null && damagedTargets.Add(GetDamageReceiverId(damageReceiver)))
+                {
+                    damageReceiver.ReceiveDamage(damageAmount, EnemyDamageType.Fire, transform);
+                    continue;
+                }
+
                 NPC_Basic npc = GetComponentInParentSafe<NPC_Basic>(hitCollider);
                 if (npc != null && damagedTargets.Add(npc.GetInstanceID()))
                 {
@@ -1051,8 +1076,14 @@ namespace Beavermania.Player.Combat
                 return;
 
             var hit = false;
+            IEnemyDamageReceiver damageReceiver = GetEnemyDamageReceiver(OBJ.collider);
+            if (damageReceiver != null && damageReceiver.ReceiveDamage(Damage, EnemyDamageType.Normal, transform))
+            {
+                hit = true;
+                RockHit();
+            }
 
-            if (ColliderHasTag(OBJ.collider, "NPC"))
+            if (!hit && ColliderHasTag(OBJ.collider, "NPC"))
             {
                 hit = true;
                 NPC_Basic npc = GetComponentInParentSafe<NPC_Basic>(OBJ.collider);
@@ -1071,7 +1102,7 @@ namespace Beavermania.Player.Combat
                     Player.ChangeSpeech = 1f;
                 }
             }
-            if (ColliderHasTag(OBJ.collider, "Scorpion"))
+            if (!hit && ColliderHasTag(OBJ.collider, "Scorpion"))
             {
                 hit = true;
                 ScorpionScript scorpion = GetComponentInParentSafe<ScorpionScript>(OBJ.collider);
@@ -1085,7 +1116,7 @@ namespace Beavermania.Player.Combat
                 else
                     RockHit();
             }
-            if (ColliderHasTag(OBJ.collider, "Hive"))
+            if (!hit && ColliderHasTag(OBJ.collider, "Hive"))
             {
                 hit = true;
                 Static_Hive hive = GetComponentInParentSafe<Static_Hive>(OBJ.collider);
@@ -1096,7 +1127,7 @@ namespace Beavermania.Player.Combat
                 else
                     RockHit();
             }
-            if (ColliderHasTag(OBJ.collider, "Isle"))
+            if (!hit && ColliderHasTag(OBJ.collider, "Isle"))
             {
                 hit = true;
                 if (UsesFireBreathLogic)

--- a/Assets/Scripts/UI/WayPoint.cs
+++ b/Assets/Scripts/UI/WayPoint.cs
@@ -152,6 +152,12 @@ namespace Beavermania.UI.Objectives
         {
             if (Mark != null)
                 return;
+
+            Mark = FindWaypointMarkImage();
+        }
+
+        static Image FindWaypointMarkImage()
+        {
             foreach (var graphic in FindObjectsOfType<Image>(true))
             {
                 if (graphic == null)
@@ -161,10 +167,11 @@ namespace Beavermania.UI.Objectives
                     || string.Equals(n, "WaypointMark", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(n, "Mark", StringComparison.OrdinalIgnoreCase))
                 {
-                    Mark = graphic;
-                    return;
+                    return graphic;
                 }
             }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds isolated Shadow Revenant enemy scripts under `Assets/Scripts/NPC/ShadowRevenant` with enum states, phase shifting, teleport validation, pooled shadow projectiles, pooled dread fog, pooled shade minions, Light Break handling, and stable Unity `.meta` files.
- Adds `ShadowRevenantConfig` ScriptableObject tuning under `Assets/Scripts/Data/NPC/ShadowRevenant`.
- Adds interface-based enemy damage hooks to player melee/projectile paths while preserving existing Wasp, Scorpion, and Hive behavior.
- Adds `Assets/Scenes/ShadowRevenantTestArena.unity` with the production Player prefab and PlayerCanvas prefab as scene-root siblings, plus a scene binder that wires HUD/menu/dialogue/shop references at load time.
- Implements Dread Fog slow in `ShadowRevenantPlayerTargetAdapter` by temporarily scaling player `Walk`/`Run` and restoring them after the fog slow expires.
- Clarifies `WayPoint` mark resolution so the static lookup helper returns an `Image` and only the instance method assigns `Mark`.

### Verification
- `dotnet build .ci/BeaverMania.CI.csproj` passed with 0 warnings and 0 errors.
- Unity batch-mode scene generation/import was attempted, but this cloud machine has no usable Unity license, so Play Mode/import verification still needs to be run in a licensed Unity Editor.

### Unity notes
- No production scene, player prefab, PlayerCanvas prefab, animation, input, pause, checkpoint, or GameManager assets were edited.
- If Unity still reports stale `WayPoint.cs(207,28)` after pulling this branch, force a reimport or clear the local `Library/` cache because this branch's `WayPoint.cs` has no line 207 and no static `WayPoint.Mark` access.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4a249a7-1cff-4947-b0ee-837786cddba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4a249a7-1cff-4947-b0ee-837786cddba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

