### PR TITLE
Tune carried log weight penalties

### DIFF
--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -10,13 +10,13 @@
 - Mixed
 
 ## Current phase
-- Phase 4 footstep feedback implementation / verification
+- Phase 5 carried-log weight implementation / verification
 
 ## Goal
 - Improve HUD clarity first, then phase in tips, objectives, footstep feedback, and carried-log game feel without replacing existing pause, input, movement, or combat systems.
 
 ## Scope
-- Phase 4 first slice: add pooled footstep contact particles through the existing animation footstep event path.
+- Phase 5 first slice: make the existing carried-log movement penalties capped and designer-tunable without replacing player movement.
 
 ## Out of scope
 - Scene placement of tip trigger zones until Unity Editor follow-up.
@@ -61,10 +61,11 @@
 - Contextual bridge construction tips are wired to intended bridge construction areas via `NewConstructor`.
 - Phase 3 objective tracker presentation is implemented for review.
 - Phase 4 footstep VFX is implemented through `AudioScript.Step()` for review.
+- Phase 5 carried-log weight penalties are centralized and capped in `Carry`.
 
 ## Next action
 - Owner: Cursor / Unity Editor
-- Action: Run Play Mode validation, confirm footstep bursts trigger only while grounded/moving animation events fire, and tune/assign surface profiles if needed.
+- Action: Run Play Mode validation, confirm log pickup/drop/build restores movement stats correctly, and tune carried-log penalty caps.
 
 ## Open questions
 - Whether collectibles should be fully moved into pause/diary UI in a later phase or remain as compact HUD counters.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,7 +1,7 @@
 # Codex → Cursor Handoff
 
 ## Task
-- UI/UX and game-feel improvements — Phase 1 HUD cleanup, Phase 2 tips, Phase 3 objective tracker, Phase 4 footstep feedback
+- UI/UX and game-feel improvements — Phase 1 HUD cleanup, Phase 2 tips, Phase 3 objective tracker, Phase 4 footstep feedback, Phase 5 carried-log weight
 
 ## Code changes made
 - Compact collectible/ammo/log HUD text values to numbers only so existing icons carry the label meaning.
@@ -11,6 +11,7 @@
 - Add contextual bridge construction tips through `NewConstructor` so bridge/log guidance appears only near intended bridge construction areas.
 - Add an objective tracker presenter that formats current objective text as a compact bullet list and keeps trader/objective override text flowing through the existing `DebugReference` path.
 - Add pooled footstep contact particles triggered from the existing `AudioScript.Step()` animation-event method, with surface resolution by profile, tag, physics material, material name, or fallback.
+- Centralize carried-log walk/run/jump/animation penalties in `Carry` with threshold, max weight penalty, per-log penalties, animation multiplier, and caps.
 - Record mixed ownership and verification requirements in `AI_WORKFLOW/active-task.md`.
 
 ## Files changed
@@ -33,6 +34,7 @@
 ## New or changed serialized fields
 - New serialized tuning fields on `TipDefinition`, `TipsService`, `PlayerIdleStateTracker`, `TipCardPresenter`, and `TipTriggerZone`.
 - New serialized tuning fields on `FootstepSurfaceEffectProfile`, `FootstepVfxEmitter`, and `AudioScript.footstepVfxEmitter`.
+- New serialized tuning fields on `Carry`: log threshold, max weight penalty, max walk/run/jump/animation penalties, animation speed multiplier, and minimum animation speed.
 - No existing serialized fields were renamed or removed.
 
 ## Inspector assignments required
@@ -40,6 +42,7 @@
 - Verify existing `DebugReference` text references and `Health_Bar_Script` slider references remain assigned in the active scenes.
 - Phase 2 scene authoring requires creating `TipDefinition` assets and assigning them to `TipTriggerZone` components in intended areas.
 - Optional: assign a `FootstepSurfaceEffectProfile` on `FootstepVfxEmitter` for tuned per-surface colors/prefabs; fallback procedural dust works without assignment.
+- Optional: tune `Carry` weight fields on the player prefab after Play Mode checks; defaults preserve the previous 9-log total penalties.
 
 ## Prefab/scene/UI/Animator follow-up required
 - Inspect `PlayerCanvas.prefab` in Unity Editor and confirm `StaminaBar` is readable at bottom-left across common resolutions.
@@ -49,11 +52,12 @@
 - Confirm bridge tips appear near `NewConstructor` trigger areas and do not appear globally when the player is away from bridge constructors.
 - Confirm the objective tracker appears middle-left, is readable, and formats current objectives as a compact list.
 - Confirm footstep particles appear subtly on walk/run animation events and do not appear while idle/airborne animations are not stepping.
+- Confirm carrying logs gradually slows walk/run/jump/animation, then restores those stats after dropping logs or building a bridge.
 - Add `TipTriggerZone` components near intended bridge/log/tutorial areas after validating the runtime card and toggle.
 
 ## What Cursor should test in Play Mode
 - Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause, toggle Tips off/on.
-- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers, footstep particles trigger from existing walk/run step events.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, carrying logs slows movement/jump/animation and restores on drop/build, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers, footstep particles trigger from existing walk/run step events.
 - Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, tips do not show while disabled, paused, in trader UI, or away from bridge construction areas.
 
 ## What Cursor should not change
@@ -67,6 +71,7 @@
 - Additional authored `TipDefinition` assets or scene `TipTriggerZone` placements have not been added yet.
 - The objective tracker runtime container is created from code; visual padding/background must be checked in the Editor.
 - Footstep VFX uses procedural fallback particles until a tuned `FootstepSurfaceEffectProfile` or particle prefabs are authored in Unity.
+- Carried-log penalties still apply through existing `Carry` stat adjustments; deeper combat attack-speed integration is deferred to avoid broad combat rewrites.
 
 ## Risk notes
 - Enemy/NPC behavior risk: Low for Phase 1.

--- a/Assets/Scripts/Player/Carry.cs
+++ b/Assets/Scripts/Player/Carry.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using Beavermania.Core.Input;
 using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
 using UnityEngine;
@@ -20,11 +18,27 @@ namespace Beavermania.Player.Movement
 
         [Header("Movement affect factors")]
         public int i = 0;
-        public float WalkFactor=0.07f;
-        public float RunFactor=0.8f;
-        public float JumpFactor=0.3f;
+        public float WalkFactor = 0.07f;
+        public float RunFactor = 0.8f;
+        public float JumpFactor = 0.3f;
         public float SlowAnim = 0.1f;
         public bool CanCarry;
+
+        [Header("Carried log weight tuning")]
+        [SerializeField] int logsCountThreshold = 1;
+        [SerializeField, Range(0f, 1f)] float maxWeightPenalty = 1f;
+        [SerializeField] float maxWalkPenalty = 0.63f;
+        [SerializeField] float maxRunPenalty = 7.2f;
+        [SerializeField] float maxJumpPenalty = 2.7f;
+        [SerializeField] float animationSpeedMultiplier = 1f;
+        [SerializeField] float maxAnimationSpeedPenalty = 0.9f;
+        [SerializeField] float minimumAnimationSpeed = 0.2f;
+
+        float appliedWalkPenalty;
+        float appliedRunPenalty;
+        float appliedJumpPenalty;
+        float appliedAnimationPenalty;
+
         public void OnCollisionEnter(Collision OBJ)
         {
             if (OBJ.gameObject.CompareTag("Part"))
@@ -34,10 +48,7 @@ namespace Beavermania.Player.Movement
                     //Goal.Otter.Play("Crouch");
                     CarryPoint[i].SetActive(true);
                     i++;
-                    Goal.JumpForce -= JumpFactor;
-                    Goal.Walk -= WalkFactor;
-                    Goal.Run -= RunFactor;
-                    Goal.Otter.speed -=SlowAnim;
+                    ApplyCarryWeightPenalty();
                     Destroy(OBJ.transform.gameObject);
                 }
             }
@@ -55,20 +66,13 @@ namespace Beavermania.Player.Movement
                 if (PlayerInputReader.WasRollReleased() && i > 0)
                 {
                     i--;
-                    Goal.JumpForce += JumpFactor;
-                    Goal.Walk += WalkFactor;
-                    Goal.Run += RunFactor;
-                    Goal.Otter.speed += SlowAnim;
+                    ApplyCarryWeightPenalty();
                     Instantiate(Log, SpawnPos, Quaternion.identity);
                     CarryPoint[i].SetActive(false);
                 }
 
                 if (PlayerInputReader.IsRollHeld() && PlayerInputReader.WasInteractPressed() && i == 9)
                 {
-                    Goal.JumpForce += 9 * JumpFactor;
-                    Goal.Otter.speed = 1;
-                    Goal.Walk += 9 * WalkFactor;
-                    Goal.Run += 9 * RunFactor;
                     LogDrop.transform.localRotation = Quaternion.Slerp(transform.rotation, Quaternion.identity, 0);
                     //SpawnPos = new Vector3(LogDrop.transform.position.x, LogDrop.position.y - 0.5f, LogDrop.position.z);
                     Bridge.transform.rotation = Goal.rotGoal * Quaternion.Euler(-90, 0, 0);
@@ -77,6 +81,7 @@ namespace Beavermania.Player.Movement
                     Destroy(newPoof);
 
                     i = 0;
+                    ApplyCarryWeightPenalty();
                     for (int x = 0; x < 9; x++)
                     {
                         CarryPoint[x].SetActive(false);
@@ -90,6 +95,39 @@ namespace Beavermania.Player.Movement
                 else
                     CanCarry = false;
             }
+        }
+
+        void ApplyCarryWeightPenalty()
+        {
+            if (Goal == null)
+                return;
+
+            float walkPenalty = CalculatePenalty(WalkFactor, maxWalkPenalty);
+            float runPenalty = CalculatePenalty(RunFactor, maxRunPenalty);
+            float jumpPenalty = CalculatePenalty(JumpFactor, maxJumpPenalty);
+            float animationPenalty = CalculatePenalty(SlowAnim * animationSpeedMultiplier, maxAnimationSpeedPenalty);
+
+            Goal.Walk += appliedWalkPenalty - walkPenalty;
+            Goal.Run += appliedRunPenalty - runPenalty;
+            Goal.JumpForce += appliedJumpPenalty - jumpPenalty;
+
+            if (Goal.Otter != null)
+            {
+                float animationSpeedBeforeCarryPenalty = Goal.Otter.speed + appliedAnimationPenalty;
+                Goal.Otter.speed = Mathf.Max(minimumAnimationSpeed, animationSpeedBeforeCarryPenalty - animationPenalty);
+                appliedAnimationPenalty = animationSpeedBeforeCarryPenalty - Goal.Otter.speed;
+            }
+
+            appliedWalkPenalty = walkPenalty;
+            appliedRunPenalty = runPenalty;
+            appliedJumpPenalty = jumpPenalty;
+        }
+
+        float CalculatePenalty(float penaltyPerLog, float maxPenalty)
+        {
+            int effectiveLogCount = Mathf.Max(0, i - Mathf.Max(1, logsCountThreshold) + 1);
+            float cappedMaxPenalty = Mathf.Max(0f, maxPenalty) * Mathf.Clamp01(maxWeightPenalty);
+            return Mathf.Min(effectiveLogCount * Mathf.Max(0f, penaltyPerLog), cappedMaxPenalty);
         }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Centralize carried-log walk/run/jump/animation penalties in `Carry`.
- Add designer tuning fields for log threshold, max weight penalty, per-channel caps, animation multiplier, and minimum animation speed.
- Preserve previous default total 9-log penalties while making the mechanic capped and safer to tune.
- Update workflow and Cursor handoff notes for Phase 5 Play Mode checks.

## Verification
- `dotnet build BeaverMania.CI.csproj` passed from `/workspace/.ci` with 0 warnings and 0 errors.
- `git diff --check` passed with no whitespace errors.
- Needs Unity Editor Play Mode verification for log pickup/drop/build movement restoration and feel.

## Risk
- Touches the existing log-carry movement stat path in `Carry`.
- Deeper combat attack-speed integration is deferred to avoid broad combat rewrites.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

