### PR TITLE
chore: add Codex/Cursor repository workflow and handoff protocol

### DIFF
--- a/.cursor/agents/unity-specialist.md
+++ b/.cursor/agents/unity-specialist.md
@@ -72,3 +72,8 @@ For each task, provide:
 4. **Test plan** — concrete Play Mode checks (input, pause token, combat, scene reload).
 
 Do not write architecture docs unless asked — delegate documentation to the `docs-architect` subagent.
+
+
+## Cross-agent escalation
+
+If Unity investigation identifies a script-level issue outside safe local script scope, do not perform broad refactors in this agent. Document the issue in `AI_WORKFLOW/handoffs/cursor-to-codex.md` and hand off to Codex.

--- a/.cursor/skills/unity-prompt-builder/beavermania.md
+++ b/.cursor/skills/unity-prompt-builder/beavermania.md
@@ -35,3 +35,14 @@ When the workspace is **BeaverProject** / BeaverMania, include these in the prom
 - **Plan**: prefab/scene YAML, animation parameters, Input Actions assets, trader/shop/dialogue flow, multi-system bugs.
 - **Agent**: single-script fix with known file and clear repro.
 - **Multitask**: rare — only when areas are file/prefab disjoint.
+
+## Cross-agent workflow prompts
+
+When a prompt involves multi-step feature work, bugfixes crossing code + Unity scene/prefab/UI/animation boundaries, Codex/Cursor cooperation, or PR/review/merge readiness, include:
+
+- `AI_WORKFLOW/README.md` as protocol context.
+- `AI_WORKFLOW/active-task.md` update requirement (yes/no + owner).
+- Whether a handoff file must be created:
+  - `AI_WORKFLOW/handoffs/cursor-to-codex.md`
+  - `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+- Which tool owns the next step (Codex, Cursor, or User).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,24 @@ Codex should avoid unless explicitly requested:
 
 Existing Cursor workflow guidance remains relevant: use planning/review for multi-system work, and only use focused implementation for a small, known script bug with a specific expected outcome.
 
+## Cross-Agent Workflow Protocol
+
+Use the repository workflow layer for mixed Codex/Cursor delivery:
+
+- `AI_WORKFLOW/README.md`
+- `AI_WORKFLOW/active-task.md`
+- `AI_WORKFLOW/handoffs/cursor-to-codex.md`
+- `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+- `AI_WORKFLOW/task-templates/`
+
+Rules:
+
+- Codex and Cursor communicate through these files, not assumptions.
+- If a task crosses script + Unity Editor boundaries, define ownership before implementing.
+- If Codex changes code requiring Inspector/prefab/scene follow-up, it must write a Codex → Cursor handoff.
+- If Cursor finds a script-level issue during Unity debugging, it must write a Cursor → Codex handoff.
+- Do not mark mixed tasks complete until both code-level checks and Unity verification status are recorded.
+
 ## 4. High-Risk Files and Areas
 
 Treat these as high risk:

--- a/AI_WORKFLOW/README.md
+++ b/AI_WORKFLOW/README.md
@@ -1,0 +1,35 @@
+# AI Workflow Layer (Codex ↔ Cursor)
+
+## Purpose
+- Provide a file-based operating protocol for mixed AI delivery in this repository.
+- Make task ownership, handoffs, verification status, and merge readiness explicit.
+- Reduce regressions from Unity serialized-reference fragility by preventing ambiguous ownership.
+
+## Communication Model
+- Codex and Cursor do **not** chat directly.
+- They communicate through committed repository files in `AI_WORKFLOW/`.
+- Use:
+  - `AI_WORKFLOW/active-task.md`
+  - `AI_WORKFLOW/handoffs/cursor-to-codex.md`
+  - `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+  - `AI_WORKFLOW/task-templates/*`
+
+## Ownership Model
+- **Codex owns:** script correctness, architecture decisions, refactors, code review, PR summaries, and workflow/documentation maintenance.
+- **Cursor owns:** Unity Editor integration (scenes, prefabs, UI wiring, Animator/animation, Inspector references), plus visual/runtime Play Mode verification.
+- **User / Product Owner owns:** prioritization, final acceptance, merge approval, and conflict resolution.
+
+## Task Lifecycle
+1. Start from `AI_WORKFLOW/active-task.md` or a task template.
+2. Define owner and scope boundaries before implementation.
+3. Implement only within assigned ownership.
+4. Record verification evidence and remaining risks.
+5. End with one of:
+   - Final report, or
+   - Formal handoff to the other tool.
+
+## Coordination Rules
+- Do not let Codex and Cursor edit the same scene/prefab/animation/UI asset concurrently.
+- For cross-boundary work (scripts + Unity Editor), lock next owner explicitly in `active-task.md`.
+- Runtime Unity behavior claims require Play Mode verification.
+- Script-level validation alone is not sufficient for serialized wiring outcomes.

--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -1,0 +1,54 @@
+# Active Task Template
+
+## Task title
+- 
+
+## Type
+- Feature / Bugfix / Review / Refactor / Documentation / Release
+
+## Owner
+- User / Codex / Cursor / Mixed
+
+## Current phase
+- Intake / Investigation / Implementation / Verification / Handoff / Done
+
+## Goal
+- 
+
+## Scope
+- 
+
+## Out of scope
+- 
+
+## Relevant files/assets
+- 
+
+## Risk level
+- Low / Medium / High
+
+## Branch
+- 
+
+## Codex responsibilities
+- 
+
+## Cursor responsibilities
+- 
+
+## Required verification
+- Code-level:
+- Unity Editor / Play Mode:
+
+## Current status
+- 
+
+## Next action
+- Owner:
+- Action:
+
+## Open questions
+- 
+
+## Handoff needed
+- Yes / No

--- a/AI_WORKFLOW/decisions/ADR-0001-codex-cursor-division.md
+++ b/AI_WORKFLOW/decisions/ADR-0001-codex-cursor-division.md
@@ -1,0 +1,40 @@
+# ADR-0001: Codex/Cursor Cooperation via Repository Files
+
+- Status: Accepted
+
+## Context
+Beavermania is a Unity project with fragile serialized references and high coupling between script behavior and Unity Editor wiring (prefabs/scenes/UI/Animator/Inspector). Prior guidance defines tool strengths, but lacked a strict operational protocol for cross-agent lifecycle ownership and handoffs.
+
+## Decision
+Codex and Cursor cooperate through repository files under `AI_WORKFLOW/` instead of direct freeform conversation.
+
+## Consequences
+- Task state becomes auditable in git history.
+- Ownership boundaries are explicit before changes start.
+- Cross-boundary tasks require formal handoffs.
+- Merge readiness depends on both code-level and Unity verification records.
+
+## Codex responsibilities
+- Script correctness, architecture, focused refactors, code reviews, risk notes, PR summaries.
+- Maintain/update workflow documents and handoff artifacts when Cursor follow-up is required.
+- Avoid unverified Unity runtime claims; request Play Mode confirmation when needed.
+
+## Cursor responsibilities
+- Unity Editor integration: prefab/scene/UI/Animator/Inspector wiring.
+- Play Mode verification and visual/system behavior validation.
+- Generate Cursor→Codex handoffs when Unity investigation indicates script-level defects.
+
+## User responsibilities
+- Define priorities and acceptance criteria.
+- Approve ownership strategy and risk tradeoffs.
+- Provide final merge approval.
+
+## Explicit anti-patterns
+- Both tools editing the same Unity asset concurrently.
+- Codex claiming Unity behavior is fixed without Play Mode verification.
+- Cursor performing broad C# refactors without Codex review.
+- Large multi-system changes without `AI_WORKFLOW/active-task.md`.
+- Unclear ownership for next action.
+
+## Why this matters for Beavermania
+Serialized references can silently break when ownership is ambiguous or when script/editor changes are not coordinated. A file-backed workflow enforces traceable handoffs and verification checkpoints, reducing regression risk for Steam release stability.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,0 +1,36 @@
+# Codex → Cursor Handoff Template
+
+## Task
+- 
+
+## Code changes made
+- 
+
+## Files changed
+- 
+
+## New or changed serialized fields
+- 
+
+## Inspector assignments required
+- 
+
+## Prefab/scene/UI/Animator follow-up required
+- 
+
+## What Cursor should test in Play Mode
+- Reproduction path:
+- Functional checks:
+- Negative/regression checks:
+
+## What Cursor should not change
+- 
+
+## Known limitations
+- 
+
+## Risk notes
+- Enemy/NPC behavior risk:
+- Interaction/dialogue/shop flow risk:
+- Player combat/input risk:
+- Pooling/performance risk:

--- a/AI_WORKFLOW/handoffs/cursor-to-codex.md
+++ b/AI_WORKFLOW/handoffs/cursor-to-codex.md
@@ -1,0 +1,43 @@
+# Cursor → Codex Handoff Template
+
+## Task
+- 
+
+## Unity context
+- Scene(s):
+- Prefab(s):
+- UI panel(s):
+- Animator/animation context:
+
+## What was changed in Editor
+- 
+
+## What was observed in Play Mode
+- Reproduction path:
+- Expected:
+- Actual:
+- Frequency:
+
+## Suspected code issue
+- 
+
+## Files/scripts likely involved
+- 
+
+## What Cursor needs from Codex
+- 
+
+## What Codex must not change
+- Protected assets (scene/prefab/UI/animation):
+- Behavioral constraints:
+
+## Required verification after Codex changes
+- Unity checks Cursor will run:
+- Script-level checks Codex should run:
+
+## Risk notes
+- Trader/dialogue/shop risk:
+- Inspector-reference risk:
+- Animation/state-machine risk:
+- Audio-routing risk:
+- Scene-integration risk:

--- a/AI_WORKFLOW/task-templates/bugfix-task.md
+++ b/AI_WORKFLOW/task-templates/bugfix-task.md
@@ -1,0 +1,50 @@
+# Bugfix Task Template
+
+## Bug title
+- 
+
+## Reproduction steps
+1. 
+2. 
+3. 
+
+## Expected behavior
+- 
+
+## Actual behavior
+- 
+
+## Evidence
+- Video:
+- Screenshot:
+- Console log:
+- User report:
+
+## Suspected systems
+- 
+
+## Codex investigation scope
+- 
+
+## Cursor investigation scope
+- 
+
+## Files/assets at risk
+- 
+
+## Minimal fix principle
+- Smallest safe change that resolves the repro without broad behavior shifts.
+
+## Regression checks
+- 
+
+## Verification checklist
+- [ ] Repro confirmed before fix.
+- [ ] Fix validated on target path.
+- [ ] Related gameplay/UI/audio/input regressions checked.
+- [ ] Remaining risks documented.
+
+## Handoff checklist
+- [ ] Active owner + phase updated in `AI_WORKFLOW/active-task.md`.
+- [ ] Cursor→Codex handoff created when script issue is suspected from Unity debugging.
+- [ ] Codex→Cursor handoff created when Editor/Inspector/scene follow-up is required.

--- a/AI_WORKFLOW/task-templates/feature-task.md
+++ b/AI_WORKFLOW/task-templates/feature-task.md
@@ -1,0 +1,59 @@
+# Feature Task Template
+
+## Feature name
+- 
+
+## Player-facing goal
+- 
+
+## Gameplay behavior
+- Trigger conditions:
+- In-game outcomes:
+- Failure/edge behavior:
+
+## Systems touched
+- Input:
+- Player/combat:
+- NPC/AI:
+- UI:
+- Audio:
+- Data/ScriptableObjects:
+- Scene/prefab integration:
+
+## Script work expected from Codex
+- 
+
+## Unity integration expected from Cursor
+- 
+
+## Data / ScriptableObject needs
+- 
+
+## UI needs
+- 
+
+## Animation/VFX/SFX needs
+- 
+
+## Prefab/scene needs
+- 
+
+## Acceptance criteria
+- [ ] 
+
+## Verification checklist
+- [ ] Code compiles / static checks complete.
+- [ ] Required Inspector assignments applied.
+- [ ] Play Mode behavior matches acceptance criteria.
+- [ ] No critical regressions in related flows.
+
+## Handoff checklist
+- [ ] Ownership boundary documented in `AI_WORKFLOW/active-task.md`.
+- [ ] Required handoff file created if ownership changes.
+- [ ] Next owner and next action explicitly recorded.
+
+## Merge readiness checklist
+- [ ] Scope matches task intent.
+- [ ] Risks and limitations documented.
+- [ ] Verification evidence recorded.
+- [ ] User/Product Owner approval requested.

--- a/AI_WORKFLOW/task-templates/unity-verification.md
+++ b/AI_WORKFLOW/task-templates/unity-verification.md
@@ -1,0 +1,37 @@
+# Unity Verification Template
+
+## Scene to test
+- 
+
+## Prefab(s) to inspect
+- 
+
+## Inspector references to verify
+- 
+
+## Play Mode checks
+- 
+
+## UI checks
+- 
+
+## Input checks
+- 
+
+## Animation checks
+- 
+
+## Audio checks
+- 
+
+## Console checks
+- 
+
+## Performance/FPS checks (if relevant)
+- 
+
+## Result
+- Pass / Fail / Needs follow-up
+
+## Notes for Codex or Cursor
+- 


### PR DESCRIPTION
## Summary
- Added a new `AI_WORKFLOW/` layer with:
  - protocol overview (`README.md`)
  - reusable active task board (`active-task.md`)
  - bidirectional handoff templates (`handoffs/`)
  - feature/bugfix/unity-verification task templates (`task-templates/`)
  - ADR defining file-based Codex/Cursor cooperation (`decisions/ADR-0001-codex-cursor-division.md`)
- Updated `AGENTS.md` with a new **Cross-Agent Workflow Protocol** section and required rules for ownership + handoffs.
- Updated `.cursor/skills/unity-prompt-builder/beavermania.md` to require AI_WORKFLOW references for cross-boundary/multi-step cooperation prompts.
- Applied optional minimal update to `.cursor/agents/unity-specialist.md` to escalate out-of-scope script-level issues via `AI_WORKFLOW/handoffs/cursor-to-codex.md`.

## Scope constraints honored
- Markdown/documentation workflow infrastructure only.
- No Unity scene/prefab/animation/binary/meta changes.

## Risk
- Low (docs/process-only change).

## Next step
- Cursor should initialize `AI_WORKFLOW/active-task.md` for the next mixed script+Unity task and enforce handoff usage at first ownership boundary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17f19cac34832a97ae151cc9267c40)