### PR TITLE
Fix WayPoint CS0120: static Mark lookup must not assign instance field

### DIFF
--- a/Assets/Scripts/UI/WayPoint.cs
+++ b/Assets/Scripts/UI/WayPoint.cs
@@ -152,6 +152,12 @@ namespace Beavermania.UI.Objectives
         {
             if (Mark != null)
                 return;
+
+            Mark = FindWaypointMarkImage();
+        }
+
+        static Image FindWaypointMarkImage()
+        {
             foreach (var graphic in FindObjectsOfType<Image>(true))
             {
                 if (graphic == null)
@@ -161,10 +167,11 @@ namespace Beavermania.UI.Objectives
                     || string.Equals(n, "WaypointMark", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(n, "Mark", StringComparison.OrdinalIgnoreCase))
                 {
-                    Mark = graphic;
-                    return;
+                    return graphic;
                 }
             }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes compile error **CS0120** in `WayPoint.cs`:

> An object reference is required for the non-static field, method, or property `WayPoint.Mark`

## Root cause

`Mark` is an instance field on `WayPoint`, but the HUD mark lookup was refactored into a **static** helper while still assigning `Mark = graphic` inside that static method. Static methods cannot access instance members without an object reference.

## Fix

- Extract mark discovery into `static Image FindWaypointMarkImage()` that **returns** the found `Image`.
- Assign the result on the instance in `TryResolveMarkFromCanvas()` via `Mark = FindWaypointMarkImage()`.

## Changed files

- `Assets/Scripts/UI/WayPoint.cs`

## Verification

- `dotnet build .ci/BeaverMania.CI.csproj` — **Build succeeded** (0 errors)

## Manual Unity verification

- Enter Play Mode on a level with waypoints.
- Confirm the waypoint HUD mark (`WayPointMark` / `Mark` on PlayerCanvas) still appears and clamps to screen edges.
- Hold Q (waypoint compass) and confirm the arrow overlay still toggles.

## Risk

**Low** — compile-only refactor of mark resolution; no gameplay logic changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5156fed-1eb4-4e27-8660-c279c0164b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5156fed-1eb4-4e27-8660-c279c0164b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

