### PR TITLE
Add tips subsystem foundation

### DIFF
--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -10,22 +10,25 @@
 - Mixed
 
 ## Current phase
-- Phase 1 implementation / verification
+- Phase 2 first implementation slice / verification
 
 ## Goal
 - Improve HUD clarity first, then phase in tips, objectives, footstep feedback, and carried-log game feel without replacing existing pause, input, movement, or combat systems.
 
 ## Scope
-- Phase 1: compact always-visible HUD counters, keep health top-left, move stamina bottom-left, and avoid broad gameplay rewrites.
+- Phase 2 first slice: add a modular tips subsystem, runtime pause-menu Tips On/Off toggle, idle/active gating, cooldown/display-count spam control, and trigger-zone hooks.
 
 ## Out of scope
-- Phase 2+ systems until Phase 1 is reviewed and Unity Play Mode verified.
-- Scene, dialogue, shop, animation, and input-action rewrites.
+- Scene placement of tip trigger zones until Unity Editor follow-up.
+- Dialogue, shop, animation, and input-action rewrites.
 
 ## Relevant files/assets
 - `Assets/Scripts/Player/BeaverPlayerBehaviour.cs`
 - `Assets/Scripts/Player/Carry.cs`
 - `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
+- `Assets/Scripts/Data/Tips/TipDefinition.cs`
+- `Assets/Scripts/UI/Tips/*`
+- `Assets/Scripts/UI/UIMenu.cs`
 
 ## Risk level
 - High
@@ -46,14 +49,16 @@
 - Unity Editor / Play Mode: open Level 1 Remastered, inspect `PlayerCanvas`, confirm HUD layout and existing UI flows.
 
 ## Current status
-- Phase 1 script and prefab changes are implemented for review.
+- Phase 1 HUD cleanup is implemented.
+- Phase 2 tips subsystem code is implemented for review.
 
 ## Next action
 - Owner: Cursor / Unity Editor
-- Action: Run Play Mode validation and adjust prefab layout if needed.
+- Action: Run Play Mode validation, confirm the runtime Tips toggle appears in pause/settings, and place `TipTriggerZone` components only after layout/functionality is accepted.
 
 ## Open questions
 - Whether collectibles should be fully moved into pause/diary UI in a later phase or remain as compact HUD counters.
+- Which scene locations should receive authored `TipTriggerZone` components for bridge/log guidance.
 
 ## Handoff needed
 - Yes

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,11 +1,13 @@
 # Codex → Cursor Handoff
 
 ## Task
-- UI/UX and game-feel improvements — Phase 1 HUD cleanup
+- UI/UX and game-feel improvements — Phase 1 HUD cleanup + Phase 2 tips subsystem first slice
 
 ## Code changes made
 - Compact collectible/ammo/log HUD text values to numbers only so existing icons carry the label meaning.
 - Move `StaminaBar` from the top-left HUD cluster to bottom-left anchored screen space in `PlayerCanvas.prefab`.
+- Add code-only tips subsystem with `TipDefinition`, settings persistence, cooldown/display-count/priority gating, idle/active gating, trigger-zone hooks, and an animated runtime tip card.
+- Add a runtime Tips On/Off toggle to the existing pause menu through `UIMenu` startup without editing the pause menu prefab hierarchy.
 - Record mixed ownership and verification requirements in `AI_WORKFLOW/active-task.md`.
 
 ## Files changed
@@ -14,34 +16,43 @@
 - `Assets/Scripts/Player/BeaverPlayerBehaviour.cs`
 - `Assets/Scripts/Player/Carry.cs`
 - `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
+- `Assets/Scripts/Data/Tips/TipDefinition.cs`
+- `Assets/Scripts/UI/Tips/*`
+- `Assets/Scripts/UI/UIMenu.cs`
 
 ## New or changed serialized fields
-- None.
+- New serialized tuning fields on `TipDefinition`, `TipsService`, `PlayerIdleStateTracker`, `TipCardPresenter`, and `TipTriggerZone`.
+- No existing serialized fields were renamed or removed.
 
 ## Inspector assignments required
 - None expected from script changes.
 - Verify existing `DebugReference` text references and `Health_Bar_Script` slider references remain assigned in the active scenes.
+- Phase 2 scene authoring requires creating `TipDefinition` assets and assigning them to `TipTriggerZone` components in intended areas.
 
 ## Prefab/scene/UI/Animator follow-up required
 - Inspect `PlayerCanvas.prefab` in Unity Editor and confirm `StaminaBar` is readable at bottom-left across common resolutions.
 - Confirm top-right collectible/ammo/log counters still align with their icons after label removal.
 - Decide in Phase 2/3 whether collectibles should move fully into pause/diary UI or remain compact HUD counters.
+- Confirm the runtime `Tips: On/Off` toggle appears in the pause menu and does not overlap volume/restart controls.
+- Add `TipTriggerZone` components near intended bridge/log/tutorial areas after validating the runtime card and toggle.
 
 ## What Cursor should test in Play Mode
-- Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause.
-- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes.
-- Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, bridge construction hinting is not treated as complete until the tips subsystem phase.
+- Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause, toggle Tips off/on.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes, Tips toggle persists across pause reopen.
+- Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, tips do not show while disabled or while gameplay input is locked.
 
 ## What Cursor should not change
 - Do not edit scenes or additional prefabs for later phases until Phase 1 layout is accepted.
 - Do not rewrite input, pause, movement, combat, or objective systems as part of this handoff.
+- Do not scatter bridge/log tips globally; place `TipTriggerZone` only at intended bridge-building/tutorial spaces.
 
 ## Known limitations
 - Unity Play Mode was not available in Cloud, so layout and serialized-reference behavior need Editor verification.
 - A compact bridge-build instruction remains in the 9/9 log HUD until Phase 2 can replace it with contextual tips.
+- The tips subsystem is code-ready, but no authored `TipDefinition` assets or scene trigger-zone placements have been added yet.
 
 ## Risk notes
 - Enemy/NPC behavior risk: Low for Phase 1.
-- Interaction/dialogue/shop flow risk: Medium because `PlayerCanvas.prefab` is shared with dialogue/shop/pause panels.
-- Player combat/input risk: Low; no input/combat logic changed.
+- Interaction/dialogue/shop flow risk: Medium because `PlayerCanvas.prefab` and pause menu runtime UI are shared with dialogue/shop/pause flows.
+- Player combat/input risk: Low; input is read for gating only, not rebound or intercepted.
 - Pooling/performance risk: None in Phase 1.

--- a/Assets/Scripts/Data/Tips.meta
+++ b/Assets/Scripts/Data/Tips.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f68fb781f3b4194bdb02f1c68a1a6df
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Tips/TipDefinition.cs
+++ b/Assets/Scripts/Data/Tips/TipDefinition.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+namespace Beavermania.Data.Tips
+{
+    public enum TipGameStage
+    {
+        EarlyGame,
+        MidGame,
+        EndGame
+    }
+
+    [CreateAssetMenu(fileName = "TipDefinition", menuName = "Beavermania/UI/Tip Definition")]
+    public sealed class TipDefinition : ScriptableObject
+    {
+        [SerializeField] string uniqueId;
+        [SerializeField] [TextArea(2, 4)] string displayText;
+        [SerializeField] int priority;
+        [SerializeField] TipGameStage category;
+        [SerializeField] float cooldownSeconds = 20f;
+        [SerializeField] int maxDisplayCount = 1;
+        [SerializeField] bool showOnlyOnce = true;
+        [SerializeField] int minimumProgress;
+        [SerializeField] bool blockDuringCombat = true;
+        [SerializeField] bool idleOnly;
+        [SerializeField] bool activeOnly;
+        [SerializeField] int triggerInterval = 1;
+        [SerializeField] float displaySeconds = 4f;
+
+        public string UniqueId => string.IsNullOrWhiteSpace(uniqueId) ? name : uniqueId;
+        public string DisplayText => displayText;
+        public int Priority => priority;
+        public TipGameStage Category => category;
+        public float CooldownSeconds => cooldownSeconds;
+        public int MaxDisplayCount => maxDisplayCount;
+        public bool ShowOnlyOnce => showOnlyOnce;
+        public int MinimumProgress => minimumProgress;
+        public bool BlockDuringCombat => blockDuringCombat;
+        public bool IdleOnly => idleOnly;
+        public bool ActiveOnly => activeOnly;
+        public int TriggerInterval => triggerInterval;
+        public float DisplaySeconds => displaySeconds;
+
+        void OnValidate()
+        {
+            cooldownSeconds = Mathf.Max(0f, cooldownSeconds);
+            maxDisplayCount = Mathf.Max(1, maxDisplayCount);
+            triggerInterval = Mathf.Max(1, triggerInterval);
+            displaySeconds = Mathf.Max(1f, displaySeconds);
+            minimumProgress = Mathf.Max(0, minimumProgress);
+        }
+    }
+}

--- a/Assets/Scripts/Data/Tips/TipDefinition.cs.meta
+++ b/Assets/Scripts/Data/Tips/TipDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00d43b0a47b34dd58d5d93f944f7bb4b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Tips.meta
+++ b/Assets/Scripts/UI/Tips.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0fd7cd3a42824f4e9b1a74a4e8ab4f8f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Tips/PlayerIdleStateTracker.cs
+++ b/Assets/Scripts/UI/Tips/PlayerIdleStateTracker.cs
@@ -1,0 +1,46 @@
+using Beavermania.Core.Input;
+using UnityEngine;
+
+namespace Beavermania.UI.Tips
+{
+    [DisallowMultipleComponent]
+    public sealed class PlayerIdleStateTracker : MonoBehaviour
+    {
+        [SerializeField] float idleSecondsRequired = 6f;
+        [SerializeField] float movementDistanceThreshold = 0.08f;
+        [SerializeField] float activeInputGraceSeconds = 0.35f;
+
+        Vector3 lastPosition;
+        float idleTimer;
+        float lastActiveInputTime;
+
+        public bool IsIdle => idleTimer >= idleSecondsRequired;
+        public bool IsActive => Time.unscaledTime - lastActiveInputTime <= activeInputGraceSeconds;
+
+        void OnEnable()
+        {
+            lastPosition = transform.position;
+            idleTimer = 0f;
+            lastActiveInputTime = Time.unscaledTime;
+        }
+
+        void Update()
+        {
+            bool moved = (transform.position - lastPosition).sqrMagnitude > movementDistanceThreshold * movementDistanceThreshold;
+            bool inputActive = PlayerInputReader.IsAnyKeyHeld();
+
+            if (moved || inputActive)
+            {
+                idleTimer = 0f;
+                if (inputActive)
+                    lastActiveInputTime = Time.unscaledTime;
+            }
+            else
+            {
+                idleTimer += Time.unscaledDeltaTime;
+            }
+
+            lastPosition = transform.position;
+        }
+    }
+}

--- a/Assets/Scripts/UI/Tips/PlayerIdleStateTracker.cs.meta
+++ b/Assets/Scripts/UI/Tips/PlayerIdleStateTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84ba7e2e4c4e47dc9bdf943ee05b29ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Tips/TipCardPresenter.cs
+++ b/Assets/Scripts/UI/Tips/TipCardPresenter.cs
@@ -1,0 +1,130 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Beavermania.UI.Tips
+{
+    [DisallowMultipleComponent]
+    public sealed class TipCardPresenter : MonoBehaviour
+    {
+        [SerializeField] RectTransform cardRoot;
+        [SerializeField] TextMeshProUGUI messageText;
+        [SerializeField] CanvasGroup canvasGroup;
+        [SerializeField] float fadeSeconds = 0.2f;
+        [SerializeField] Vector2 hiddenOffset = new(24f, 0f);
+
+        RectTransform rectTransform;
+        Vector2 visiblePosition;
+        Vector2 hiddenPosition;
+        float hideAtTime;
+        float alphaTarget;
+
+        public bool IsShowing => canvasGroup != null && canvasGroup.alpha > 0.01f && Time.unscaledTime < hideAtTime;
+        public int CurrentPriority { get; private set; }
+
+        void Awake()
+        {
+            EnsureRuntimeView();
+        }
+
+        void OnEnable()
+        {
+            TipsSettings.Changed += OnTipsSettingChanged;
+        }
+
+        void OnDisable()
+        {
+            TipsSettings.Changed -= OnTipsSettingChanged;
+        }
+
+        void Update()
+        {
+            if (canvasGroup == null || rectTransform == null)
+                return;
+
+            alphaTarget = Time.unscaledTime < hideAtTime && TipsSettings.Enabled ? 1f : 0f;
+            float fadeSpeed = fadeSeconds <= 0f ? 1f : Time.unscaledDeltaTime / fadeSeconds;
+            canvasGroup.alpha = Mathf.MoveTowards(canvasGroup.alpha, alphaTarget, fadeSpeed);
+            rectTransform.anchoredPosition = Vector2.Lerp(hiddenPosition, visiblePosition, canvasGroup.alpha);
+
+            if (canvasGroup.alpha <= 0.01f && alphaTarget <= 0f)
+                CurrentPriority = int.MinValue;
+        }
+
+        public void Show(string message, int priority, float displaySeconds)
+        {
+            EnsureRuntimeView();
+            if (messageText == null || canvasGroup == null)
+                return;
+
+            CurrentPriority = priority;
+            messageText.text = message;
+            hideAtTime = Time.unscaledTime + Mathf.Max(1f, displaySeconds);
+            alphaTarget = 1f;
+        }
+
+        void EnsureRuntimeView()
+        {
+            if (cardRoot == null)
+                CreateRuntimeCard();
+
+            rectTransform = cardRoot;
+            if (canvasGroup == null && cardRoot != null)
+                canvasGroup = cardRoot.GetComponent<CanvasGroup>();
+
+            if (canvasGroup != null)
+            {
+                canvasGroup.alpha = 0f;
+                canvasGroup.interactable = false;
+                canvasGroup.blocksRaycasts = false;
+            }
+
+            if (rectTransform != null)
+            {
+                visiblePosition = rectTransform.anchoredPosition;
+                hiddenPosition = visiblePosition + hiddenOffset;
+                rectTransform.anchoredPosition = hiddenPosition;
+            }
+
+            CurrentPriority = int.MinValue;
+        }
+
+        void CreateRuntimeCard()
+        {
+            var card = new GameObject("TipsCard", typeof(RectTransform), typeof(CanvasGroup), typeof(Image));
+            card.transform.SetParent(transform, false);
+            cardRoot = card.GetComponent<RectTransform>();
+            cardRoot.anchorMin = new Vector2(1f, 1f);
+            cardRoot.anchorMax = new Vector2(1f, 1f);
+            cardRoot.pivot = new Vector2(1f, 1f);
+            cardRoot.anchoredPosition = new Vector2(-28f, -112f);
+            cardRoot.sizeDelta = new Vector2(360f, 86f);
+
+            canvasGroup = card.GetComponent<CanvasGroup>();
+            var background = card.GetComponent<Image>();
+            background.color = new Color(0.05f, 0.035f, 0.025f, 0.78f);
+            background.raycastTarget = false;
+
+            var textObject = new GameObject("Message", typeof(RectTransform), typeof(TextMeshProUGUI));
+            textObject.transform.SetParent(card.transform, false);
+            var textRect = textObject.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = new Vector2(16f, 10f);
+            textRect.offsetMax = new Vector2(-16f, -10f);
+
+            messageText = textObject.GetComponent<TextMeshProUGUI>();
+            messageText.text = string.Empty;
+            messageText.fontSize = 22f;
+            messageText.enableWordWrapping = true;
+            messageText.alignment = TextAlignmentOptions.MidlineLeft;
+            messageText.raycastTarget = false;
+        }
+
+        void OnTipsSettingChanged(bool enabled)
+        {
+            if (!enabled)
+                hideAtTime = 0f;
+        }
+    }
+}

--- a/Assets/Scripts/UI/Tips/TipCardPresenter.cs.meta
+++ b/Assets/Scripts/UI/Tips/TipCardPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7c3df88c813475e8c34dfeac543ac97
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Tips/TipTriggerZone.cs
+++ b/Assets/Scripts/UI/Tips/TipTriggerZone.cs
@@ -1,0 +1,48 @@
+using Beavermania.Data.Tips;
+using UnityEngine;
+
+namespace Beavermania.UI.Tips
+{
+    [DisallowMultipleComponent]
+    public sealed class TipTriggerZone : MonoBehaviour
+    {
+        [SerializeField] TipDefinition tip;
+        [SerializeField] string areaKey;
+        [SerializeField] bool triggerOnEnter = true;
+        [SerializeField] bool triggerWhileInside;
+        [SerializeField] float repeatAttemptSeconds = 2f;
+
+        float nextRepeatTime;
+
+        void OnTriggerEnter(Collider other)
+        {
+            if (!triggerOnEnter || !IsPlayer(other))
+                return;
+
+            TryTrigger();
+        }
+
+        void OnTriggerStay(Collider other)
+        {
+            if (!triggerWhileInside || !IsPlayer(other) || Time.unscaledTime < nextRepeatTime)
+                return;
+
+            TryTrigger();
+            nextRepeatTime = Time.unscaledTime + Mathf.Max(0.25f, repeatAttemptSeconds);
+        }
+
+        void TryTrigger()
+        {
+            if (tip == null)
+                return;
+
+            string resolvedAreaKey = string.IsNullOrWhiteSpace(areaKey) ? name : areaKey;
+            TipsService.TryShowTip(tip, resolvedAreaKey);
+        }
+
+        static bool IsPlayer(Collider other)
+        {
+            return other != null && other.CompareTag("Player");
+        }
+    }
+}

--- a/Assets/Scripts/UI/Tips/TipTriggerZone.cs.meta
+++ b/Assets/Scripts/UI/Tips/TipTriggerZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35037ff07dad4933bc00d41af16122d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Tips/TipsPauseMenuToggleInstaller.cs
+++ b/Assets/Scripts/UI/Tips/TipsPauseMenuToggleInstaller.cs
@@ -1,0 +1,146 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Beavermania.UI.Tips
+{
+    public static class TipsPauseMenuToggleInstaller
+    {
+        const string ToggleName = "Tips Toggle";
+
+        public static void Ensure(GameObject pauseMenu)
+        {
+            if (pauseMenu == null)
+                return;
+
+            Toggle toggle = FindExistingToggle(pauseMenu.transform);
+            Text label = null;
+
+            if (toggle == null)
+                toggle = CreateToggle(pauseMenu.transform, out label);
+            else
+                label = toggle.GetComponentInChildren<Text>(true);
+
+            if (toggle == null)
+                return;
+
+            WireToggle(toggle, label);
+        }
+
+        static Toggle FindExistingToggle(Transform root)
+        {
+            Toggle[] toggles = root.GetComponentsInChildren<Toggle>(true);
+            for (int i = 0; i < toggles.Length; i++)
+            {
+                if (toggles[i] != null && toggles[i].gameObject.name == ToggleName)
+                    return toggles[i];
+            }
+
+            return null;
+        }
+
+        static Toggle CreateToggle(Transform pauseMenuRoot, out Text label)
+        {
+            label = null;
+            Transform parent = ResolveControlsParent(pauseMenuRoot);
+            var root = new GameObject(ToggleName, typeof(RectTransform), typeof(Toggle));
+            root.transform.SetParent(parent, false);
+
+            var rect = root.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.sizeDelta = new Vector2(260f, 32f);
+            rect.anchoredPosition = ResolveTogglePosition(parent);
+
+            var backgroundObject = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            backgroundObject.transform.SetParent(root.transform, false);
+            var backgroundRect = backgroundObject.GetComponent<RectTransform>();
+            backgroundRect.anchorMin = new Vector2(0f, 0.5f);
+            backgroundRect.anchorMax = new Vector2(0f, 0.5f);
+            backgroundRect.pivot = new Vector2(0f, 0.5f);
+            backgroundRect.sizeDelta = new Vector2(24f, 24f);
+            backgroundRect.anchoredPosition = Vector2.zero;
+            var background = backgroundObject.GetComponent<Image>();
+            background.color = new Color(1f, 1f, 1f, 0.8f);
+
+            var checkmarkObject = new GameObject("Checkmark", typeof(RectTransform), typeof(Image));
+            checkmarkObject.transform.SetParent(backgroundObject.transform, false);
+            var checkmarkRect = checkmarkObject.GetComponent<RectTransform>();
+            checkmarkRect.anchorMin = new Vector2(0.5f, 0.5f);
+            checkmarkRect.anchorMax = new Vector2(0.5f, 0.5f);
+            checkmarkRect.pivot = new Vector2(0.5f, 0.5f);
+            checkmarkRect.sizeDelta = new Vector2(14f, 14f);
+            checkmarkRect.anchoredPosition = Vector2.zero;
+            var checkmark = checkmarkObject.GetComponent<Image>();
+            checkmark.color = new Color(0.2f, 0.8f, 0.35f, 1f);
+
+            var labelObject = new GameObject("Label", typeof(RectTransform), typeof(Text));
+            labelObject.transform.SetParent(root.transform, false);
+            var labelRect = labelObject.GetComponent<RectTransform>();
+            labelRect.anchorMin = new Vector2(0f, 0f);
+            labelRect.anchorMax = new Vector2(1f, 1f);
+            labelRect.offsetMin = new Vector2(34f, 0f);
+            labelRect.offsetMax = Vector2.zero;
+            label = labelObject.GetComponent<Text>();
+            label.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            label.fontSize = 22;
+            label.alignment = TextAnchor.MiddleLeft;
+            label.color = Color.white;
+
+            var toggle = root.GetComponent<Toggle>();
+            toggle.targetGraphic = background;
+            toggle.graphic = checkmark;
+            return toggle;
+        }
+
+        static Transform ResolveControlsParent(Transform pauseMenuRoot)
+        {
+            Slider[] sliders = pauseMenuRoot.GetComponentsInChildren<Slider>(true);
+            for (int i = 0; i < sliders.Length; i++)
+            {
+                if (sliders[i] != null && sliders[i].transform.parent != null)
+                    return sliders[i].transform.parent;
+            }
+
+            return pauseMenuRoot;
+        }
+
+        static Vector2 ResolveTogglePosition(Transform parent)
+        {
+            Slider[] sliders = parent.GetComponentsInChildren<Slider>(true);
+            if (sliders.Length == 0)
+                return new Vector2(0f, -150f);
+
+            RectTransform lowest = null;
+            for (int i = 0; i < sliders.Length; i++)
+            {
+                var rect = sliders[i].GetComponent<RectTransform>();
+                if (rect == null)
+                    continue;
+
+                if (lowest == null || rect.anchoredPosition.y < lowest.anchoredPosition.y)
+                    lowest = rect;
+            }
+
+            return lowest != null ? lowest.anchoredPosition + new Vector2(0f, -45f) : new Vector2(0f, -150f);
+        }
+
+        static void WireToggle(Toggle toggle, Text label)
+        {
+            toggle.onValueChanged.RemoveAllListeners();
+            toggle.SetIsOnWithoutNotify(TipsSettings.Enabled);
+            UpdateLabel(label, TipsSettings.Enabled);
+            toggle.onValueChanged.AddListener(enabled =>
+            {
+                TipsSettings.Enabled = enabled;
+                UpdateLabel(label, enabled);
+            });
+        }
+
+        static void UpdateLabel(Text label, bool enabled)
+        {
+            if (label != null)
+                label.text = enabled ? "Tips: On" : "Tips: Off";
+        }
+    }
+}

--- a/Assets/Scripts/UI/Tips/TipsPauseMenuToggleInstaller.cs.meta
+++ b/Assets/Scripts/UI/Tips/TipsPauseMenuToggleInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2ea3c15747d47b2bcf0c25893b94b78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Tips/TipsService.cs
+++ b/Assets/Scripts/UI/Tips/TipsService.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using Beavermania.Core.Input;
+using Beavermania.Data.Tips;
+using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
+using UnityEngine;
+
+namespace Beavermania.UI.Tips
+{
+    [DisallowMultipleComponent]
+    public sealed class TipsService : MonoBehaviour
+    {
+        sealed class TipRuntimeState
+        {
+            public int DisplayCount;
+            public int TriggerCount;
+            public float LastDisplayTime = float.NegativeInfinity;
+        }
+
+        static readonly Dictionary<string, TipRuntimeState> RuntimeState = new();
+
+        [SerializeField] BeaverPlayer player;
+        [SerializeField] TipCardPresenter presenter;
+        [SerializeField] PlayerIdleStateTracker idleState;
+        [SerializeField] TipGameStage currentStage = TipGameStage.EarlyGame;
+        [SerializeField] int currentProgress;
+
+        bool scriptedBlockActive;
+
+        public static TipsService Instance { get; private set; }
+
+        public static TipsService EnsureForCanvas(GameObject canvasRoot, BeaverPlayer player)
+        {
+            if (Instance != null)
+            {
+                Instance.BindPlayer(player);
+                return Instance;
+            }
+
+            if (canvasRoot == null)
+                return null;
+
+            TipsService service = canvasRoot.GetComponent<TipsService>();
+            if (service == null)
+                service = canvasRoot.AddComponent<TipsService>();
+
+            service.BindPlayer(player);
+            return service;
+        }
+
+        public static bool TryShowTip(TipDefinition tip, string areaKey = null)
+        {
+            return Instance != null && Instance.TryShow(tip, areaKey);
+        }
+
+        public static void SetProgress(int progress)
+        {
+            if (Instance != null)
+                Instance.currentProgress = Mathf.Max(0, progress);
+        }
+
+        public static void SetStage(TipGameStage stage)
+        {
+            if (Instance != null)
+                Instance.currentStage = stage;
+        }
+
+        public static void SetScriptedBlock(bool blocked)
+        {
+            if (Instance != null)
+                Instance.scriptedBlockActive = blocked;
+        }
+
+        void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(this);
+                return;
+            }
+
+            Instance = this;
+            EnsurePresenter();
+        }
+
+        void OnDestroy()
+        {
+            if (Instance == this)
+                Instance = null;
+        }
+
+        public void BindPlayer(BeaverPlayer newPlayer)
+        {
+            if (newPlayer == null)
+                return;
+
+            player = newPlayer;
+            idleState = player.GetComponent<PlayerIdleStateTracker>();
+            if (idleState == null)
+                idleState = player.gameObject.AddComponent<PlayerIdleStateTracker>();
+        }
+
+        public bool TryShow(TipDefinition tip, string areaKey = null)
+        {
+            EnsurePresenter();
+
+            if (!CanShowTip(tip))
+                return false;
+
+            string stateKey = BuildStateKey(tip.UniqueId, areaKey);
+            TipRuntimeState state = GetState(stateKey);
+            state.TriggerCount++;
+
+            if (state.TriggerCount % tip.TriggerInterval != 0)
+                return false;
+
+            if (HasExceededDisplayLimit(tip, state))
+                return false;
+
+            if (Time.unscaledTime - state.LastDisplayTime < tip.CooldownSeconds)
+                return false;
+
+            if (presenter != null && presenter.IsShowing && presenter.CurrentPriority >= tip.Priority)
+                return false;
+
+            presenter.Show(tip.DisplayText, tip.Priority, tip.DisplaySeconds);
+            state.DisplayCount++;
+            state.LastDisplayTime = Time.unscaledTime;
+            return true;
+        }
+
+        bool CanShowTip(TipDefinition tip)
+        {
+            if (!TipsSettings.Enabled || tip == null || string.IsNullOrWhiteSpace(tip.DisplayText))
+                return false;
+
+            if (player != null && player.IsGameplayInputLocked())
+                return false;
+
+            if (tip.MinimumProgress > currentProgress)
+                return false;
+
+            if (tip.Category != currentStage)
+                return false;
+
+            if (tip.BlockDuringCombat && IsCombatOrPressureActive())
+                return false;
+
+            if (tip.IdleOnly && (idleState == null || !idleState.IsIdle))
+                return false;
+
+            if (tip.ActiveOnly && (idleState == null || !idleState.IsActive))
+                return false;
+
+            return true;
+        }
+
+        bool IsCombatOrPressureActive()
+        {
+            if (scriptedBlockActive)
+                return true;
+
+            if (player != null && (player.Rolling || player.Defend || player.isParried))
+                return true;
+
+            return PlayerInputReader.IsPrimaryHeld()
+                || PlayerInputReader.IsSecondaryHeld()
+                || PlayerInputReader.IsRollHeld()
+                || PlayerInputReader.IsDefendKeyHeld();
+        }
+
+        void EnsurePresenter()
+        {
+            if (presenter == null)
+                presenter = GetComponent<TipCardPresenter>();
+            if (presenter == null)
+                presenter = gameObject.AddComponent<TipCardPresenter>();
+        }
+
+        static TipRuntimeState GetState(string key)
+        {
+            if (!RuntimeState.TryGetValue(key, out TipRuntimeState state))
+            {
+                state = new TipRuntimeState();
+                RuntimeState.Add(key, state);
+            }
+
+            return state;
+        }
+
+        static bool HasExceededDisplayLimit(TipDefinition tip, TipRuntimeState state)
+        {
+            if (tip.ShowOnlyOnce && state.DisplayCount > 0)
+                return true;
+
+            return state.DisplayCount >= tip.MaxDisplayCount;
+        }
+
+        static string BuildStateKey(string uniqueId, string areaKey)
+        {
+            if (string.IsNullOrWhiteSpace(areaKey))
+                return uniqueId;
+
+            return uniqueId + "@" + areaKey;
+        }
+    }
+}

--- a/Assets/Scripts/UI/Tips/TipsService.cs.meta
+++ b/Assets/Scripts/UI/Tips/TipsService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ebdb87e7c8b4d81bb0c08e02f66fc1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Tips/TipsSettings.cs
+++ b/Assets/Scripts/UI/Tips/TipsSettings.cs
@@ -1,0 +1,29 @@
+using System;
+using UnityEngine;
+
+namespace Beavermania.UI.Tips
+{
+    public static class TipsSettings
+    {
+        public const string TipsEnabledPrefKey = "Beavermania.Tips.Enabled";
+        const int EnabledValue = 1;
+        const int DisabledValue = 0;
+
+        public static event Action<bool> Changed;
+
+        public static bool Enabled
+        {
+            get => PlayerPrefs.GetInt(TipsEnabledPrefKey, EnabledValue) == EnabledValue;
+            set
+            {
+                int nextValue = value ? EnabledValue : DisabledValue;
+                if (PlayerPrefs.GetInt(TipsEnabledPrefKey, EnabledValue) == nextValue)
+                    return;
+
+                PlayerPrefs.SetInt(TipsEnabledPrefKey, nextValue);
+                PlayerPrefs.Save();
+                Changed?.Invoke(value);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/Tips/TipsSettings.cs.meta
+++ b/Assets/Scripts/UI/Tips/TipsSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1769d1e3ff744a7f91324ec8614cbdf9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -1,5 +1,6 @@
 using Beavermania.Audio;
 using Beavermania.Core.GameFlow;
+using Beavermania.UI.Tips;
 using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
 using System.Collections;
 using UnityEngine;
@@ -64,6 +65,13 @@ namespace Beavermania.UI.Menus
             RefreshRestartCheckpointButtonState();
             InitializeVolumeSlider();
             InitializeSfxVolumeSlider();
+            InitializeTipsUi();
+        }
+
+        void InitializeTipsUi()
+        {
+            TipsService.EnsureForCanvas(gameObject, Player);
+            TipsPauseMenuToggleInstaller.Ensure(PauseMenu);
         }
 
         void InitializeVolumeSlider()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Phase 2 tips subsystem foundation: `TipDefinition` data, settings persistence, animated card presenter, spam-control service, idle/active gating, trigger-zone hooks, and runtime pause-menu Tips On/Off toggle.
- Keep scene/prefab placement of actual tips as Unity Editor follow-up through the workflow handoff.

## Verification
- `dotnet build BeaverMania.CI.csproj` passed from `/workspace/.ci` with 0 warnings and 0 errors after Phase 2 code changes.
- `git diff --check` passed with no whitespace errors.
- Needs Unity Editor Play Mode verification for runtime Tips toggle placement, pause flow, tip card rendering, and authored tip trigger zones.

## Risk
- Runtime pause-menu UI creation must be visually checked for overlap with volume/restart controls.
- No `TipDefinition` assets or scene `TipTriggerZone` placements are authored yet; those require Unity Editor follow-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

