### PR TITLE
Add footstep contact VFX

### DIFF
--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -10,13 +10,13 @@
 - Mixed
 
 ## Current phase
-- Phase 3 objective tracker implementation / verification
+- Phase 4 footstep feedback implementation / verification
 
 ## Goal
 - Improve HUD clarity first, then phase in tips, objectives, footstep feedback, and carried-log game feel without replacing existing pause, input, movement, or combat systems.
 
 ## Scope
-- Phase 3: route the existing objective string through a compact middle-left objective tracker while preserving trader/objective overrides.
+- Phase 4 first slice: add pooled footstep contact particles through the existing animation footstep event path.
 
 ## Out of scope
 - Scene placement of tip trigger zones until Unity Editor follow-up.
@@ -33,6 +33,9 @@
 - `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
 - `Assets/Scripts/UI/DebugReference.cs`
 - `Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs`
+- `Assets/Scripts/Data/Display/FootstepSurfaceEffectProfile.cs`
+- `Assets/Scripts/Display/FootstepVfxEmitter.cs`
+- `Assets/Scripts/Player/SoundScripts/AudioScript.cs`
 
 ## Risk level
 - High
@@ -57,10 +60,11 @@
 - Phase 2 tips subsystem code is implemented for review.
 - Contextual bridge construction tips are wired to intended bridge construction areas via `NewConstructor`.
 - Phase 3 objective tracker presentation is implemented for review.
+- Phase 4 footstep VFX is implemented through `AudioScript.Step()` for review.
 
 ## Next action
 - Owner: Cursor / Unity Editor
-- Action: Run Play Mode validation, confirm objective tracker readability at middle-left, and verify trader/objective override text still routes correctly.
+- Action: Run Play Mode validation, confirm footstep bursts trigger only while grounded/moving animation events fire, and tune/assign surface profiles if needed.
 
 ## Open questions
 - Whether collectibles should be fully moved into pause/diary UI in a later phase or remain as compact HUD counters.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,7 +1,7 @@
 # Codex → Cursor Handoff
 
 ## Task
-- UI/UX and game-feel improvements — Phase 1 HUD cleanup, Phase 2 tips, Phase 3 objective tracker
+- UI/UX and game-feel improvements — Phase 1 HUD cleanup, Phase 2 tips, Phase 3 objective tracker, Phase 4 footstep feedback
 
 ## Code changes made
 - Compact collectible/ammo/log HUD text values to numbers only so existing icons carry the label meaning.
@@ -10,6 +10,7 @@
 - Add a runtime Tips On/Off toggle to the existing pause menu through `UIMenu` startup without editing the pause menu prefab hierarchy.
 - Add contextual bridge construction tips through `NewConstructor` so bridge/log guidance appears only near intended bridge construction areas.
 - Add an objective tracker presenter that formats current objective text as a compact bullet list and keeps trader/objective override text flowing through the existing `DebugReference` path.
+- Add pooled footstep contact particles triggered from the existing `AudioScript.Step()` animation-event method, with surface resolution by profile, tag, physics material, material name, or fallback.
 - Record mixed ownership and verification requirements in `AI_WORKFLOW/active-task.md`.
 
 ## Files changed
@@ -25,15 +26,20 @@
 - `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
 - `Assets/Scripts/UI/DebugReference.cs`
 - `Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs`
+- `Assets/Scripts/Data/Display/FootstepSurfaceEffectProfile.cs`
+- `Assets/Scripts/Display/FootstepVfxEmitter.cs`
+- `Assets/Scripts/Player/SoundScripts/AudioScript.cs`
 
 ## New or changed serialized fields
 - New serialized tuning fields on `TipDefinition`, `TipsService`, `PlayerIdleStateTracker`, `TipCardPresenter`, and `TipTriggerZone`.
+- New serialized tuning fields on `FootstepSurfaceEffectProfile`, `FootstepVfxEmitter`, and `AudioScript.footstepVfxEmitter`.
 - No existing serialized fields were renamed or removed.
 
 ## Inspector assignments required
 - None expected from script changes.
 - Verify existing `DebugReference` text references and `Health_Bar_Script` slider references remain assigned in the active scenes.
 - Phase 2 scene authoring requires creating `TipDefinition` assets and assigning them to `TipTriggerZone` components in intended areas.
+- Optional: assign a `FootstepSurfaceEffectProfile` on `FootstepVfxEmitter` for tuned per-surface colors/prefabs; fallback procedural dust works without assignment.
 
 ## Prefab/scene/UI/Animator follow-up required
 - Inspect `PlayerCanvas.prefab` in Unity Editor and confirm `StaminaBar` is readable at bottom-left across common resolutions.
@@ -42,11 +48,12 @@
 - Confirm the runtime `Tips: On/Off` toggle appears in the pause menu and does not overlap volume/restart controls.
 - Confirm bridge tips appear near `NewConstructor` trigger areas and do not appear globally when the player is away from bridge constructors.
 - Confirm the objective tracker appears middle-left, is readable, and formats current objectives as a compact list.
+- Confirm footstep particles appear subtly on walk/run animation events and do not appear while idle/airborne animations are not stepping.
 - Add `TipTriggerZone` components near intended bridge/log/tutorial areas after validating the runtime card and toggle.
 
 ## What Cursor should test in Play Mode
 - Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause, toggle Tips off/on.
-- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers, footstep particles trigger from existing walk/run step events.
 - Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, tips do not show while disabled, paused, in trader UI, or away from bridge construction areas.
 
 ## What Cursor should not change
@@ -59,9 +66,10 @@
 - A compact bridge-build instruction remains in the 9/9 log HUD as a fallback while contextual bridge-area tips are verified.
 - Additional authored `TipDefinition` assets or scene `TipTriggerZone` placements have not been added yet.
 - The objective tracker runtime container is created from code; visual padding/background must be checked in the Editor.
+- Footstep VFX uses procedural fallback particles until a tuned `FootstepSurfaceEffectProfile` or particle prefabs are authored in Unity.
 
 ## Risk notes
 - Enemy/NPC behavior risk: Low for Phase 1.
 - Interaction/dialogue/shop flow risk: Medium because `PlayerCanvas.prefab` and pause menu runtime UI are shared with dialogue/shop/pause flows.
 - Player combat/input risk: Low; input is read for gating only, not rebound or intercepted.
-- Pooling/performance risk: Low; bridge tips use cooldown/attempt throttling and do not spawn particles or pooled objects.
+- Pooling/performance risk: Medium-low; footstep particles are pooled and throttled, but visual/performance impact needs Play Mode observation.

--- a/Assets/Scripts/Data/Display.meta
+++ b/Assets/Scripts/Data/Display.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e78fe3a67c94d06adf29f49b0e5a4a2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Display/FootstepSurfaceEffectProfile.cs
+++ b/Assets/Scripts/Data/Display/FootstepSurfaceEffectProfile.cs
@@ -1,0 +1,155 @@
+using System;
+using UnityEngine;
+
+namespace Beavermania.Data.Display
+{
+    public enum FootstepSurfaceType
+    {
+        Dust,
+        Grass,
+        Sand,
+        Mud,
+        Wood,
+        Water
+    }
+
+    [CreateAssetMenu(fileName = "FootstepSurfaceEffectProfile", menuName = "Beavermania/Display/Footstep Surface Effect Profile")]
+    public sealed class FootstepSurfaceEffectProfile : ScriptableObject
+    {
+        [SerializeField] SurfaceRule[] rules;
+        [SerializeField] SurfaceRule fallback = SurfaceRule.CreateDefault(FootstepSurfaceType.Dust);
+
+        public SurfaceRule Resolve(RaycastHit hit)
+        {
+            if (rules != null)
+            {
+                for (int i = 0; i < rules.Length; i++)
+                {
+                    if (rules[i].Matches(hit))
+                        return rules[i];
+                }
+            }
+
+            return fallback.IsConfigured ? fallback : SurfaceRule.CreateDefault(FootstepSurfaceType.Dust);
+        }
+
+        void OnValidate()
+        {
+            if (!fallback.IsConfigured)
+                fallback = SurfaceRule.CreateDefault(FootstepSurfaceType.Dust);
+        }
+
+        [Serializable]
+        public struct SurfaceRule
+        {
+            [SerializeField] FootstepSurfaceType surfaceType;
+            [SerializeField] Color color;
+            [SerializeField] string[] tags;
+            [SerializeField] string[] materialNameContains;
+            [SerializeField] string[] physicsMaterialNameContains;
+            [SerializeField] LayerMask layers;
+            [SerializeField] GameObject effectPrefab;
+            [SerializeField] float scale;
+
+            public FootstepSurfaceType SurfaceType => surfaceType;
+            public Color Color => color;
+            public GameObject EffectPrefab => effectPrefab;
+            public float Scale => scale > 0f ? scale : 1f;
+            public bool IsConfigured => color.a > 0f || effectPrefab != null;
+
+            public bool Matches(RaycastHit hit)
+            {
+                Collider hitCollider = hit.collider;
+                if (hitCollider == null)
+                    return false;
+
+                if (MatchesLayer(hitCollider.gameObject.layer))
+                    return true;
+
+                if (MatchesTag(hitCollider.tag))
+                    return true;
+
+                if (MatchesName(hitCollider.sharedMaterial != null ? hitCollider.sharedMaterial.name : null, physicsMaterialNameContains))
+                    return true;
+
+                var renderer = hitCollider.GetComponent<Renderer>();
+                if (renderer != null && MatchesName(renderer.sharedMaterial != null ? renderer.sharedMaterial.name : null, materialNameContains))
+                    return true;
+
+                return false;
+            }
+
+            public static SurfaceRule CreateDefault(FootstepSurfaceType type)
+            {
+                Color resolvedColor;
+                switch (type)
+                {
+                    case FootstepSurfaceType.Grass:
+                        resolvedColor = new Color(0.34f, 0.65f, 0.28f, 0.72f);
+                        break;
+                    case FootstepSurfaceType.Sand:
+                        resolvedColor = new Color(0.88f, 0.72f, 0.42f, 0.68f);
+                        break;
+                    case FootstepSurfaceType.Mud:
+                        resolvedColor = new Color(0.28f, 0.16f, 0.08f, 0.7f);
+                        break;
+                    case FootstepSurfaceType.Wood:
+                        resolvedColor = new Color(0.48f, 0.28f, 0.12f, 0.62f);
+                        break;
+                    case FootstepSurfaceType.Water:
+                        resolvedColor = new Color(0.35f, 0.7f, 1f, 0.6f);
+                        break;
+                    default:
+                        resolvedColor = new Color(0.68f, 0.58f, 0.44f, 0.65f);
+                        break;
+                }
+
+                return new SurfaceRule
+                {
+                    surfaceType = type,
+                    color = resolvedColor,
+                    scale = 1f
+                };
+            }
+
+            static bool MatchesName(string candidate, string[] fragments)
+            {
+                if (string.IsNullOrWhiteSpace(candidate) || fragments == null)
+                    return false;
+
+                for (int i = 0; i < fragments.Length; i++)
+                {
+                    if (!string.IsNullOrWhiteSpace(fragments[i])
+                        && candidate.IndexOf(fragments[i], StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            bool MatchesTag(string candidate)
+            {
+                if (string.IsNullOrWhiteSpace(candidate) || tags == null)
+                    return false;
+
+                for (int i = 0; i < tags.Length; i++)
+                {
+                    if (!string.IsNullOrWhiteSpace(tags[i])
+                        && string.Equals(candidate, tags[i], StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            bool MatchesLayer(int layer)
+            {
+                return layers.value != 0 && (layers.value & (1 << layer)) != 0;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Data/Display/FootstepSurfaceEffectProfile.cs.meta
+++ b/Assets/Scripts/Data/Display/FootstepSurfaceEffectProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ccf18f089c34f1599d35c2c1136d4de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Display/FootstepVfxEmitter.cs
+++ b/Assets/Scripts/Display/FootstepVfxEmitter.cs
@@ -87,14 +87,15 @@ namespace Beavermania.Display
                     return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Dust);
                 }
 
-                string materialName = hitCollider.sharedMaterial != null ? hitCollider.sharedMaterial.name : null;
-                if (Contains(materialName, "wood"))
+                string physicsMaterialName = hitCollider.sharedMaterial != null ? hitCollider.sharedMaterial.name : null;
+                string rendererMaterialName = ResolveRendererMaterialName(hitCollider);
+                if (Contains(physicsMaterialName, "wood") || Contains(rendererMaterialName, "wood"))
                     return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Wood);
-                if (Contains(materialName, "sand"))
+                if (Contains(physicsMaterialName, "sand") || Contains(rendererMaterialName, "sand"))
                     return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Sand);
-                if (Contains(materialName, "mud"))
+                if (Contains(physicsMaterialName, "mud") || Contains(rendererMaterialName, "mud"))
                     return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Mud);
-                if (Contains(materialName, "water"))
+                if (Contains(physicsMaterialName, "water") || Contains(rendererMaterialName, "water"))
                     return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Water);
             }
 
@@ -206,6 +207,20 @@ namespace Beavermania.Display
         {
             return !string.IsNullOrWhiteSpace(value)
                 && value.IndexOf(fragment, System.StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        static string ResolveRendererMaterialName(Collider hitCollider)
+        {
+            if (hitCollider == null)
+                return null;
+
+            Renderer renderer = hitCollider.GetComponent<Renderer>();
+            if (renderer == null)
+                renderer = hitCollider.GetComponentInParent<Renderer>();
+
+            return renderer != null && renderer.sharedMaterial != null
+                ? renderer.sharedMaterial.name
+                : null;
         }
     }
 }

--- a/Assets/Scripts/Display/FootstepVfxEmitter.cs
+++ b/Assets/Scripts/Display/FootstepVfxEmitter.cs
@@ -1,0 +1,211 @@
+using System.Collections;
+using System.Collections.Generic;
+using Beavermania.Data.Display;
+using UnityEngine;
+
+namespace Beavermania.Display
+{
+    [DisallowMultipleComponent]
+    public sealed class FootstepVfxEmitter : MonoBehaviour
+    {
+        const int DefaultPoolSize = 8;
+
+        [SerializeField] FootstepSurfaceEffectProfile surfaceProfile;
+        [SerializeField] Transform raycastOrigin;
+        [SerializeField] LayerMask groundLayers = ~0;
+        [SerializeField] float raycastDistance = 1.45f;
+        [SerializeField] float minStepInterval = 0.08f;
+        [SerializeField] float originHeight = 0.35f;
+        [SerializeField] int poolSize = DefaultPoolSize;
+
+        readonly Queue<ParticleSystem> proceduralPool = new();
+        float nextAllowedStepTime;
+
+        public void PlayStep()
+        {
+            if (Time.time < nextAllowedStepTime)
+                return;
+
+            if (!TryResolveSurface(out RaycastHit hit, out FootstepSurfaceEffectProfile.SurfaceRule rule))
+                return;
+
+            nextAllowedStepTime = Time.time + Mathf.Max(0f, minStepInterval);
+
+            if (rule.EffectPrefab != null)
+            {
+                PooledOneShotVfx.Spawn(rule.EffectPrefab, hit.point, Quaternion.LookRotation(hit.normal), Vector3.one * rule.Scale);
+                return;
+            }
+
+            PlayProceduralBurst(hit.point, hit.normal, rule);
+        }
+
+        void PlayProceduralBurst(Vector3 position, Vector3 normal, FootstepSurfaceEffectProfile.SurfaceRule rule)
+        {
+            ParticleSystem particles = GetProceduralParticleSystem();
+            if (particles == null)
+                return;
+
+            particles.transform.SetPositionAndRotation(position + normal * 0.025f, Quaternion.LookRotation(normal));
+            particles.transform.localScale = Vector3.one * rule.Scale;
+            ApplyParticleColor(particles, rule.Color);
+            particles.gameObject.SetActive(true);
+            particles.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+            particles.Play(true);
+            StartCoroutine(ReturnWhenComplete(particles));
+        }
+
+        bool TryResolveSurface(out RaycastHit hit, out FootstepSurfaceEffectProfile.SurfaceRule rule)
+        {
+            Transform origin = raycastOrigin != null ? raycastOrigin : transform;
+            Vector3 start = origin.position + Vector3.up * originHeight;
+            if (!Physics.Raycast(start, Vector3.down, out hit, raycastDistance, groundLayers, QueryTriggerInteraction.Ignore))
+            {
+                rule = default;
+                return false;
+            }
+
+            rule = surfaceProfile != null
+                ? surfaceProfile.Resolve(hit)
+                : ResolveDefaultSurface(hit);
+            return true;
+        }
+
+        FootstepSurfaceEffectProfile.SurfaceRule ResolveDefaultSurface(RaycastHit hit)
+        {
+            Collider hitCollider = hit.collider;
+            if (hitCollider != null)
+            {
+                string tag = hitCollider.tag;
+                if (string.Equals(tag, "Bridge", System.StringComparison.OrdinalIgnoreCase))
+                    return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Wood);
+                if (string.Equals(tag, "Isle", System.StringComparison.OrdinalIgnoreCase))
+                    return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Grass);
+                if (string.Equals(tag, "Tile", System.StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(tag, "stairs", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Dust);
+                }
+
+                string materialName = hitCollider.sharedMaterial != null ? hitCollider.sharedMaterial.name : null;
+                if (Contains(materialName, "wood"))
+                    return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Wood);
+                if (Contains(materialName, "sand"))
+                    return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Sand);
+                if (Contains(materialName, "mud"))
+                    return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Mud);
+                if (Contains(materialName, "water"))
+                    return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Water);
+            }
+
+            return FootstepSurfaceEffectProfile.SurfaceRule.CreateDefault(FootstepSurfaceType.Dust);
+        }
+
+        ParticleSystem GetProceduralParticleSystem()
+        {
+            if (proceduralPool.Count > 0)
+                return proceduralPool.Dequeue();
+
+            if (poolSize <= 0)
+                return null;
+
+            var instance = new GameObject("FootstepDustVfx", typeof(ParticleSystem));
+            instance.transform.SetParent(transform, false);
+            var particles = instance.GetComponent<ParticleSystem>();
+            ConfigureParticles(particles);
+            instance.SetActive(false);
+            poolSize--;
+            return particles;
+        }
+
+        IEnumerator ReturnWhenComplete(ParticleSystem particles)
+        {
+            if (particles == null)
+                yield break;
+
+            float lifetime = GetLifetime(particles);
+            yield return new WaitForSeconds(lifetime);
+
+            if (particles == null)
+                yield break;
+
+            particles.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+            particles.gameObject.SetActive(false);
+            proceduralPool.Enqueue(particles);
+        }
+
+        static void ConfigureParticles(ParticleSystem particles)
+        {
+            var main = particles.main;
+            main.duration = 0.28f;
+            main.loop = false;
+            main.startLifetime = new ParticleSystem.MinMaxCurve(0.18f, 0.38f);
+            main.startSpeed = new ParticleSystem.MinMaxCurve(0.35f, 0.75f);
+            main.startSize = new ParticleSystem.MinMaxCurve(0.07f, 0.16f);
+            main.simulationSpace = ParticleSystemSimulationSpace.World;
+            main.maxParticles = 18;
+
+            var emission = particles.emission;
+            emission.rateOverTime = 0f;
+            emission.SetBursts(new[] { new ParticleSystem.Burst(0f, 8, 12) });
+
+            var shape = particles.shape;
+            shape.shapeType = ParticleSystemShapeType.Circle;
+            shape.radius = 0.18f;
+            shape.arc = 360f;
+
+            var velocity = particles.velocityOverLifetime;
+            velocity.enabled = true;
+            velocity.space = ParticleSystemSimulationSpace.Local;
+            velocity.y = new ParticleSystem.MinMaxCurve(0.08f, 0.18f);
+
+            var color = particles.colorOverLifetime;
+            color.enabled = true;
+            color.color = new ParticleSystem.MinMaxGradient(
+                new Gradient
+                {
+                    colorKeys = new[]
+                    {
+                        new GradientColorKey(Color.white, 0f),
+                        new GradientColorKey(Color.white, 1f)
+                    },
+                    alphaKeys = new[]
+                    {
+                        new GradientAlphaKey(0.7f, 0f),
+                        new GradientAlphaKey(0f, 1f)
+                    }
+                });
+        }
+
+        static void ApplyParticleColor(ParticleSystem particles, Color color)
+        {
+            var main = particles.main;
+            main.startColor = color;
+        }
+
+        static float GetLifetime(ParticleSystem particles)
+        {
+            var main = particles.main;
+            return main.duration + Max(main.startLifetime);
+        }
+
+        static float Max(ParticleSystem.MinMaxCurve curve)
+        {
+            switch (curve.mode)
+            {
+                case ParticleSystemCurveMode.Constant:
+                    return curve.constant;
+                case ParticleSystemCurveMode.TwoConstants:
+                    return curve.constantMax;
+                default:
+                    return 0.4f;
+            }
+        }
+
+        static bool Contains(string value, string fragment)
+        {
+            return !string.IsNullOrWhiteSpace(value)
+                && value.IndexOf(fragment, System.StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}

--- a/Assets/Scripts/Display/FootstepVfxEmitter.cs.meta
+++ b/Assets/Scripts/Display/FootstepVfxEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd5d07fcdd7447feb1e1dc4f0f24270b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/SoundScripts/AudioScript.cs
+++ b/Assets/Scripts/Player/SoundScripts/AudioScript.cs
@@ -1,3 +1,4 @@
+using Beavermania.Display;
 using UnityEngine;
 
 namespace Beavermania.Audio
@@ -8,6 +9,15 @@ namespace Beavermania.Audio
         [SerializeField] AudioClip[] audioClip;
         [SerializeField] AudioSource audioSource;
         [SerializeField] AudioSource audioEffects;
+        [SerializeField] FootstepVfxEmitter footstepVfxEmitter;
+
+        void Awake()
+        {
+            if (footstepVfxEmitter == null)
+                footstepVfxEmitter = GetComponentInParent<FootstepVfxEmitter>();
+            if (footstepVfxEmitter == null)
+                footstepVfxEmitter = gameObject.AddComponent<FootstepVfxEmitter>();
+        }
 
         public void SwordSwing3()
         {
@@ -142,6 +152,9 @@ namespace Beavermania.Audio
         }
         public void Step()
         {
+            if (footstepVfxEmitter != null)
+                footstepVfxEmitter.PlayStep();
+
             if (audioSource == null || audioClip == null || audioClip.Length <= 1)
                 return;
 

--- a/Assets/Scripts/Player/SoundScripts/AudioScript.cs
+++ b/Assets/Scripts/Player/SoundScripts/AudioScript.cs
@@ -1,4 +1,5 @@
 using Beavermania.Display;
+using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
 using UnityEngine;
 
 namespace Beavermania.Audio
@@ -15,7 +16,7 @@ namespace Beavermania.Audio
         {
             if (footstepVfxEmitter == null)
                 footstepVfxEmitter = GetComponentInParent<FootstepVfxEmitter>();
-            if (footstepVfxEmitter == null)
+            if (footstepVfxEmitter == null && GetComponentInParent<BeaverPlayer>() != null)
                 footstepVfxEmitter = gameObject.AddComponent<FootstepVfxEmitter>();
         }
 

--- a/Assets/Scripts/Player/SoundScripts/AudioScript.cs
+++ b/Assets/Scripts/Player/SoundScripts/AudioScript.cs
@@ -14,10 +14,16 @@ namespace Beavermania.Audio
 
         void Awake()
         {
-            if (footstepVfxEmitter == null)
-                footstepVfxEmitter = GetComponentInParent<FootstepVfxEmitter>();
-            if (footstepVfxEmitter == null && GetComponentInParent<BeaverPlayer>() != null)
-                footstepVfxEmitter = gameObject.AddComponent<FootstepVfxEmitter>();
+            if (footstepVfxEmitter != null)
+                return;
+
+            footstepVfxEmitter = GetComponentInParent<FootstepVfxEmitter>();
+            if (footstepVfxEmitter != null)
+                return;
+
+            BeaverPlayer player = GetComponentInParent<BeaverPlayer>();
+            if (player != null)
+                footstepVfxEmitter = player.gameObject.AddComponent<FootstepVfxEmitter>();
         }
 
         public void SwordSwing3()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `FootstepSurfaceEffectProfile` for optional designer-authored surface rules and particle prefabs.
- Add pooled procedural `FootstepVfxEmitter` with fallback surface detection by tag, physics material, renderer material name, and layer profile rules.
- Hook VFX into the existing player `AudioScript.Step()` animation-event path without editing animation clips or input/movement code.
- Address review feedback by checking visible renderer materials in the no-profile fallback path.
- Address review feedback by auto-creating footstep emitters only for player-owned `AudioScript` instances; non-player audio can opt in only with an explicitly assigned emitter.

## Verification
- `dotnet build BeaverMania.CI.csproj` passed from `/workspace/.ci` with 0 warnings and 0 errors after the review fixes.
- `git diff --check` passed with no whitespace errors.
- Needs Unity Editor Play Mode verification for footstep timing, surface colors, particle scale, and FPS impact.

## Risk
- Footstep VFX is additive and pooled, but it touches player animation-event audio flow.
- Procedural particles are a fallback; designers can assign tuned surface profiles/prefabs later.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

