### PR TITLE
Add pause collectibles summary

### DIFF
--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -10,13 +10,13 @@
 - Mixed
 
 ## Current phase
-- Phase 5 carried-log weight implementation / verification
+- Phase 1 follow-up collectibles pause summary / verification
 
 ## Goal
 - Improve HUD clarity first, then phase in tips, objectives, footstep feedback, and carried-log game feel without replacing existing pause, input, movement, or combat systems.
 
 ## Scope
-- Phase 5 first slice: make the existing carried-log movement penalties capped and designer-tunable without replacing player movement.
+- Phase 1 follow-up: add a pause-menu collectibles summary while preserving compact always-visible HUD counters.
 
 ## Out of scope
 - Scene placement of tip trigger zones until Unity Editor follow-up.
@@ -30,6 +30,7 @@
 - `Assets/Scripts/Data/Tips/TipRequest.cs`
 - `Assets/Scripts/UI/Tips/*`
 - `Assets/Scripts/UI/UIMenu.cs`
+- `Assets/Scripts/UI/Menus/PauseCollectiblesSummary.cs`
 - `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
 - `Assets/Scripts/UI/DebugReference.cs`
 - `Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs`
@@ -64,10 +65,11 @@
 - Phase 5 carried-log weight penalties are centralized and capped in `Carry`.
 - Phase 5 penalties now rebase when other systems temporarily change walk/run/jump/animation values.
 - Phase 5 carry component now exposes current weight penalty and guards missing references for Play Mode diagnostics.
+- Pause menu now has a runtime collectibles summary for coins, nuts, apples, goblets, arrows, and logs.
 
 ## Next action
 - Owner: Cursor / Unity Editor
-- Action: Run Play Mode validation, confirm log pickup/drop/build restores movement stats correctly, and tune carried-log penalty caps.
+- Action: Run Play Mode validation and confirm the pause-menu collectibles summary is readable and does not overlap existing pause controls.
 
 ## Open questions
 - Whether collectibles should be fully moved into pause/diary UI in a later phase or remain as compact HUD counters.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -6,6 +6,7 @@
 ## Code changes made
 - Compact collectible/ammo/log HUD text values to numbers only so existing icons carry the label meaning.
 - Move `StaminaBar` from the top-left HUD cluster to bottom-left anchored screen space in `PlayerCanvas.prefab`.
+- Add a runtime pause-menu collectibles summary for coins, nuts, apples, goblets, arrows, and logs while preserving compact HUD counters.
 - Add code-only tips subsystem with `TipDefinition`, settings persistence, cooldown/display-count/priority gating, idle/active gating, trigger-zone hooks, and an animated runtime tip card.
 - Add a runtime Tips On/Off toggle to the existing pause menu through `UIMenu` startup without editing the pause menu prefab hierarchy.
 - Add contextual bridge construction tips through `NewConstructor` so bridge/log guidance appears only near intended bridge construction areas.
@@ -26,6 +27,7 @@
 - `Assets/Scripts/Data/Tips/TipRequest.cs`
 - `Assets/Scripts/UI/Tips/*`
 - `Assets/Scripts/UI/UIMenu.cs`
+- `Assets/Scripts/UI/Menus/PauseCollectiblesSummary.cs`
 - `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
 - `Assets/Scripts/UI/DebugReference.cs`
 - `Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs`
@@ -50,6 +52,7 @@
 ## Prefab/scene/UI/Animator follow-up required
 - Inspect `PlayerCanvas.prefab` in Unity Editor and confirm `StaminaBar` is readable at bottom-left across common resolutions.
 - Confirm top-right collectible/ammo/log counters still align with their icons after label removal.
+- Confirm pause-menu collectibles summary appears, refreshes when pause opens, and does not overlap volume/restart/controls UI.
 - Decide in Phase 2/3 whether collectibles should move fully into pause/diary UI or remain compact HUD counters.
 - Confirm the runtime `Tips: On/Off` toggle appears in the pause menu and does not overlap volume/restart controls.
 - Confirm bridge tips appear near `NewConstructor` trigger areas and do not appear globally when the player is away from bridge constructors.
@@ -62,7 +65,7 @@
 
 ## What Cursor should test in Play Mode
 - Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause, toggle Tips off/on.
-- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, carrying logs slows movement/jump/animation and restores on drop/build, goblet boost preserves carried-log penalties, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers, footstep particles trigger from existing walk/run step events.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, pause menu shows collectibles summary with current counts, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, carrying logs slows movement/jump/animation and restores on drop/build, goblet boost preserves carried-log penalties, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers, footstep particles trigger from existing walk/run step events.
 - Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, tips do not show while disabled, paused, in trader UI, or away from bridge construction areas.
 
 ## What Cursor should not change

--- a/Assets/Scripts/UI/Menus/PauseCollectiblesSummary.cs
+++ b/Assets/Scripts/UI/Menus/PauseCollectiblesSummary.cs
@@ -1,0 +1,109 @@
+using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Beavermania.UI.Menus
+{
+    [DisallowMultipleComponent]
+    public sealed class PauseCollectiblesSummary : MonoBehaviour
+    {
+        const string PanelName = "Collectibles Summary";
+
+        Text titleText;
+        Text bodyText;
+
+        public static PauseCollectiblesSummary Ensure(GameObject pauseMenu)
+        {
+            if (pauseMenu == null)
+                return null;
+
+            PauseCollectiblesSummary existing = pauseMenu.GetComponentInChildren<PauseCollectiblesSummary>(true);
+            if (existing != null)
+                return existing;
+
+            return Create(pauseMenu.transform);
+        }
+
+        public void Refresh(BeaverPlayer player)
+        {
+            EnsureView();
+
+            if (titleText != null)
+                titleText.text = "Collectibles";
+
+            if (bodyText == null)
+                return;
+
+            if (player == null)
+            {
+                bodyText.text = "Player data unavailable";
+                return;
+            }
+
+            int logCount = player.Load != null ? player.Load.i : 0;
+            bodyText.text =
+                $"Coins: {player.Currency}\n" +
+                $"Nuts: {player.NutCount}\n" +
+                $"Apples: {player.Apple}\n" +
+                $"Goblets: {player.GobletPickup}\n" +
+                $"Arrows: {player.arrowMunition}\n" +
+                $"Logs: {logCount}/9";
+        }
+
+        static PauseCollectiblesSummary Create(Transform parent)
+        {
+            var panelObject = new GameObject(PanelName, typeof(RectTransform), typeof(Image), typeof(PauseCollectiblesSummary));
+            panelObject.transform.SetParent(parent, false);
+
+            var rect = panelObject.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(1f, 0.5f);
+            rect.anchorMax = new Vector2(1f, 0.5f);
+            rect.pivot = new Vector2(1f, 0.5f);
+            rect.anchoredPosition = new Vector2(-48f, 0f);
+            rect.sizeDelta = new Vector2(260f, 220f);
+
+            var background = panelObject.GetComponent<Image>();
+            background.color = new Color(0.05f, 0.035f, 0.025f, 0.68f);
+            background.raycastTarget = false;
+
+            var summary = panelObject.GetComponent<PauseCollectiblesSummary>();
+            summary.EnsureView();
+            return summary;
+        }
+
+        void EnsureView()
+        {
+            if (titleText != null && bodyText != null)
+                return;
+
+            titleText = ResolveOrCreateText("Title", new Vector2(14f, 176f), new Vector2(-14f, -12f), 24, FontStyle.Bold);
+            bodyText = ResolveOrCreateText("Body", new Vector2(14f, 14f), new Vector2(-14f, -52f), 20, FontStyle.Normal);
+        }
+
+        Text ResolveOrCreateText(string childName, Vector2 offsetMin, Vector2 offsetMax, int fontSize, FontStyle fontStyle)
+        {
+            Transform child = transform.Find(childName);
+            Text text = child != null ? child.GetComponent<Text>() : null;
+            if (text == null)
+            {
+                var textObject = new GameObject(childName, typeof(RectTransform), typeof(Text));
+                textObject.transform.SetParent(transform, false);
+                text = textObject.GetComponent<Text>();
+            }
+
+            var rect = text.GetComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = offsetMin;
+            rect.offsetMax = offsetMax;
+
+            text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            text.fontSize = fontSize;
+            text.fontStyle = fontStyle;
+            text.alignment = TextAnchor.UpperLeft;
+            text.color = Color.white;
+            text.raycastTarget = false;
+            return text;
+        }
+    }
+}

--- a/Assets/Scripts/UI/Menus/PauseCollectiblesSummary.cs.meta
+++ b/Assets/Scripts/UI/Menus/PauseCollectiblesSummary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 772bb35a92e74c8db06f72c87d43d2bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/UIMenu.cs
+++ b/Assets/Scripts/UI/UIMenu.cs
@@ -22,6 +22,7 @@ namespace Beavermania.UI.Menus
         [SerializeField] GameObject restartCheckpointConfirmationPanel;
 
         PauseController pauseController;
+        PauseCollectiblesSummary collectiblesSummary;
         bool loggedMissingPlayer;
         bool loggedMissingMusic;
         bool loggedMissingPauseMenu;
@@ -66,12 +67,19 @@ namespace Beavermania.UI.Menus
             InitializeVolumeSlider();
             InitializeSfxVolumeSlider();
             InitializeTipsUi();
+            InitializeCollectiblesSummary();
         }
 
         void InitializeTipsUi()
         {
             TipsService.EnsureForCanvas(gameObject, Player);
             TipsPauseMenuToggleInstaller.Ensure(PauseMenu);
+        }
+
+        void InitializeCollectiblesSummary()
+        {
+            collectiblesSummary = PauseCollectiblesSummary.Ensure(PauseMenu);
+            RefreshCollectiblesSummary();
         }
 
         void InitializeVolumeSlider()
@@ -146,14 +154,14 @@ namespace Beavermania.UI.Menus
         public void Pause()
         {
             PauseController.Pause();
-            RefreshRestartCheckpointButtonState();
+            RefreshPauseMenuDynamicUi();
         }
 
         public void ChangeBolean()
         {
             PauseController.ChangeBolean();
             if (PauseController.ActivePause)
-                RefreshRestartCheckpointButtonState();
+                RefreshPauseMenuDynamicUi();
         }
 
         public void RestartCheckpointFromMenu()
@@ -197,6 +205,21 @@ namespace Beavermania.UI.Menus
                 return;
 
             restartLastCheckpointButton.interactable = Player != null && Player.Lives > 1;
+        }
+
+        public void RefreshPauseMenuDynamicUi()
+        {
+            RefreshRestartCheckpointButtonState();
+            RefreshCollectiblesSummary();
+        }
+
+        void RefreshCollectiblesSummary()
+        {
+            if (collectiblesSummary == null)
+                collectiblesSummary = PauseCollectiblesSummary.Ensure(PauseMenu);
+
+            if (collectiblesSummary != null)
+                collectiblesSummary.Refresh(Player);
         }
 
         void EnsurePauseMenuOpenListener()
@@ -327,7 +350,7 @@ namespace Beavermania.UI.Menus
 
         void OnEnable()
         {
-            owner?.RefreshRestartCheckpointButtonState();
+            owner?.RefreshPauseMenuDynamicUi();
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a runtime pause-menu collectibles summary for coins, nuts, apples, goblets, arrows, and logs.
- Refresh the summary when the pause menu opens alongside the existing restart-checkpoint button refresh.
- Preserve compact always-visible HUD counters while giving collectibles a fuller pause-menu home.
- Update workflow and Cursor handoff notes for pause-menu layout Play Mode checks.

## Verification
- `dotnet build BeaverMania.CI.csproj` passed from `/workspace/.ci` with 0 warnings and 0 errors.
- `git diff --check` passed with no whitespace errors.
- Needs Unity Editor Play Mode verification for pause-menu layout, overlap, and count refresh behavior.

## Risk
- Runtime UI is additive, but pause menu layout must be visually checked.
- No existing serialized fields were renamed or removed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f35a0-da66-43d8-84ba-de1dee3675e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

