### PR TITLE
Add contextual bridge tips

### DIFF
--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -16,7 +16,7 @@
 - Improve HUD clarity first, then phase in tips, objectives, footstep feedback, and carried-log game feel without replacing existing pause, input, movement, or combat systems.
 
 ## Scope
-- Phase 2 first slice: add a modular tips subsystem, runtime pause-menu Tips On/Off toggle, idle/active gating, cooldown/display-count spam control, and trigger-zone hooks.
+- Phase 2 second slice: add contextual bridge-area tips through the existing bridge construction component, while keeping the compact log HUD fallback.
 
 ## Out of scope
 - Scene placement of tip trigger zones until Unity Editor follow-up.
@@ -27,8 +27,10 @@
 - `Assets/Scripts/Player/Carry.cs`
 - `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
 - `Assets/Scripts/Data/Tips/TipDefinition.cs`
+- `Assets/Scripts/Data/Tips/TipRequest.cs`
 - `Assets/Scripts/UI/Tips/*`
 - `Assets/Scripts/UI/UIMenu.cs`
+- `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
 
 ## Risk level
 - High
@@ -51,10 +53,11 @@
 ## Current status
 - Phase 1 HUD cleanup is implemented.
 - Phase 2 tips subsystem code is implemented for review.
+- Contextual bridge construction tips are wired to intended bridge construction areas via `NewConstructor`.
 
 ## Next action
 - Owner: Cursor / Unity Editor
-- Action: Run Play Mode validation, confirm the runtime Tips toggle appears in pause/settings, and place `TipTriggerZone` components only after layout/functionality is accepted.
+- Action: Run Play Mode validation, confirm bridge-area tips trigger only near bridge constructors, and place additional `TipTriggerZone` components only after layout/functionality is accepted.
 
 ## Open questions
 - Whether collectibles should be fully moved into pause/diary UI in a later phase or remain as compact HUD counters.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,13 +1,14 @@
 # Codex → Cursor Handoff
 
 ## Task
-- UI/UX and game-feel improvements — Phase 1 HUD cleanup + Phase 2 tips subsystem first slice
+- UI/UX and game-feel improvements — Phase 1 HUD cleanup + Phase 2 tips subsystem and bridge tips
 
 ## Code changes made
 - Compact collectible/ammo/log HUD text values to numbers only so existing icons carry the label meaning.
 - Move `StaminaBar` from the top-left HUD cluster to bottom-left anchored screen space in `PlayerCanvas.prefab`.
 - Add code-only tips subsystem with `TipDefinition`, settings persistence, cooldown/display-count/priority gating, idle/active gating, trigger-zone hooks, and an animated runtime tip card.
 - Add a runtime Tips On/Off toggle to the existing pause menu through `UIMenu` startup without editing the pause menu prefab hierarchy.
+- Add contextual bridge construction tips through `NewConstructor` so bridge/log guidance appears only near intended bridge construction areas.
 - Record mixed ownership and verification requirements in `AI_WORKFLOW/active-task.md`.
 
 ## Files changed
@@ -17,8 +18,10 @@
 - `Assets/Scripts/Player/Carry.cs`
 - `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
 - `Assets/Scripts/Data/Tips/TipDefinition.cs`
+- `Assets/Scripts/Data/Tips/TipRequest.cs`
 - `Assets/Scripts/UI/Tips/*`
 - `Assets/Scripts/UI/UIMenu.cs`
+- `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
 
 ## New or changed serialized fields
 - New serialized tuning fields on `TipDefinition`, `TipsService`, `PlayerIdleStateTracker`, `TipCardPresenter`, and `TipTriggerZone`.
@@ -34,12 +37,13 @@
 - Confirm top-right collectible/ammo/log counters still align with their icons after label removal.
 - Decide in Phase 2/3 whether collectibles should move fully into pause/diary UI or remain compact HUD counters.
 - Confirm the runtime `Tips: On/Off` toggle appears in the pause menu and does not overlap volume/restart controls.
+- Confirm bridge tips appear near `NewConstructor` trigger areas and do not appear globally when the player is away from bridge constructors.
 - Add `TipTriggerZone` components near intended bridge/log/tutorial areas after validating the runtime card and toggle.
 
 ## What Cursor should test in Play Mode
 - Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause, toggle Tips off/on.
-- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes, Tips toggle persists across pause reopen.
-- Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, tips do not show while disabled or while gameplay input is locked.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers.
+- Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, tips do not show while disabled, paused, in trader UI, or away from bridge construction areas.
 
 ## What Cursor should not change
 - Do not edit scenes or additional prefabs for later phases until Phase 1 layout is accepted.
@@ -48,11 +52,11 @@
 
 ## Known limitations
 - Unity Play Mode was not available in Cloud, so layout and serialized-reference behavior need Editor verification.
-- A compact bridge-build instruction remains in the 9/9 log HUD until Phase 2 can replace it with contextual tips.
-- The tips subsystem is code-ready, but no authored `TipDefinition` assets or scene trigger-zone placements have been added yet.
+- A compact bridge-build instruction remains in the 9/9 log HUD as a fallback while contextual bridge-area tips are verified.
+- Additional authored `TipDefinition` assets or scene `TipTriggerZone` placements have not been added yet.
 
 ## Risk notes
 - Enemy/NPC behavior risk: Low for Phase 1.
 - Interaction/dialogue/shop flow risk: Medium because `PlayerCanvas.prefab` and pause menu runtime UI are shared with dialogue/shop/pause flows.
 - Player combat/input risk: Low; input is read for gating only, not rebound or intercepted.
-- Pooling/performance risk: None in Phase 1.
+- Pooling/performance risk: Low; bridge tips use cooldown/attempt throttling and do not spawn particles or pooled objects.

--- a/Assets/Scripts/Data/Tips/TipDefinition.cs
+++ b/Assets/Scripts/Data/Tips/TipDefinition.cs
@@ -40,6 +40,24 @@ namespace Beavermania.Data.Tips
         public int TriggerInterval => triggerInterval;
         public float DisplaySeconds => displaySeconds;
 
+        public TipRequest ToRequest()
+        {
+            return new TipRequest(
+                UniqueId,
+                DisplayText,
+                Priority,
+                Category,
+                CooldownSeconds,
+                MaxDisplayCount,
+                ShowOnlyOnce,
+                MinimumProgress,
+                BlockDuringCombat,
+                IdleOnly,
+                ActiveOnly,
+                TriggerInterval,
+                DisplaySeconds);
+        }
+
         void OnValidate()
         {
             cooldownSeconds = Mathf.Max(0f, cooldownSeconds);

--- a/Assets/Scripts/Data/Tips/TipRequest.cs
+++ b/Assets/Scripts/Data/Tips/TipRequest.cs
@@ -1,0 +1,49 @@
+namespace Beavermania.Data.Tips
+{
+    public readonly struct TipRequest
+    {
+        public TipRequest(
+            string uniqueId,
+            string displayText,
+            int priority = 0,
+            TipGameStage category = TipGameStage.EarlyGame,
+            float cooldownSeconds = 20f,
+            int maxDisplayCount = 1,
+            bool showOnlyOnce = true,
+            int minimumProgress = 0,
+            bool blockDuringCombat = true,
+            bool idleOnly = false,
+            bool activeOnly = false,
+            int triggerInterval = 1,
+            float displaySeconds = 4f)
+        {
+            UniqueId = uniqueId;
+            DisplayText = displayText;
+            Priority = priority;
+            Category = category;
+            CooldownSeconds = cooldownSeconds;
+            MaxDisplayCount = maxDisplayCount;
+            ShowOnlyOnce = showOnlyOnce;
+            MinimumProgress = minimumProgress;
+            BlockDuringCombat = blockDuringCombat;
+            IdleOnly = idleOnly;
+            ActiveOnly = activeOnly;
+            TriggerInterval = triggerInterval;
+            DisplaySeconds = displaySeconds;
+        }
+
+        public string UniqueId { get; }
+        public string DisplayText { get; }
+        public int Priority { get; }
+        public TipGameStage Category { get; }
+        public float CooldownSeconds { get; }
+        public int MaxDisplayCount { get; }
+        public bool ShowOnlyOnce { get; }
+        public int MinimumProgress { get; }
+        public bool BlockDuringCombat { get; }
+        public bool IdleOnly { get; }
+        public bool ActiveOnly { get; }
+        public int TriggerInterval { get; }
+        public float DisplaySeconds { get; }
+    }
+}

--- a/Assets/Scripts/Data/Tips/TipRequest.cs.meta
+++ b/Assets/Scripts/Data/Tips/TipRequest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c6c9e56e23a49c68bf1c81775256b8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Objects/Newbridge/NewConstructor.cs
+++ b/Assets/Scripts/Objects/Newbridge/NewConstructor.cs
@@ -2,12 +2,19 @@ using UnityEngine;
 using UnityEngine.UI;
 using Beavermania.Audio;
 using Beavermania.Core.Input;
+using Beavermania.Data.Tips;
+using Beavermania.UI.Tips;
 using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
 
 namespace Beavermania.Objects
 {
     public class NewConstructor : MonoBehaviour
     {
+        const string BridgeLockTipId = "bridge.lock-construction";
+        const string BridgeCarryLogsTipId = "bridge.carry-logs";
+        const string BridgeBuildTipId = "bridge.build-with-logs";
+        const string BridgeExtendTipId = "bridge.extend-with-nut";
+
         public BeaverPlayer Player;
         public int PartCount = 0;
         public int BridgeLimit = 8;
@@ -31,6 +38,10 @@ namespace Beavermania.Objects
         public BoxCollider[] partsColliders;
         bool invokeLock = false;
         Vector3 lockPos;
+        [SerializeField] float bridgeTipRepeatAttemptSeconds = 2f;
+        float nextBridgeTipAttemptTime;
+        string bridgeTipAreaKey;
+
         private void Awake()
         {
             //Ramp = GetComponent<MeshRenderer>();
@@ -45,6 +56,7 @@ namespace Beavermania.Objects
             isLocked = false;
             BridgeText = "press left ctrl for bridge lock and construction";
             BridgeUI.text = BridgeText;
+            bridgeTipAreaKey = "bridge:" + GetInstanceID();
         }
 
         [System.Obsolete]
@@ -87,6 +99,8 @@ namespace Beavermania.Objects
         {
             if (OBJ.gameObject.CompareTag("Player"))
             {
+                TryShowBridgeTip();
+
                 if (PlayerInputReader.WasRollPressed())
                 {
                     if (invokeLock==false)
@@ -120,6 +134,63 @@ namespace Beavermania.Objects
                 Player.ChangeSpeech = 3;
             }
 
+        }
+
+        void TryShowBridgeTip()
+        {
+            if (Time.unscaledTime < nextBridgeTipAttemptTime)
+                return;
+
+            nextBridgeTipAttemptTime = Time.unscaledTime + Mathf.Max(0.25f, bridgeTipRepeatAttemptSeconds);
+
+            if (!isLocked)
+            {
+                TipsService.TryShowTip(new TipRequest(
+                    BridgeLockTipId,
+                    "Hold LCtrl here to lock bridge construction.",
+                    priority: 20,
+                    cooldownSeconds: 12f,
+                    maxDisplayCount: 2,
+                    showOnlyOnce: false,
+                    displaySeconds: 4f), bridgeTipAreaKey);
+                return;
+            }
+
+            if (PartCount >= BridgeLimit)
+            {
+                TipsService.TryShowTip(new TipRequest(
+                    BridgeExtendTipId,
+                    "Use a nut here to extend the bridge.",
+                    priority: 15,
+                    cooldownSeconds: 12f,
+                    maxDisplayCount: 2,
+                    showOnlyOnce: false,
+                    displaySeconds: 4f), bridgeTipAreaKey);
+                return;
+            }
+
+            if (Player != null && Player.Load != null && Player.Load.i > 0)
+            {
+                TipsService.TryShowTip(new TipRequest(
+                    BridgeBuildTipId,
+                    "Drop logs into this bridge frame to build.",
+                    priority: 25,
+                    cooldownSeconds: 8f,
+                    maxDisplayCount: 3,
+                    showOnlyOnce: false,
+                    displaySeconds: 4f), bridgeTipAreaKey);
+                return;
+            }
+
+            TipsService.TryShowTip(new TipRequest(
+                BridgeCarryLogsTipId,
+                "Bring logs here after locking the bridge frame.",
+                priority: 10,
+                cooldownSeconds: 14f,
+                maxDisplayCount: 2,
+                showOnlyOnce: false,
+                idleOnly: true,
+                displaySeconds: 4f), bridgeTipAreaKey);
         }
 
         void MergeColliders(BoxCollider[] bridgeParts)

--- a/Assets/Scripts/UI/Tips/TipsService.cs
+++ b/Assets/Scripts/UI/Tips/TipsService.cs
@@ -49,6 +49,11 @@ namespace Beavermania.UI.Tips
 
         public static bool TryShowTip(TipDefinition tip, string areaKey = null)
         {
+            return tip != null && TryShowTip(tip.ToRequest(), areaKey);
+        }
+
+        public static bool TryShowTip(TipRequest tip, string areaKey = null)
+        {
             return Instance != null && Instance.TryShow(tip, areaKey);
         }
 
@@ -99,7 +104,7 @@ namespace Beavermania.UI.Tips
                 idleState = player.gameObject.AddComponent<PlayerIdleStateTracker>();
         }
 
-        public bool TryShow(TipDefinition tip, string areaKey = null)
+        public bool TryShow(TipRequest tip, string areaKey = null)
         {
             EnsurePresenter();
 
@@ -110,13 +115,14 @@ namespace Beavermania.UI.Tips
             TipRuntimeState state = GetState(stateKey);
             state.TriggerCount++;
 
-            if (state.TriggerCount % tip.TriggerInterval != 0)
+            int triggerInterval = Mathf.Max(1, tip.TriggerInterval);
+            if (state.TriggerCount % triggerInterval != 0)
                 return false;
 
             if (HasExceededDisplayLimit(tip, state))
                 return false;
 
-            if (Time.unscaledTime - state.LastDisplayTime < tip.CooldownSeconds)
+            if (Time.unscaledTime - state.LastDisplayTime < Mathf.Max(0f, tip.CooldownSeconds))
                 return false;
 
             if (presenter != null && presenter.IsShowing && presenter.CurrentPriority >= tip.Priority)
@@ -128,9 +134,11 @@ namespace Beavermania.UI.Tips
             return true;
         }
 
-        bool CanShowTip(TipDefinition tip)
+        bool CanShowTip(TipRequest tip)
         {
-            if (!TipsSettings.Enabled || tip == null || string.IsNullOrWhiteSpace(tip.DisplayText))
+            if (!TipsSettings.Enabled
+                || string.IsNullOrWhiteSpace(tip.UniqueId)
+                || string.IsNullOrWhiteSpace(tip.DisplayText))
                 return false;
 
             if (player != null && player.IsGameplayInputLocked())
@@ -187,12 +195,12 @@ namespace Beavermania.UI.Tips
             return state;
         }
 
-        static bool HasExceededDisplayLimit(TipDefinition tip, TipRuntimeState state)
+        static bool HasExceededDisplayLimit(TipRequest tip, TipRuntimeState state)
         {
             if (tip.ShowOnlyOnce && state.DisplayCount > 0)
                 return true;
 
-            return state.DisplayCount >= tip.MaxDisplayCount;
+            return state.DisplayCount >= Mathf.Max(1, tip.MaxDisplayCount);
         }
 
         static string BuildStateKey(string uniqueId, string areaKey)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `TipRequest` so code paths can submit throttled runtime tips without requiring scene assets.
- Wire `NewConstructor` to show bridge-area guidance only while the player is inside intended bridge construction triggers.
- Keep the compact 9/9 log HUD prompt as a fallback until Unity Play Mode verification confirms contextual tips.
- Update workflow and Cursor handoff notes for bridge-tip Play Mode checks.

## Verification
- `dotnet build BeaverMania.CI.csproj` passed from `/workspace/.ci` with 0 warnings and 0 errors.
- `git diff --check` passed with no whitespace errors.
- Needs Unity Editor Play Mode verification for bridge-tip timing, pause/tips toggle behavior, and no global/random tip display.

## Risk
- `NewConstructor` is scene-bound bridge gameplay code; behavior is additive but requires Play Mode checks.
- Tips are throttled and gated, but visual placement and exact copy need in-Editor validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

