### PR TITLE
Keep log penalties during temporary boosts

### DIFF
--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -62,6 +62,7 @@
 - Phase 3 objective tracker presentation is implemented for review.
 - Phase 4 footstep VFX is implemented through `AudioScript.Step()` for review.
 - Phase 5 carried-log weight penalties are centralized and capped in `Carry`.
+- Phase 5 penalties now rebase when other systems temporarily change walk/run/jump/animation values.
 
 ## Next action
 - Owner: Cursor / Unity Editor

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -12,6 +12,7 @@
 - Add an objective tracker presenter that formats current objective text as a compact bullet list and keeps trader/objective override text flowing through the existing `DebugReference` path.
 - Add pooled footstep contact particles triggered from the existing `AudioScript.Step()` animation-event method, with surface resolution by profile, tag, physics material, material name, or fallback.
 - Centralize carried-log walk/run/jump/animation penalties in `Carry` with threshold, max weight penalty, per-log penalties, animation multiplier, and caps.
+- Rebase carried-log penalties when other temporary effects change player walk/run/jump/animation values, so the log penalty remains active and restores cleanly.
 - Record mixed ownership and verification requirements in `AI_WORKFLOW/active-task.md`.
 
 ## Files changed
@@ -53,11 +54,12 @@
 - Confirm the objective tracker appears middle-left, is readable, and formats current objectives as a compact list.
 - Confirm footstep particles appear subtly on walk/run animation events and do not appear while idle/airborne animations are not stepping.
 - Confirm carrying logs gradually slows walk/run/jump/animation, then restores those stats after dropping logs or building a bridge.
+- Confirm goblet boost and other temporary movement changes still preserve carried-log penalties while active and restore correctly afterward.
 - Add `TipTriggerZone` components near intended bridge/log/tutorial areas after validating the runtime card and toggle.
 
 ## What Cursor should test in Play Mode
 - Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause, toggle Tips off/on.
-- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, carrying logs slows movement/jump/animation and restores on drop/build, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers, footstep particles trigger from existing walk/run step events.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, carrying logs slows movement/jump/animation and restores on drop/build, goblet boost preserves carried-log penalties, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers, footstep particles trigger from existing walk/run step events.
 - Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, tips do not show while disabled, paused, in trader UI, or away from bridge construction areas.
 
 ## What Cursor should not change

--- a/Assets/Scripts/Player/Carry.cs
+++ b/Assets/Scripts/Player/Carry.cs
@@ -38,6 +38,11 @@ namespace Beavermania.Player.Movement
         float appliedRunPenalty;
         float appliedJumpPenalty;
         float appliedAnimationPenalty;
+        float lastAppliedWalkValue;
+        float lastAppliedRunValue;
+        float lastAppliedJumpValue;
+        float lastAppliedAnimationSpeed;
+        bool hasAppliedStats;
 
         public void OnCollisionEnter(Collision OBJ)
         {
@@ -58,6 +63,7 @@ namespace Beavermania.Player.Movement
         {
             Vector3 SpawnPos = LogDrop.transform.position;
             Goal.LogCount = i + "/9";
+            ApplyCarryWeightPenalty();
 
             if (Goal.grounded == true)
             {
@@ -107,20 +113,29 @@ namespace Beavermania.Player.Movement
             float jumpPenalty = CalculatePenalty(JumpFactor, maxJumpPenalty);
             float animationPenalty = CalculatePenalty(SlowAnim * animationSpeedMultiplier, maxAnimationSpeedPenalty);
 
-            Goal.Walk += appliedWalkPenalty - walkPenalty;
-            Goal.Run += appliedRunPenalty - runPenalty;
-            Goal.JumpForce += appliedJumpPenalty - jumpPenalty;
+            float baseWalk = ResolveBaseValue(Goal.Walk, lastAppliedWalkValue, appliedWalkPenalty);
+            float baseRun = ResolveBaseValue(Goal.Run, lastAppliedRunValue, appliedRunPenalty);
+            float baseJump = ResolveBaseValue(Goal.JumpForce, lastAppliedJumpValue, appliedJumpPenalty);
+
+            Goal.Walk = baseWalk - walkPenalty;
+            Goal.Run = baseRun - runPenalty;
+            Goal.JumpForce = baseJump - jumpPenalty;
 
             if (Goal.Otter != null)
             {
-                float animationSpeedBeforeCarryPenalty = Goal.Otter.speed + appliedAnimationPenalty;
-                Goal.Otter.speed = Mathf.Max(minimumAnimationSpeed, animationSpeedBeforeCarryPenalty - animationPenalty);
-                appliedAnimationPenalty = animationSpeedBeforeCarryPenalty - Goal.Otter.speed;
+                float baseAnimationSpeed = ResolveBaseValue(Goal.Otter.speed, lastAppliedAnimationSpeed, appliedAnimationPenalty);
+                Goal.Otter.speed = Mathf.Max(minimumAnimationSpeed, baseAnimationSpeed - animationPenalty);
+                appliedAnimationPenalty = baseAnimationSpeed - Goal.Otter.speed;
+                lastAppliedAnimationSpeed = Goal.Otter.speed;
             }
 
             appliedWalkPenalty = walkPenalty;
             appliedRunPenalty = runPenalty;
             appliedJumpPenalty = jumpPenalty;
+            lastAppliedWalkValue = Goal.Walk;
+            lastAppliedRunValue = Goal.Run;
+            lastAppliedJumpValue = Goal.JumpForce;
+            hasAppliedStats = true;
         }
 
         float CalculatePenalty(float penaltyPerLog, float maxPenalty)
@@ -128,6 +143,16 @@ namespace Beavermania.Player.Movement
             int effectiveLogCount = Mathf.Max(0, i - Mathf.Max(1, logsCountThreshold) + 1);
             float cappedMaxPenalty = Mathf.Max(0f, maxPenalty) * Mathf.Clamp01(maxWeightPenalty);
             return Mathf.Min(effectiveLogCount * Mathf.Max(0f, penaltyPerLog), cappedMaxPenalty);
+        }
+
+        float ResolveBaseValue(float currentValue, float lastAppliedValue, float appliedPenalty)
+        {
+            if (!hasAppliedStats)
+                return currentValue + appliedPenalty;
+
+            return Mathf.Approximately(currentValue, lastAppliedValue)
+                ? currentValue + appliedPenalty
+                : currentValue;
         }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rebase carried-log penalties when another temporary effect changes player walk/run/jump/animation values.
- Keep carried-log penalties active during boosts while still restoring the exact applied deltas on drop/build.
- Update workflow and Cursor handoff notes for goblet/temporary boost Play Mode checks.

## Verification
- `dotnet build BeaverMania.CI.csproj` passed from `/workspace/.ci` with 0 warnings and 0 errors.
- `git diff --check` passed with no whitespace errors.
- Needs Unity Editor Play Mode verification for carry penalties during goblet boost, drop, and bridge build.

## Risk
- Touches the existing log-carry movement stat path in `Carry`.
- Deeper combat attack-speed integration remains deferred to avoid broad combat rewrites.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

