### PR TITLE
Harden carried log weight state

### DIFF
--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -63,6 +63,7 @@
 - Phase 4 footstep VFX is implemented through `AudioScript.Step()` for review.
 - Phase 5 carried-log weight penalties are centralized and capped in `Carry`.
 - Phase 5 penalties now rebase when other systems temporarily change walk/run/jump/animation values.
+- Phase 5 carry component now exposes current weight penalty and guards missing references for Play Mode diagnostics.
 
 ## Next action
 - Owner: Cursor / Unity Editor

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -13,6 +13,7 @@
 - Add pooled footstep contact particles triggered from the existing `AudioScript.Step()` animation-event method, with surface resolution by profile, tag, physics material, material name, or fallback.
 - Centralize carried-log walk/run/jump/animation penalties in `Carry` with threshold, max weight penalty, per-log penalties, animation multiplier, and caps.
 - Rebase carried-log penalties when other temporary effects change player walk/run/jump/animation values, so the log penalty remains active and restores cleanly.
+- Expose `Carry.CurrentWeightPenalty01` for future HUD/combat hooks and add warning guards for missing carry references.
 - Record mixed ownership and verification requirements in `AI_WORKFLOW/active-task.md`.
 
 ## Files changed
@@ -44,6 +45,7 @@
 - Phase 2 scene authoring requires creating `TipDefinition` assets and assigning them to `TipTriggerZone` components in intended areas.
 - Optional: assign a `FootstepSurfaceEffectProfile` on `FootstepVfxEmitter` for tuned per-surface colors/prefabs; fallback procedural dust works without assignment.
 - Optional: tune `Carry` weight fields on the player prefab after Play Mode checks; defaults preserve the previous 9-log total penalties.
+- Inspect any `Carry` missing-reference warnings before tuning movement penalties.
 
 ## Prefab/scene/UI/Animator follow-up required
 - Inspect `PlayerCanvas.prefab` in Unity Editor and confirm `StaminaBar` is readable at bottom-left across common resolutions.
@@ -55,6 +57,7 @@
 - Confirm footstep particles appear subtly on walk/run animation events and do not appear while idle/airborne animations are not stepping.
 - Confirm carrying logs gradually slows walk/run/jump/animation, then restores those stats after dropping logs or building a bridge.
 - Confirm goblet boost and other temporary movement changes still preserve carried-log penalties while active and restore correctly afterward.
+- Confirm no `Carry` missing-reference warnings appear on player prefab instances.
 - Add `TipTriggerZone` components near intended bridge/log/tutorial areas after validating the runtime card and toggle.
 
 ## What Cursor should test in Play Mode

--- a/Assets/Scripts/Player/Carry.cs
+++ b/Assets/Scripts/Player/Carry.cs
@@ -46,6 +46,8 @@ namespace Beavermania.Player.Movement
         bool loggedMissingGoal;
         bool loggedMissingLogDrop;
         bool loggedMissingCarryPoint;
+        bool loggedMissingBridgeDrop;
+        bool loggedMissingBridge;
 
         public float CurrentWeightPenalty01 { get; private set; }
 
@@ -96,6 +98,9 @@ namespace Beavermania.Player.Movement
 
                 if (PlayerInputReader.IsRollHeld() && PlayerInputReader.WasInteractPressed() && i == 9)
                 {
+                    if (!CanBuildBridge())
+                        return;
+
                     LogDrop.transform.localRotation = Quaternion.Slerp(transform.rotation, Quaternion.identity, 0);
                     //SpawnPos = new Vector3(LogDrop.transform.position.x, LogDrop.position.y - 0.5f, LogDrop.position.z);
                     if (Bridge != null)
@@ -194,6 +199,24 @@ namespace Beavermania.Player.Movement
                 && CarryPoint[i] != null;
         }
 
+        bool CanBuildBridge()
+        {
+            bool canBuildBridge = true;
+            if (BridgeDrop == null)
+            {
+                LogMissingBuildReference(nameof(BridgeDrop), ref loggedMissingBridgeDrop);
+                canBuildBridge = false;
+            }
+
+            if (Bridge == null)
+            {
+                LogMissingBuildReference(nameof(Bridge), ref loggedMissingBridge);
+                canBuildBridge = false;
+            }
+
+            return canBuildBridge;
+        }
+
         bool HasRequiredReferences()
         {
             ResolveGoalIfMissing();
@@ -235,6 +258,15 @@ namespace Beavermania.Player.Movement
 
             logged = true;
             Debug.LogWarning($"{nameof(Carry)} on '{name}' is missing {referenceName}; carried-log behavior is disabled until it is assigned.", this);
+        }
+
+        void LogMissingBuildReference(string referenceName, ref bool logged)
+        {
+            if (logged)
+                return;
+
+            logged = true;
+            Debug.LogWarning($"{nameof(Carry)} on '{name}' is missing {referenceName}; bridge build is blocked and carried logs are preserved until it is assigned.", this);
         }
 
 

--- a/Assets/Scripts/Player/Carry.cs
+++ b/Assets/Scripts/Player/Carry.cs
@@ -43,12 +43,25 @@ namespace Beavermania.Player.Movement
         float lastAppliedJumpValue;
         float lastAppliedAnimationSpeed;
         bool hasAppliedStats;
+        bool loggedMissingGoal;
+        bool loggedMissingLogDrop;
+        bool loggedMissingCarryPoint;
+
+        public float CurrentWeightPenalty01 { get; private set; }
+
+        void Awake()
+        {
+            ResolveGoalIfMissing();
+        }
 
         public void OnCollisionEnter(Collision OBJ)
         {
+            if (OBJ == null || OBJ.gameObject == null)
+                return;
+
             if (OBJ.gameObject.CompareTag("Part"))
             {
-                if (i < CarryPoint.Length - 1 && !PlayerInputReader.IsPrimaryHeld())
+                if (CanAddLog() && !PlayerInputReader.IsPrimaryHeld())
                 {
                     //Goal.Otter.Play("Crouch");
                     CarryPoint[i].SetActive(true);
@@ -61,6 +74,9 @@ namespace Beavermania.Player.Movement
 
         public void Update()
         {
+            if (!HasRequiredReferences())
+                return;
+
             Vector3 SpawnPos = LogDrop.transform.position;
             Goal.LogCount = i + "/9";
             ApplyCarryWeightPenalty();
@@ -74,23 +90,34 @@ namespace Beavermania.Player.Movement
                     i--;
                     ApplyCarryWeightPenalty();
                     Instantiate(Log, SpawnPos, Quaternion.identity);
-                    CarryPoint[i].SetActive(false);
+                    if (i >= 0 && i < CarryPoint.Length && CarryPoint[i] != null)
+                        CarryPoint[i].SetActive(false);
                 }
 
                 if (PlayerInputReader.IsRollHeld() && PlayerInputReader.WasInteractPressed() && i == 9)
                 {
                     LogDrop.transform.localRotation = Quaternion.Slerp(transform.rotation, Quaternion.identity, 0);
                     //SpawnPos = new Vector3(LogDrop.transform.position.x, LogDrop.position.y - 0.5f, LogDrop.position.z);
-                    Bridge.transform.rotation = Goal.rotGoal * Quaternion.Euler(-90, 0, 0);
-                    var newPoof= Instantiate(Poof, BridgeDrop.position + new Vector3(0, 0.5f, 0), Goal.transform.rotation * Quaternion.Euler(0, 180, 0));
-                    Instantiate(Bridge, BridgeDrop.position + new Vector3(0,0.5f,0), Goal.transform.rotation*Quaternion.Euler(0,180,0));
-                    Destroy(newPoof);
+                    if (Bridge != null)
+                        Bridge.transform.rotation = Goal.rotGoal * Quaternion.Euler(-90, 0, 0);
+                    if (BridgeDrop != null)
+                    {
+                        if (Poof != null)
+                        {
+                            var newPoof = Instantiate(Poof, BridgeDrop.position + new Vector3(0, 0.5f, 0), Goal.transform.rotation * Quaternion.Euler(0, 180, 0));
+                            Destroy(newPoof);
+                        }
+                        if (Bridge != null)
+                            Instantiate(Bridge, BridgeDrop.position + new Vector3(0, 0.5f, 0), Goal.transform.rotation * Quaternion.Euler(0, 180, 0));
+                    }
 
                     i = 0;
                     ApplyCarryWeightPenalty();
-                    for (int x = 0; x < 9; x++)
+                    int carriedVisualCount = CarryPoint != null ? Mathf.Min(9, CarryPoint.Length) : 0;
+                    for (int x = 0; x < carriedVisualCount; x++)
                     {
-                        CarryPoint[x].SetActive(false);
+                        if (CarryPoint[x] != null)
+                            CarryPoint[x].SetActive(false);
                     }
                 }
 
@@ -108,6 +135,7 @@ namespace Beavermania.Player.Movement
             if (Goal == null)
                 return;
 
+            CurrentWeightPenalty01 = 0f;
             float walkPenalty = CalculatePenalty(WalkFactor, maxWalkPenalty);
             float runPenalty = CalculatePenalty(RunFactor, maxRunPenalty);
             float jumpPenalty = CalculatePenalty(JumpFactor, maxJumpPenalty);
@@ -142,7 +170,9 @@ namespace Beavermania.Player.Movement
         {
             int effectiveLogCount = Mathf.Max(0, i - Mathf.Max(1, logsCountThreshold) + 1);
             float cappedMaxPenalty = Mathf.Max(0f, maxPenalty) * Mathf.Clamp01(maxWeightPenalty);
-            return Mathf.Min(effectiveLogCount * Mathf.Max(0f, penaltyPerLog), cappedMaxPenalty);
+            float penalty = Mathf.Min(effectiveLogCount * Mathf.Max(0f, penaltyPerLog), cappedMaxPenalty);
+            CurrentWeightPenalty01 = Mathf.Max(CurrentWeightPenalty01, cappedMaxPenalty > 0f ? penalty / cappedMaxPenalty : 0f);
+            return penalty;
         }
 
         float ResolveBaseValue(float currentValue, float lastAppliedValue, float appliedPenalty)
@@ -153,6 +183,58 @@ namespace Beavermania.Player.Movement
             return Mathf.Approximately(currentValue, lastAppliedValue)
                 ? currentValue + appliedPenalty
                 : currentValue;
+        }
+
+        bool CanAddLog()
+        {
+            return CarryPoint != null
+                && CarryPoint.Length > 0
+                && i >= 0
+                && i < CarryPoint.Length - 1
+                && CarryPoint[i] != null;
+        }
+
+        bool HasRequiredReferences()
+        {
+            ResolveGoalIfMissing();
+
+            bool hasReferences = true;
+            if (Goal == null)
+            {
+                LogMissingReference(nameof(Goal), ref loggedMissingGoal);
+                hasReferences = false;
+            }
+
+            if (LogDrop == null)
+            {
+                LogMissingReference(nameof(LogDrop), ref loggedMissingLogDrop);
+                hasReferences = false;
+            }
+
+            if (CarryPoint == null || CarryPoint.Length == 0)
+            {
+                LogMissingReference(nameof(CarryPoint), ref loggedMissingCarryPoint);
+                hasReferences = false;
+            }
+
+            return hasReferences;
+        }
+
+        void ResolveGoalIfMissing()
+        {
+            if (Goal != null)
+                return;
+
+            Goal = GetComponent<BeaverPlayer>();
+        }
+
+        void LogMissingReference(string referenceName, ref bool logged)
+        {
+            if (logged)
+                return;
+
+            logged = true;
+            Debug.LogWarning($"{nameof(Carry)} on '{name}' is missing {referenceName}; carried-log behavior is disabled until it is assigned.", this);
         }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Expose `Carry.CurrentWeightPenalty01` for future HUD/combat hooks.
- Add missing-reference guards and one-time warnings for carry dependencies.
- Guard carry-point visual toggles and optional bridge-build VFX/prefab references.
- Keep carried-log penalty rebasing intact for temporary movement effects.

## Verification
- `dotnet build BeaverMania.CI.csproj` passed from `/workspace/.ci` with 0 warnings and 0 errors.
- `git diff --check` passed with no whitespace errors.
- Needs Unity Editor Play Mode verification for carry pickup/drop/build and absence of missing-reference warnings on player prefabs.

## Risk
- Touches the existing log-carry movement/stat path in `Carry`.
- Combat attack-speed behavior is still deferred; current change only exposes a safe weight readout for future hooks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

