### PR TITLE
chore: automate Cursor AI_WORKFLOW protocol usage for BeaverMania

### DIFF
--- a/.cursor/agents/unity-specialist.md
+++ b/.cursor/agents/unity-specialist.md
@@ -77,3 +77,10 @@ Do not write architecture docs unless asked — delegate documentation to the `d
 ## Cross-agent escalation
 
 If Unity investigation identifies a script-level issue outside safe local script scope, do not perform broad refactors in this agent. Document the issue in `AI_WORKFLOW/handoffs/cursor-to-codex.md` and hand off to Codex.
+
+
+## Automatic AI_WORKFLOW usage
+
+- For any Beavermania task crossing code + Unity integration boundaries, follow `.cursor/rules/beavermania-ai-workflow.mdc`.
+- If the task needs Codex, write a Cursor → Codex handoff instead of broad refactoring.
+- If Play Mode verification is required, record the verification status clearly.

--- a/.cursor/rules/beavermania-ai-workflow.mdc
+++ b/.cursor/rules/beavermania-ai-workflow.mdc
@@ -1,0 +1,55 @@
+---
+description: Enforce automatic AI_WORKFLOW protocol usage for BeaverMania tasks
+alwaysApply: true
+---
+
+# BeaverMania AI_WORKFLOW Protocol (Automatic)
+
+For BeaverMania work, apply AI_WORKFLOW protocol by default.
+
+## Required reads before implementation
+
+- `AGENTS.md`
+- `AI_WORKFLOW/README.md`
+- `AI_WORKFLOW/active-task.md`
+
+Also read as task type requires:
+
+- Feature work: `AI_WORKFLOW/task-templates/feature-task.md`
+- Bugfix work: `AI_WORKFLOW/task-templates/bugfix-task.md`
+- Unity testing/Editor verification: `AI_WORKFLOW/task-templates/unity-verification.md`
+- Mixed Codex/Cursor work: `AI_WORKFLOW/handoffs/cursor-to-codex.md` and `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+
+## Ownership classification (mandatory)
+
+Classify every task before implementation as exactly one:
+
+- Cursor-owned
+- Codex-owned
+- Mixed
+- User decision required
+
+## active-task update policy
+
+Create/update `AI_WORKFLOW/active-task.md`, or explicitly recommend user update, when any of the following are true:
+
+- task touches multiple systems
+- task crosses code + Unity Editor boundaries
+- task affects scene/prefab/UI/animation/Inspector wiring
+- task requires Codex review or handoff
+- task is a new gameplay feature
+- task is a regression-prone bugfix
+
+## Handoff policy
+
+- Create/update `AI_WORKFLOW/handoffs/cursor-to-codex.md` when Cursor discovers a script-level issue outside safe local script scope.
+- Create/update `AI_WORKFLOW/handoffs/codex-to-cursor.md` only when applying or reviewing Codex output that requires Unity Editor follow-up.
+
+## Guardrails
+
+Do not:
+
+- perform broad C# refactors without Codex review
+- edit scenes/prefabs/animation/UI assets without explicit scope
+- claim a Unity runtime issue is fixed without Play Mode verification
+- mark mixed tasks complete without workflow status and verification notes

--- a/.cursor/skills/unity-prompt-builder/beavermania.md
+++ b/.cursor/skills/unity-prompt-builder/beavermania.md
@@ -46,3 +46,10 @@ When a prompt involves multi-step feature work, bugfixes crossing code + Unity s
   - `AI_WORKFLOW/handoffs/cursor-to-codex.md`
   - `AI_WORKFLOW/handoffs/codex-to-cursor.md`
 - Which tool owns the next step (Codex, Cursor, or User).
+
+
+## AI_WORKFLOW default assumption
+
+- Generated BeaverMania prompts should assume the AI_WORKFLOW protocol is active.
+- Do not repeat full workflow instructions unless the user asks.
+- Include only the specific `active-task`/handoff requirement relevant to the current task.


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/beavermania-ai-workflow.mdc` with always-on BeaverMania workflow protocol rules.
- Require pre-implementation reads (`AGENTS.md`, `AI_WORKFLOW/README.md`, `AI_WORKFLOW/active-task.md`) and task-template/handoff references by task type.
- Enforce mandatory task ownership classification: Cursor-owned / Codex-owned / Mixed / User decision required.
- Enforce `AI_WORKFLOW/active-task.md` update-or-recommend policy for multi-system, mixed-boundary, risky, feature, and regression-prone work.
- Enforce handoff creation/update conditions for `cursor-to-codex.md` and `codex-to-cursor.md`.
- Add minimal "Automatic AI_WORKFLOW usage" section to `.cursor/agents/unity-specialist.md`.
- Add minimal default-assumption note to `.cursor/skills/unity-prompt-builder/beavermania.md`.

## Scope
- Markdown/config only.
- No Unity assets, scenes, prefabs, animation, scripts, or `.meta` GUIDs modified.

## Validation
- Reviewed `git diff` and `git status` to confirm only intended files changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17f4512870832a9de75ce96ace5c60)