### PR TITLE
Implement Phase 1 HUD cleanup

### DIFF
--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -1,54 +1,59 @@
-# Active Task Template
+# Active Task
 
 ## Task title
-- 
+- UI/UX and game-feel improvements
 
 ## Type
-- Feature / Bugfix / Review / Refactor / Documentation / Release
+- Feature
 
 ## Owner
-- User / Codex / Cursor / Mixed
+- Mixed
 
 ## Current phase
-- Intake / Investigation / Implementation / Verification / Handoff / Done
+- Phase 1 implementation / verification
 
 ## Goal
-- 
+- Improve HUD clarity first, then phase in tips, objectives, footstep feedback, and carried-log game feel without replacing existing pause, input, movement, or combat systems.
 
 ## Scope
-- 
+- Phase 1: compact always-visible HUD counters, keep health top-left, move stamina bottom-left, and avoid broad gameplay rewrites.
 
 ## Out of scope
-- 
+- Phase 2+ systems until Phase 1 is reviewed and Unity Play Mode verified.
+- Scene, dialogue, shop, animation, and input-action rewrites.
 
 ## Relevant files/assets
-- 
+- `Assets/Scripts/Player/BeaverPlayerBehaviour.cs`
+- `Assets/Scripts/Player/Carry.cs`
+- `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
 
 ## Risk level
-- Low / Medium / High
+- High
 
 ## Branch
-- 
+- `cursor/feature-ui-ux-gamefeel-improvements-75e4`
 
 ## Codex responsibilities
-- 
+- Keep script changes narrow and compile-safe.
+- Record prefab/Unity risks and required Play Mode verification.
 
 ## Cursor responsibilities
-- 
+- Verify HUD layout in Unity Editor across common resolutions.
+- Verify pause/menu/input/gameplay flows in Play Mode.
 
 ## Required verification
-- Code-level:
-- Unity Editor / Play Mode:
+- Code-level: `dotnet build .ci/BeaverMania.CI.csproj`
+- Unity Editor / Play Mode: open Level 1 Remastered, inspect `PlayerCanvas`, confirm HUD layout and existing UI flows.
 
 ## Current status
-- 
+- Phase 1 script and prefab changes are implemented for review.
 
 ## Next action
-- Owner:
-- Action:
+- Owner: Cursor / Unity Editor
+- Action: Run Play Mode validation and adjust prefab layout if needed.
 
 ## Open questions
-- 
+- Whether collectibles should be fully moved into pause/diary UI in a later phase or remain as compact HUD counters.
 
 ## Handoff needed
-- Yes / No
+- Yes

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -29,7 +29,7 @@
 
 ## What Cursor should test in Play Mode
 - Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause.
-- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, log count shows `N/9`, pause menu still opens/closes.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes.
 - Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, bridge construction hinting is not treated as complete until the tips subsystem phase.
 
 ## What Cursor should not change
@@ -38,7 +38,7 @@
 
 ## Known limitations
 - Unity Play Mode was not available in Cloud, so layout and serialized-reference behavior need Editor verification.
-- The long bridge/log instruction text was removed from the always-visible log HUD; Phase 2 should reintroduce contextual bridge guidance through the tips subsystem.
+- A compact bridge-build instruction remains in the 9/9 log HUD until Phase 2 can replace it with contextual tips.
 
 ## Risk notes
 - Enemy/NPC behavior risk: Low for Phase 1.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,36 +1,47 @@
-# Codex → Cursor Handoff Template
+# Codex → Cursor Handoff
 
 ## Task
-- 
+- UI/UX and game-feel improvements — Phase 1 HUD cleanup
 
 ## Code changes made
-- 
+- Compact collectible/ammo/log HUD text values to numbers only so existing icons carry the label meaning.
+- Move `StaminaBar` from the top-left HUD cluster to bottom-left anchored screen space in `PlayerCanvas.prefab`.
+- Record mixed ownership and verification requirements in `AI_WORKFLOW/active-task.md`.
 
 ## Files changed
-- 
+- `AI_WORKFLOW/active-task.md`
+- `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+- `Assets/Scripts/Player/BeaverPlayerBehaviour.cs`
+- `Assets/Scripts/Player/Carry.cs`
+- `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
 
 ## New or changed serialized fields
-- 
+- None.
 
 ## Inspector assignments required
-- 
+- None expected from script changes.
+- Verify existing `DebugReference` text references and `Health_Bar_Script` slider references remain assigned in the active scenes.
 
 ## Prefab/scene/UI/Animator follow-up required
-- 
+- Inspect `PlayerCanvas.prefab` in Unity Editor and confirm `StaminaBar` is readable at bottom-left across common resolutions.
+- Confirm top-right collectible/ammo/log counters still align with their icons after label removal.
+- Decide in Phase 2/3 whether collectibles should move fully into pause/diary UI or remain compact HUD counters.
 
 ## What Cursor should test in Play Mode
-- Reproduction path:
-- Functional checks:
-- Negative/regression checks:
+- Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, log count shows `N/9`, pause menu still opens/closes.
+- Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, bridge construction hinting is not treated as complete until the tips subsystem phase.
 
 ## What Cursor should not change
-- 
+- Do not edit scenes or additional prefabs for later phases until Phase 1 layout is accepted.
+- Do not rewrite input, pause, movement, combat, or objective systems as part of this handoff.
 
 ## Known limitations
-- 
+- Unity Play Mode was not available in Cloud, so layout and serialized-reference behavior need Editor verification.
+- The long bridge/log instruction text was removed from the always-visible log HUD; Phase 2 should reintroduce contextual bridge guidance through the tips subsystem.
 
 ## Risk notes
-- Enemy/NPC behavior risk:
-- Interaction/dialogue/shop flow risk:
-- Player combat/input risk:
-- Pooling/performance risk:
+- Enemy/NPC behavior risk: Low for Phase 1.
+- Interaction/dialogue/shop flow risk: Medium because `PlayerCanvas.prefab` is shared with dialogue/shop/pause panels.
+- Player combat/input risk: Low; no input/combat logic changed.
+- Pooling/performance risk: None in Phase 1.

--- a/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
+++ b/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
@@ -4064,11 +4064,11 @@ RectTransform:
   m_Father: {fileID: 6569126030801917452}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 475.4414, y: -75.21533}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 32, y: 34}
   m_SizeDelta: {x: 1720.9468, y: 693.448}
-  m_Pivot: {x: 1, y: 1}
+  m_Pivot: {x: 0, y: 0}
 --- !u!114 &594329238740800077
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
+++ b/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
@@ -2287,11 +2287,11 @@ namespace Beavermania.Player
                 DebugText = HealthPercent + "%";
                 StaminaPercent = System.Math.Round((CurrentStamina / MaxStamina) * 100f, 1);
                 StaminaText = StaminaPercent + "%";
-                Wallet = "COINS: " + Currency;
-                SeedText = "NUTS (R): " + NutCount;
-                AppleText = "APPLES (T): " + Apple;
-                GobletText = "GOBLETS (Y): " + GobletPickup;
-                ArrowText = "ARROWS (RM): " + arrowMunition;
+                Wallet = Currency.ToString();
+                SeedText = NutCount.ToString();
+                AppleText = Apple.ToString();
+                GobletText = GobletPickup.ToString();
+                ArrowText = arrowMunition.ToString();
                 if (ICON_1 != null || ICON_2 != null || ICON_3 != null)
                 {
                     if (Lives >= 3)

--- a/Assets/Scripts/Player/Carry.cs
+++ b/Assets/Scripts/Player/Carry.cs
@@ -46,12 +46,12 @@ namespace Beavermania.Player.Movement
         public void Update()
         {
             Vector3 SpawnPos = LogDrop.transform.position;
-            Goal.LogCount =("Log count: "+ i + "/9");
+            Goal.LogCount = i + "/9";
 
             if (Goal.grounded == true)
             {
                 if (i == 9)
-                    Goal.LogCount = ("Log count: 9/9. Press LCtrl+Rmouse for bridge construction");
+                    Goal.LogCount = "9/9";
                 if (PlayerInputReader.WasRollReleased() && i > 0)
                 {
                     i--;

--- a/Assets/Scripts/Player/Carry.cs
+++ b/Assets/Scripts/Player/Carry.cs
@@ -51,7 +51,7 @@ namespace Beavermania.Player.Movement
             if (Goal.grounded == true)
             {
                 if (i == 9)
-                    Goal.LogCount = "9/9";
+                    Goal.LogCount = "9/9  LCtrl+RMB to build";
                 if (PlayerInputReader.WasRollReleased() && i > 0)
                 {
                     i--;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Compact HUD counter text to numeric values so existing icons carry item meaning.
- Move stamina HUD from the top-left cluster to bottom-left anchored space.
- Preserve a compact `9/9 LCtrl+RMB to build` log prompt until Phase 2 contextual tips replace it.
- Record mixed Unity workflow status and Cursor Editor verification handoff.

## Verification
- `dotnet build BeaverMania.CI.csproj` passed from `/workspace/.ci` with 0 warnings and 0 errors after the bridge prompt follow-up.
- Needs Unity Editor Play Mode verification for PlayerCanvas layout, pause flow, and HUD runtime updates.

## Risk
- `PlayerCanvas.prefab` is high risk because it also contains pause, dialogue, shop, and lose-screen UI.
- The bridge/log instruction remains intentionally visible only at 9/9 logs to preserve discoverability before Phase 2 tips.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

