### PR TITLE
Add objective tracker presentation

### DIFF
--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -10,13 +10,13 @@
 - Mixed
 
 ## Current phase
-- Phase 2 first implementation slice / verification
+- Phase 3 objective tracker implementation / verification
 
 ## Goal
 - Improve HUD clarity first, then phase in tips, objectives, footstep feedback, and carried-log game feel without replacing existing pause, input, movement, or combat systems.
 
 ## Scope
-- Phase 2 second slice: add contextual bridge-area tips through the existing bridge construction component, while keeping the compact log HUD fallback.
+- Phase 3: route the existing objective string through a compact middle-left objective tracker while preserving trader/objective overrides.
 
 ## Out of scope
 - Scene placement of tip trigger zones until Unity Editor follow-up.
@@ -31,6 +31,8 @@
 - `Assets/Scripts/UI/Tips/*`
 - `Assets/Scripts/UI/UIMenu.cs`
 - `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
+- `Assets/Scripts/UI/DebugReference.cs`
+- `Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs`
 
 ## Risk level
 - High
@@ -54,10 +56,11 @@
 - Phase 1 HUD cleanup is implemented.
 - Phase 2 tips subsystem code is implemented for review.
 - Contextual bridge construction tips are wired to intended bridge construction areas via `NewConstructor`.
+- Phase 3 objective tracker presentation is implemented for review.
 
 ## Next action
 - Owner: Cursor / Unity Editor
-- Action: Run Play Mode validation, confirm bridge-area tips trigger only near bridge constructors, and place additional `TipTriggerZone` components only after layout/functionality is accepted.
+- Action: Run Play Mode validation, confirm objective tracker readability at middle-left, and verify trader/objective override text still routes correctly.
 
 ## Open questions
 - Whether collectibles should be fully moved into pause/diary UI in a later phase or remain as compact HUD counters.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,7 +1,7 @@
 # Codex → Cursor Handoff
 
 ## Task
-- UI/UX and game-feel improvements — Phase 1 HUD cleanup + Phase 2 tips subsystem and bridge tips
+- UI/UX and game-feel improvements — Phase 1 HUD cleanup, Phase 2 tips, Phase 3 objective tracker
 
 ## Code changes made
 - Compact collectible/ammo/log HUD text values to numbers only so existing icons carry the label meaning.
@@ -9,6 +9,7 @@
 - Add code-only tips subsystem with `TipDefinition`, settings persistence, cooldown/display-count/priority gating, idle/active gating, trigger-zone hooks, and an animated runtime tip card.
 - Add a runtime Tips On/Off toggle to the existing pause menu through `UIMenu` startup without editing the pause menu prefab hierarchy.
 - Add contextual bridge construction tips through `NewConstructor` so bridge/log guidance appears only near intended bridge construction areas.
+- Add an objective tracker presenter that formats current objective text as a compact bullet list and keeps trader/objective override text flowing through the existing `DebugReference` path.
 - Record mixed ownership and verification requirements in `AI_WORKFLOW/active-task.md`.
 
 ## Files changed
@@ -22,6 +23,8 @@
 - `Assets/Scripts/UI/Tips/*`
 - `Assets/Scripts/UI/UIMenu.cs`
 - `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
+- `Assets/Scripts/UI/DebugReference.cs`
+- `Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs`
 
 ## New or changed serialized fields
 - New serialized tuning fields on `TipDefinition`, `TipsService`, `PlayerIdleStateTracker`, `TipCardPresenter`, and `TipTriggerZone`.
@@ -38,11 +41,12 @@
 - Decide in Phase 2/3 whether collectibles should move fully into pause/diary UI or remain compact HUD counters.
 - Confirm the runtime `Tips: On/Off` toggle appears in the pause menu and does not overlap volume/restart controls.
 - Confirm bridge tips appear near `NewConstructor` trigger areas and do not appear globally when the player is away from bridge constructors.
+- Confirm the objective tracker appears middle-left, is readable, and formats current objectives as a compact list.
 - Add `TipTriggerZone` components near intended bridge/log/tutorial areas after validating the runtime card and toggle.
 
 ## What Cursor should test in Play Mode
 - Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause, toggle Tips off/on.
-- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers.
 - Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, tips do not show while disabled, paused, in trader UI, or away from bridge construction areas.
 
 ## What Cursor should not change
@@ -54,6 +58,7 @@
 - Unity Play Mode was not available in Cloud, so layout and serialized-reference behavior need Editor verification.
 - A compact bridge-build instruction remains in the 9/9 log HUD as a fallback while contextual bridge-area tips are verified.
 - Additional authored `TipDefinition` assets or scene `TipTriggerZone` placements have not been added yet.
+- The objective tracker runtime container is created from code; visual padding/background must be checked in the Editor.
 
 ## Risk notes
 - Enemy/NPC behavior risk: Low for Phase 1.

--- a/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
+++ b/Assets/Prefabs/Objects/UI/PlayerCanvas.prefab
@@ -10705,11 +10705,11 @@ RectTransform:
   m_Father: {fileID: 6569126030801917452}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 415.93}
-  m_SizeDelta: {x: 605.99, y: 43.430298}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 56, y: 80}
+  m_SizeDelta: {x: 382, y: 104}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &2405199762443094178
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -10765,14 +10765,14 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 24
+  m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 2
+  m_HorizontalAlignment: 1
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0

--- a/Assets/Scripts/UI/DebugReference.cs
+++ b/Assets/Scripts/UI/DebugReference.cs
@@ -23,10 +23,12 @@ namespace Beavermania.UI
         public TextMeshProUGUI ArrowMunition;
 
         bool loggedMissingPlayer;
+        ObjectiveTrackerPresenter objectiveTracker;
 
         void Start()
         {
             BindPlayerHudState();
+            InitializeObjectiveTracker();
         }
 
         void BindPlayerHudState()
@@ -85,10 +87,11 @@ namespace Beavermania.UI
                 }
             }
 
-            if (PlayerHudState.ObjectiveTextOverrideActive)
-                SetText(ObjectiveText, PlayerHudState.ObjectiveTextOverride);
-            else
-                SetText(ObjectiveText, PlayerHudState.ObjectiveText);
+            SetObjectiveText(
+                PlayerHudState.ObjectiveTextOverrideActive
+                    ? PlayerHudState.ObjectiveTextOverride
+                    : PlayerHudState.ObjectiveText,
+                PlayerHudState.ObjectiveTextOverrideActive);
             SetText(DisplayText, PlayerHudState.DebugText);
             SetText(StaminaText, PlayerHudState.StaminaText);
             SetText(LogCountText, PlayerHudState.LogCount);
@@ -98,6 +101,32 @@ namespace Beavermania.UI
             SetText(GobletCount, PlayerHudState.GobletText);
             SetText(AppleCount, PlayerHudState.AppleText);
             SetText(ArrowMunition, PlayerHudState.ArrowText);
+        }
+
+        void InitializeObjectiveTracker()
+        {
+            if (ObjectiveText == null)
+                return;
+
+            objectiveTracker = GetComponent<ObjectiveTrackerPresenter>();
+            if (objectiveTracker == null)
+                objectiveTracker = gameObject.AddComponent<ObjectiveTrackerPresenter>();
+
+            objectiveTracker.Bind(ObjectiveText);
+        }
+
+        void SetObjectiveText(string value, bool isOverride)
+        {
+            if (objectiveTracker == null)
+                InitializeObjectiveTracker();
+
+            if (objectiveTracker != null)
+            {
+                objectiveTracker.SetObjective(value, isOverride);
+                return;
+            }
+
+            SetText(ObjectiveText, value);
         }
 
         static void SetText(TextMeshProUGUI text, string value)

--- a/Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs
+++ b/Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Text;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Beavermania.UI.Objectives
+{
+    [DisallowMultipleComponent]
+    public sealed class ObjectiveTrackerPresenter : MonoBehaviour
+    {
+        const string TrackerPanelName = "ObjectiveTrackerPanel";
+        const string SeparatorName = "ObjectiveTrackerSeparator";
+
+        [SerializeField] TextMeshProUGUI objectiveText;
+        [SerializeField] RectTransform panelRoot;
+        [SerializeField] Vector2 anchoredPosition = new(32f, 80f);
+        [SerializeField] Vector2 size = new(420f, 128f);
+        [SerializeField] float fontSize = 24f;
+
+        readonly StringBuilder builder = new(256);
+
+        public void Bind(TextMeshProUGUI text)
+        {
+            if (text == null)
+                return;
+
+            objectiveText = text;
+            EnsureRuntimePresentation();
+        }
+
+        public void SetObjective(string value, bool isOverride)
+        {
+            EnsureRuntimePresentation();
+
+            if (objectiveText == null)
+                return;
+
+            string formatted = FormatObjective(value, isOverride);
+            objectiveText.text = formatted;
+
+            if (panelRoot != null)
+                panelRoot.gameObject.SetActive(!string.IsNullOrWhiteSpace(formatted));
+        }
+
+        void EnsureRuntimePresentation()
+        {
+            if (objectiveText == null)
+                return;
+
+            if (panelRoot == null)
+                panelRoot = ResolveOrCreatePanel();
+
+            StylePanel();
+            StyleText();
+        }
+
+        RectTransform ResolveOrCreatePanel()
+        {
+            Transform existing = objectiveText.transform.parent != null
+                ? objectiveText.transform.parent.Find(TrackerPanelName)
+                : null;
+
+            RectTransform panel = existing != null ? existing.GetComponent<RectTransform>() : null;
+            if (panel == null)
+            {
+                var panelObject = new GameObject(TrackerPanelName, typeof(RectTransform), typeof(Image));
+                panelObject.transform.SetParent(objectiveText.transform.parent, false);
+                panel = panelObject.GetComponent<RectTransform>();
+
+                var background = panelObject.GetComponent<Image>();
+                background.color = new Color(0.04f, 0.035f, 0.03f, 0.72f);
+                background.raycastTarget = false;
+
+                CreateSeparator(panel);
+            }
+
+            objectiveText.transform.SetParent(panel, false);
+            return panel;
+        }
+
+        static void CreateSeparator(RectTransform panel)
+        {
+            var separatorObject = new GameObject(SeparatorName, typeof(RectTransform), typeof(Image));
+            separatorObject.transform.SetParent(panel, false);
+            var separatorRect = separatorObject.GetComponent<RectTransform>();
+            separatorRect.anchorMin = new Vector2(0f, 0f);
+            separatorRect.anchorMax = new Vector2(0f, 1f);
+            separatorRect.pivot = new Vector2(0f, 0.5f);
+            separatorRect.anchoredPosition = new Vector2(10f, 0f);
+            separatorRect.sizeDelta = new Vector2(3f, 0f);
+
+            var separator = separatorObject.GetComponent<Image>();
+            separator.color = new Color(1f, 0.75f, 0.25f, 0.85f);
+            separator.raycastTarget = false;
+        }
+
+        void StylePanel()
+        {
+            panelRoot.anchorMin = new Vector2(0f, 0.5f);
+            panelRoot.anchorMax = new Vector2(0f, 0.5f);
+            panelRoot.pivot = new Vector2(0f, 0.5f);
+            panelRoot.anchoredPosition = anchoredPosition;
+            panelRoot.sizeDelta = size;
+        }
+
+        void StyleText()
+        {
+            RectTransform textRect = objectiveText.rectTransform;
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = new Vector2(24f, 12f);
+            textRect.offsetMax = new Vector2(-14f, -12f);
+            textRect.pivot = new Vector2(0f, 0.5f);
+
+            objectiveText.alignment = TextAlignmentOptions.TopLeft;
+            objectiveText.fontSize = fontSize;
+            objectiveText.enableWordWrapping = true;
+            objectiveText.raycastTarget = false;
+        }
+
+        string FormatObjective(string value, bool isOverride)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            builder.Clear();
+            builder.Append("<b>");
+            builder.Append(isOverride ? "Interaction" : "Objectives");
+            builder.AppendLine("</b>");
+
+            string[] entries = value.Split(new[] { '\n', ';', '|' }, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < entries.Length; i++)
+            {
+                string entry = entries[i].Trim();
+                if (entry.Length == 0)
+                    continue;
+
+                if (entry.StartsWith("- "))
+                    builder.AppendLine(entry);
+                else
+                    builder.Append("- ").AppendLine(entry);
+            }
+
+            return builder.ToString().TrimEnd();
+        }
+    }
+}

--- a/Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs.meta
+++ b/Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a6349bc18444f21b60af52fd91a6b87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an `ObjectiveTrackerPresenter` that formats the existing objective string as a compact tracker with heading and bullet-style entries.
- Route objective and trader override text through the presenter from `DebugReference`, preserving the existing objective data flow.
- Reposition the existing `ObjectiveText` prefab element toward middle-left as the tracker anchor.
- Update workflow and Cursor handoff notes for objective tracker Play Mode checks.

## Verification
- `dotnet build BeaverMania.CI.csproj` passed from `/workspace/.ci` with 0 warnings and 0 errors.
- `git diff --check` passed with no whitespace errors.
- Needs Unity Editor Play Mode verification for objective tracker placement, readability, and trader/objective override behavior.

## Risk
- `PlayerCanvas.prefab` is high risk because it also contains pause, dialogue, shop, and lose-screen UI.
- The tracker background/separator is created at runtime and must be visually checked in the Editor.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

