### PR TITLE
Add AI_WORKFLOW routing layer with prompts and inbox files; reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,8 @@ Recommended branch names:
 - FPS and rendering stability.
 - Avoid large architecture work unless it directly supports Steam release stability.
 
+For intake and routing between ChatGPT, Cursor, and Codex, use the lightweight routing inbox layer in [AI_WORKFLOW/README.md](AI_WORKFLOW/README.md).
+
 For repo-local workflow detail, read:
 
 - [AI_CONTEXT/PROJECT_OVERVIEW.md](AI_CONTEXT/PROJECT_OVERVIEW.md)

--- a/AI_WORKFLOW/README.md
+++ b/AI_WORKFLOW/README.md
@@ -1,0 +1,50 @@
+# AI Workflow Layer (Codex ↔ Cursor)
+
+## Purpose
+
+- Provide a file-based operating protocol for mixed AI delivery in this repository.
+- Make task ownership, handoffs, verification status, and merge readiness explicit.
+- Reduce regressions from Unity serialized-reference fragility by preventing ambiguous ownership.
+
+## Communication Model
+
+- Codex and Cursor do **not** chat directly.
+- They communicate through committed repository files in `AI_WORKFLOW/`.
+- Use:
+  - `AI_WORKFLOW/active-task.md`
+  - `AI_WORKFLOW/handoffs/cursor-to-codex.md`
+  - `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+  - `AI_WORKFLOW/task-templates/*`
+
+## Ownership Model
+
+- **Codex owns:** script correctness, architecture decisions, refactors, code review, PR summaries, and workflow/documentation maintenance.
+- **Cursor owns:** Unity Editor integration (scenes, prefabs, UI wiring, Animator/animation, Inspector references), plus visual/runtime Play Mode verification.
+- **User / Product Owner owns:** prioritization, final acceptance, merge approval, and conflict resolution.
+
+## Task Lifecycle
+
+1. Start from `AI_WORKFLOW/active-task.md` or a task template.
+2. Define owner and scope boundaries before implementation.
+3. Implement only within assigned ownership.
+4. Record verification evidence and remaining risks.
+5. End with one of:
+   - Final report, or
+   - Formal handoff to the other tool.
+
+## Coordination Rules
+
+- Do not let Codex and Cursor edit the same scene/prefab/animation/UI asset concurrently.
+- For cross-boundary work (scripts + Unity Editor), lock next owner explicitly in `active-task.md`.
+- Runtime Unity behavior claims require Play Mode verification.
+- Script-level validation alone is not sufficient for serialized wiring outcomes.
+
+## Routing Inbox Layer
+
+Use the routing inbox layer when a task needs intake, ownership classification, and prepared execution prompts before work starts:
+
+- `AI_WORKFLOW/inbox/task-intake.md` records the incoming task, evidence, constraints, and first owner guess.
+- `AI_WORKFLOW/routing/current-routing.md` records ChatGPT's routing decision, execution order, mode, stop condition, and verification needs.
+- `AI_WORKFLOW/prompts/cursor-next.md` is the reusable Cursor execution prompt for Cursor-owned work.
+- `AI_WORKFLOW/prompts/codex-next.md` is the reusable Codex execution prompt for Codex-owned work.
+- `AI_WORKFLOW/automation/README.md` explains the semi-automatic ChatGPT → repo command bus → Cursor/Codex pipeline.

--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -1,0 +1,83 @@
+# Active Task
+
+## Task title
+
+- UI/UX and game-feel improvements
+
+## Type
+
+- Feature
+
+## Owner
+
+- Mixed (code complete; Unity verification pending)
+
+## Current phase
+
+- Verification and merge readiness
+
+## Goal
+
+- Improve HUD clarity, tips, objectives, footstep feedback, and carried-log game feel without replacing pause, input, movement, or combat systems.
+
+## Scope
+
+- All five implementation phases (HUD, tips, objectives, footsteps, log weight) plus pause-menu collectibles summary.
+
+## Out of scope
+
+- Scene placement of `TipTriggerZone` until Unity Editor follow-up.
+- Combat-speed penalty wiring (`GroundBeat`/`AirBeat` are not attack gates).
+- Dialogue, shop, animation, and input-action rewrites.
+
+## Relevant files/assets
+
+- `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
+- `Assets/Scripts/Player/BeaverPlayerBehaviour.cs`, `Carry.cs`, `SoundScripts/AudioScript.cs`
+- `Assets/Scripts/UI/UIMenu.cs`, `DebugReference.cs`, `Menus/PauseCollectiblesSummary.cs`
+- `Assets/Scripts/UI/Tips/*`, `Assets/Scripts/Data/Tips/*`
+- `Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs`
+- `Assets/Scripts/Display/FootstepVfxEmitter.cs`, `Assets/Scripts/Data/Display/FootstepSurfaceEffectProfile.cs`
+- `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
+
+## Risk level
+
+- High (prefab + runtime UI + movement penalties)
+
+## Branch
+
+- `cursor/feature-ui-ux-gamefeel-improvements-75e4` (local commits present; remote upstream deleted — re-push before PR)
+
+## Codex responsibilities
+
+- Done: script-level implementation and handoff notes.
+
+## Cursor responsibilities
+
+- Run Unity Play Mode checklist (below).
+- Re-push branch and open/refresh PR if merging.
+
+## Required verification
+
+- Code-level: `dotnet build .ci/BeaverMania.CI.csproj` (requires Unity managed DLL paths on the machine; failed locally without Unity install — use Unity Editor compile or CI with Unity refs).
+- Unity Editor / Play Mode: Level 1 Remastered, `PlayerCanvas`, pause/tips/objectives/footsteps/carry flows.
+
+## Current status
+
+- Phase 1–5 implementation complete on branch.
+- Pause-menu collectibles summary implemented.
+- PR review fixes applied (bridge hint, footstep material/player gating, carry rebase/penalty readout).
+
+## Next action
+
+- Owner: User / Unity Editor
+- Action: Complete Play Mode checklist; re-push branch; merge when verified.
+
+## Open questions
+
+- Hide compact HUD collectibles after pause summary is accepted?
+- Which scenes get authored `TipDefinition` + `TipTriggerZone` placements?
+
+## Handoff needed
+
+- No further code handoff unless Play Mode finds regressions.

--- a/AI_WORKFLOW/automation/README.md
+++ b/AI_WORKFLOW/automation/README.md
@@ -1,0 +1,29 @@
+# AI Workflow Automation
+
+This folder documents the semi-automatic routing pipeline for Beavermania AI work.
+
+## Roles
+
+- ChatGPT is the router and orchestrator.
+- GitHub plus `AI_WORKFLOW/` acts as the command bus and shared memory.
+- Codex and Cursor execute from prepared repo files instead of ad hoc rewritten instructions.
+- The user still manually launches Codex or Cursor when needed.
+- Full remote execution of Cursor from ChatGPT is not assumed.
+- Unity Play Mode remains the source of truth for runtime and Editor verification.
+
+## Practical flow
+
+1. User describes the task to ChatGPT.
+2. ChatGPT fills or proposes [AI_WORKFLOW/inbox/task-intake.md](../inbox/task-intake.md).
+3. ChatGPT writes the routing decision in [AI_WORKFLOW/routing/current-routing.md](../routing/current-routing.md).
+4. ChatGPT prepares [AI_WORKFLOW/prompts/cursor-next.md](../prompts/cursor-next.md) and/or [AI_WORKFLOW/prompts/codex-next.md](../prompts/codex-next.md).
+5. User launches the selected tool and tells it to execute the matching prompt file.
+6. The tool updates a handoff file or final report with changed files, verification, risks, and next needs.
+7. ChatGPT reviews the PR/output and routes the next step.
+
+## Operating notes
+
+- Use the routing file as the single source of truth for ownership, mode, branch, stop condition, and verification.
+- Keep prompt files task-specific enough to execute without the user rewriting instructions.
+- Use handoff files when ownership changes between Codex and Cursor.
+- Do not treat code-level checks as Unity runtime verification.

--- a/AI_WORKFLOW/decisions/ADR-0001-codex-cursor-division.md
+++ b/AI_WORKFLOW/decisions/ADR-0001-codex-cursor-division.md
@@ -1,0 +1,48 @@
+# ADR-0001: Codex/Cursor Cooperation via Repository Files
+
+- Status: Accepted
+
+## Context
+
+Beavermania is a Unity project with fragile serialized references and high coupling between script behavior and Unity Editor wiring (prefabs/scenes/UI/Animator/Inspector). Prior guidance defines tool strengths, but lacked a strict operational protocol for cross-agent lifecycle ownership and handoffs.
+
+## Decision
+
+Codex and Cursor cooperate through repository files under `AI_WORKFLOW/` instead of direct freeform conversation.
+
+## Consequences
+
+- Task state becomes auditable in git history.
+- Ownership boundaries are explicit before changes start.
+- Cross-boundary tasks require formal handoffs.
+- Merge readiness depends on both code-level and Unity verification records.
+
+## Codex responsibilities
+
+- Script correctness, architecture, focused refactors, code reviews, risk notes, PR summaries.
+- Maintain/update workflow documents and handoff artifacts when Cursor follow-up is required.
+- Avoid unverified Unity runtime claims; request Play Mode confirmation when needed.
+
+## Cursor responsibilities
+
+- Unity Editor integration: prefab/scene/UI/Animator/Inspector wiring.
+- Play Mode verification and visual/system behavior validation.
+- Generate Cursor→Codex handoffs when Unity investigation indicates script-level defects.
+
+## User responsibilities
+
+- Define priorities and acceptance criteria.
+- Approve ownership strategy and risk tradeoffs.
+- Provide final merge approval.
+
+## Explicit anti-patterns
+
+- Both tools editing the same Unity asset concurrently.
+- Codex claiming Unity behavior is fixed without Play Mode verification.
+- Cursor performing broad C# refactors without Codex review.
+- Large multi-system changes without `AI_WORKFLOW/active-task.md`.
+- Unclear ownership for next action.
+
+## Why this matters for Beavermania
+
+Serialized references can silently break when ownership is ambiguous or when script/editor changes are not coordinated. A file-backed workflow enforces traceable handoffs and verification checkpoints, reducing regression risk for Steam release stability.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,0 +1,103 @@
+# Codex → Cursor Handoff
+
+## Task
+
+- UI/UX and game-feel improvements — Phase 1 HUD cleanup, Phase 2 tips, Phase 3 objective tracker, Phase 4 footstep feedback, Phase 5 carried-log weight
+
+## Code changes made
+
+- Compact collectible/ammo/log HUD text values to numbers only so existing icons carry the label meaning.
+- Move `StaminaBar` from the top-left HUD cluster to bottom-left anchored screen space in `PlayerCanvas.prefab`.
+- Add a runtime pause-menu collectibles summary for coins, nuts, apples, goblets, arrows, and logs while preserving compact HUD counters.
+- Add code-only tips subsystem with `TipDefinition`, settings persistence, cooldown/display-count/priority gating, idle/active gating, trigger-zone hooks, and an animated runtime tip card.
+- Add a runtime Tips On/Off toggle to the existing pause menu through `UIMenu` startup without editing the pause menu prefab hierarchy.
+- Add contextual bridge construction tips through `NewConstructor` so bridge/log guidance appears only near intended bridge construction areas.
+- Add an objective tracker presenter that formats current objective text as a compact bullet list and keeps trader/objective override text flowing through the existing `DebugReference` path.
+- Add pooled footstep contact particles triggered from the existing `AudioScript.Step()` animation-event method, with surface resolution by profile, tag, physics material, material name, or fallback.
+- Centralize carried-log walk/run/jump/animation penalties in `Carry` with threshold, max weight penalty, per-log penalties, animation multiplier, and caps.
+- Rebase carried-log penalties when other temporary effects change player walk/run/jump/animation values, so the log penalty remains active and restores cleanly.
+- Expose `Carry.CurrentWeightPenalty01` for future HUD/combat hooks and add warning guards for missing carry references.
+- Record mixed ownership and verification requirements in `AI_WORKFLOW/active-task.md`.
+
+## Files changed
+
+- `AI_WORKFLOW/active-task.md`
+- `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+- `Assets/Scripts/Player/BeaverPlayerBehaviour.cs`
+- `Assets/Scripts/Player/Carry.cs`
+- `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
+- `Assets/Scripts/Data/Tips/TipDefinition.cs`
+- `Assets/Scripts/Data/Tips/TipRequest.cs`
+- `Assets/Scripts/UI/Tips/*`
+- `Assets/Scripts/UI/UIMenu.cs`
+- `Assets/Scripts/UI/Menus/PauseCollectiblesSummary.cs`
+- `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
+- `Assets/Scripts/UI/DebugReference.cs`
+- `Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs`
+- `Assets/Scripts/Data/Display/FootstepSurfaceEffectProfile.cs`
+- `Assets/Scripts/Display/FootstepVfxEmitter.cs`
+- `Assets/Scripts/Player/SoundScripts/AudioScript.cs`
+
+## New or changed serialized fields
+
+- New serialized tuning fields on `TipDefinition`, `TipsService`, `PlayerIdleStateTracker`, `TipCardPresenter`, and `TipTriggerZone`.
+- New serialized tuning fields on `FootstepSurfaceEffectProfile`, `FootstepVfxEmitter`, and `AudioScript.footstepVfxEmitter`.
+- New serialized tuning fields on `Carry`: log threshold, max weight penalty, max walk/run/jump/animation penalties, animation speed multiplier, and minimum animation speed.
+- No existing serialized fields were renamed or removed.
+
+## Inspector assignments required
+
+- None expected from script changes.
+- Verify existing `DebugReference` text references and `Health_Bar_Script` slider references remain assigned in the active scenes.
+- Phase 2 scene authoring requires creating `TipDefinition` assets and assigning them to `TipTriggerZone` components in intended areas.
+- Optional: assign a `FootstepSurfaceEffectProfile` on `FootstepVfxEmitter` for tuned per-surface colors/prefabs; fallback procedural dust works without assignment.
+- Optional: tune `Carry` weight fields on the player prefab after Play Mode checks; defaults preserve the previous 9-log total penalties.
+- Inspect any `Carry` missing-reference warnings before tuning movement penalties.
+
+## Prefab/scene/UI/Animator follow-up required
+
+- Inspect `PlayerCanvas.prefab` in Unity Editor and confirm `StaminaBar` is readable at bottom-left across common resolutions.
+- Confirm top-right collectible/ammo/log counters still align with their icons after label removal.
+- Confirm pause-menu collectibles summary appears, refreshes when pause opens, and does not overlap volume/restart/controls UI.
+- Decide in Phase 2/3 whether collectibles should move fully into pause/diary UI or remain compact HUD counters.
+- Confirm the runtime `Tips: On/Off` toggle appears in the pause menu and does not overlap volume/restart controls.
+- Confirm bridge tips appear near `NewConstructor` trigger areas and do not appear globally when the player is away from bridge constructors.
+- Confirm the objective tracker appears middle-left, is readable, and formats current objectives as a compact list.
+- Confirm footstep particles appear subtly on walk/run animation events and do not appear while idle/airborne animations are not stepping.
+- Confirm carrying logs gradually slows walk/run/jump/animation, then restores those stats after dropping logs or building a bridge.
+- Confirm goblet boost and other temporary movement changes still preserve carried-log penalties while active and restore correctly afterward.
+- Confirm no `Carry` missing-reference warnings appear on player prefab instances.
+- Add `TipTriggerZone` components near intended bridge/log/tutorial areas after validating the runtime card and toggle.
+
+## What Cursor should test in Play Mode
+
+- Reproduction path: open Level 1 Remastered, enter Play Mode, move/jump/sprint, pick up coins/nuts/apples/goblets/arrows/logs, open/close pause, toggle Tips off/on.
+- Functional checks: health stays top-left, stamina appears bottom-left and updates, counter text shows icon + number only, pause menu shows collectibles summary with current counts, objective tracker appears middle-left, log count shows `N/9`, 9-log carry state shows `LCtrl+RMB to build`, carrying logs slows movement/jump/animation and restores on drop/build, goblet boost preserves carried-log penalties, pause menu still opens/closes, Tips toggle persists across pause reopen, bridge tips appear only near bridge construction triggers, footstep particles trigger from existing walk/run step events.
+- Negative/regression checks: no `NullReferenceException`, trader/lose UI still locks input/cursor, objective text still updates, tips do not show while disabled, paused, in trader UI, or away from bridge construction areas.
+
+## What Cursor should not change
+
+- Do not edit scenes or additional prefabs for later phases until Phase 1 layout is accepted.
+- Do not rewrite input, pause, movement, combat, or objective systems as part of this handoff.
+- Do not scatter bridge/log tips globally; place `TipTriggerZone` only at intended bridge-building/tutorial spaces.
+
+## Implementation complete (code)
+
+- All planned phases (1–5) and pause collectibles summary are committed on `cursor/feature-ui-ux-gamefeel-improvements-75e4`.
+- Remote tracking branch was deleted; re-push before opening or refreshing a PR.
+
+## Known limitations
+
+- Unity Play Mode was not available in Cloud, so layout and serialized-reference behavior need Editor verification.
+- A compact bridge-build instruction remains in the 9/9 log HUD as a fallback while contextual bridge-area tips are verified.
+- Additional authored `TipDefinition` assets or scene `TipTriggerZone` placements have not been added yet.
+- The objective tracker runtime container is created from code; visual padding/background must be checked in the Editor.
+- Footstep VFX uses procedural fallback particles until a tuned `FootstepSurfaceEffectProfile` or particle prefabs are authored in Unity.
+- Carried-log penalties still apply through existing `Carry` stat adjustments; deeper combat attack-speed integration is deferred to avoid broad combat rewrites.
+
+## Risk notes
+
+- Enemy/NPC behavior risk: Low for Phase 1.
+- Interaction/dialogue/shop flow risk: Medium because `PlayerCanvas.prefab` and pause menu runtime UI are shared with dialogue/shop/pause flows.
+- Player combat/input risk: Low; input is read for gating only, not rebound or intercepted.
+- Pooling/performance risk: Medium-low; footstep particles are pooled and throttled, but visual/performance impact needs Play Mode observation.

--- a/AI_WORKFLOW/handoffs/cursor-to-codex.md
+++ b/AI_WORKFLOW/handoffs/cursor-to-codex.md
@@ -1,0 +1,53 @@
+# Cursor → Codex Handoff Template
+
+## Task
+
+-
+
+## Unity context
+
+- Scene(s):
+- Prefab(s):
+- UI panel(s):
+- Animator/animation context:
+
+## What was changed in Editor
+
+-
+
+## What was observed in Play Mode
+
+- Reproduction path:
+- Expected:
+- Actual:
+- Frequency:
+
+## Suspected code issue
+
+-
+
+## Files/scripts likely involved
+
+-
+
+## What Cursor needs from Codex
+
+-
+
+## What Codex must not change
+
+- Protected assets (scene/prefab/UI/animation):
+- Behavioral constraints:
+
+## Required verification after Codex changes
+
+- Unity checks Cursor will run:
+- Script-level checks Codex should run:
+
+## Risk notes
+
+- Trader/dialogue/shop risk:
+- Inspector-reference risk:
+- Animation/state-machine risk:
+- Audio-routing risk:
+- Scene-integration risk:

--- a/AI_WORKFLOW/inbox/task-intake.md
+++ b/AI_WORKFLOW/inbox/task-intake.md
@@ -1,0 +1,87 @@
+# Task Intake
+
+Purpose: record the incoming task before routing so ChatGPT or the user can preserve the original request, evidence, constraints, and first owner guess.
+
+## Raw user request
+
+```text
+Paste the user request here.
+```
+
+## Task type
+
+Choose one:
+
+- [ ] Feature
+- [ ] Bugfix
+- [ ] Review
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Release
+- [ ] Unknown
+
+## Problem / goal
+
+- _Describe the problem to solve or the outcome to achieve._
+
+## Observed behavior
+
+- _What currently happens?_
+
+## Expected behavior
+
+- _What should happen instead?_
+
+## Evidence
+
+### Video
+
+- _Link or path:_
+
+### Screenshot
+
+- _Link or path:_
+
+### Console log
+
+```text
+Paste relevant logs here.
+```
+
+### Files
+
+- _Relevant repo paths:_
+
+### User report
+
+- _Important user-provided details:_
+
+## Constraints
+
+- _Scope limits, files not to touch, release constraints, platform constraints, or verification limits._
+
+## Known affected systems
+
+- _Examples: player, combat, trader, dialogue, shop UI, checkpoints, audio, menus, input, camera, Level 1 Remastered._
+
+## Risk notes
+
+- _Unity serialization, prefab/scene wiring, runtime behavior, regression, or release risk._
+
+## Desired outcome
+
+- _Definition of done from the user or router._
+
+## Deadline / priority
+
+- _Priority, milestone, or date if known._
+
+## Initial owner guess
+
+Choose one:
+
+- [ ] GPT
+- [ ] Codex
+- [ ] Cursor
+- [ ] Mixed
+- [ ] Unknown

--- a/AI_WORKFLOW/prompts/codex-next.md
+++ b/AI_WORKFLOW/prompts/codex-next.md
@@ -1,0 +1,80 @@
+# Codex Next Prompt
+
+Use this file as the execution prompt for the Codex-owned portion of the current routed task.
+
+## Required startup reads
+
+Before acting, read:
+
+1. [AGENTS.md](../../AGENTS.md)
+2. [AI_WORKFLOW/README.md](../README.md)
+3. `AI_WORKFLOW/active-task.md`
+4. [AI_WORKFLOW/routing/current-routing.md](../routing/current-routing.md)
+
+## Task summary
+
+- _Paste or summarize the routed task here._
+
+## Codex ownership
+
+- Execute only the Codex-owned part of the task.
+- Prefer minimal script/code changes.
+- Preserve Unity serialized references.
+- Do not take over Cursor-owned scene, prefab, UI, animation, Inspector, or Play Mode work unless the routing file explicitly assigns it to Codex review only.
+
+## Allowed scope
+
+- _List allowed files, systems, or review targets._
+
+## Forbidden scope
+
+- Avoid scene, prefab, animation, Animator, UI YAML, texture, model, audio, `.meta` GUID, or unrelated asset edits.
+- Avoid broad refactors and unrelated cleanup.
+- Do not rename or remove serialized fields unless the routing file explicitly covers migration and Unity follow-up.
+- Do not claim runtime behavior is fixed without Unity Play Mode verification.
+
+## Required files to inspect
+
+- [AI_WORKFLOW/routing/current-routing.md](../routing/current-routing.md)
+- _Add task-specific files here._
+
+## Implementation / review instructions
+
+- Make the smallest safe code or documentation change that satisfies the routed task.
+- Keep changes compatible with Unity 2021.3 and C# 9 when code changes are in scope.
+- Preserve existing gameplay feel unless the routed task explicitly changes it.
+- If reviewing only, do not edit files unless the routing file allows implementation.
+
+## Code-level verification
+
+- Run available code-level validation when applicable.
+- For C# changes, prefer:
+
+```bash
+dotnet build .ci/BeaverMania.CI.csproj
+```
+
+- For Markdown-only changes, confirm the diff is documentation-only and links are valid.
+
+## Handoff trigger
+
+Stop and update `AI_WORKFLOW/handoffs/codex-to-cursor.md` if:
+
+- Code changes require Inspector, prefab, scene, UI, animation, input, audio, or Play Mode follow-up.
+- A serialized reference or Unity asset risk must be resolved in the Editor.
+- Runtime behavior cannot be verified without Cursor + Unity Editor.
+
+## Expected final report
+
+Include:
+
+- Branch used
+- Files changed
+- Codex-owned work completed
+- Behavior changed
+- Risk level
+- Code-level verification performed and what it proves
+- Unity Play Mode verification required or not required
+- Handoff created or not created
+- Inspector/prefab/scene assignments required
+- Assumptions, risks, and limitations

--- a/AI_WORKFLOW/prompts/cursor-next.md
+++ b/AI_WORKFLOW/prompts/cursor-next.md
@@ -1,0 +1,73 @@
+# Cursor Next Prompt
+
+Use this file as the execution prompt for the Cursor-owned portion of the current routed task.
+
+## Required startup reads
+
+Before acting, read:
+
+1. [AGENTS.md](../../AGENTS.md)
+2. [AI_WORKFLOW/README.md](../README.md)
+3. `AI_WORKFLOW/active-task.md`
+4. [AI_WORKFLOW/routing/current-routing.md](../routing/current-routing.md)
+
+## Task summary
+
+- _Paste or summarize the routed task here._
+
+## Cursor ownership
+
+- Execute only the Cursor-owned part of the task.
+- Prefer Plan mode for Unity scene, prefab, UI, animation, input, audio, or multi-system tasks.
+- Use Agent only for narrow, clearly scoped implementation.
+- Do not take over Codex-owned script-only work unless the routing file explicitly assigns it to Cursor.
+
+## Allowed scope
+
+- _List allowed files, systems, scenes, prefabs, UI panels, Inspector assignments, or verification steps._
+
+## Forbidden scope
+
+- Avoid broad C# refactors.
+- Avoid editing Unity assets outside the explicit routed scope.
+- Do not modify unrelated scenes, prefabs, animation clips, Animator assets, textures, models, audio assets, `.meta` GUIDs, or gameplay scripts.
+- Do not claim runtime behavior is fixed without Play Mode verification.
+
+## Required files to inspect
+
+- [AI_WORKFLOW/routing/current-routing.md](../routing/current-routing.md)
+- _Add task-specific files here._
+
+## Unity Editor work
+
+- _Describe required Editor, Inspector, prefab, scene, UI, animation, input, or audio work._
+- Record exactly what was changed and which assets were touched.
+- If no Editor work is required, state `Not required`.
+
+## Play Mode verification
+
+- _Describe required Play Mode scenario(s), expected result, and actual result._
+- If Play Mode was not run, state: `Needs Unity Play Mode verification.`
+
+## Handoff trigger
+
+Stop and update `AI_WORKFLOW/handoffs/cursor-to-codex.md` if:
+
+- A script-level issue is discovered outside safe local Cursor scope.
+- The required fix becomes a code-only Codex task.
+- The task needs independent code review before more Unity asset work.
+
+## Expected final report
+
+Include:
+
+- Branch used
+- Files changed
+- Cursor-owned work completed
+- Behavior changed
+- Risk level
+- Unity Editor verification status
+- Play Mode verification status
+- Handoff created or not created
+- Inspector/prefab/scene assignments required
+- Assumptions, risks, and limitations

--- a/AI_WORKFLOW/routing/current-routing.md
+++ b/AI_WORKFLOW/routing/current-routing.md
@@ -1,0 +1,103 @@
+# Current Routing Decision
+
+Purpose: record ChatGPT's routing decision before work starts so Cursor and Codex can execute from repo-based command files.
+
+## Routing decision ID
+
+- `ROUTE-YYYYMMDD-001`
+
+## Source task
+
+- Intake file: [AI_WORKFLOW/inbox/task-intake.md](../inbox/task-intake.md)
+- Related issue / PR / branch:
+
+## Classification
+
+Choose one:
+
+- [ ] Cursor-owned
+- [ ] Codex-owned
+- [ ] Mixed
+- [ ] User decision required
+
+## Reasoning summary
+
+- _Why this owner and mode were selected._
+
+## First executor
+
+- _GPT / Cursor / Codex / User_
+
+## Second executor if needed
+
+- _GPT / Cursor / Codex / User / None_
+
+## Mode recommendation
+
+### Cursor
+
+Choose one when Cursor is involved:
+
+- [ ] Plan
+- [ ] Agent
+- [ ] Multitask
+- [ ] Not applicable
+
+### Codex
+
+Choose one when Codex is involved:
+
+- [ ] Plan
+- [ ] Agent
+- [ ] Review
+- [ ] Not applicable
+
+## Branch recommendation
+
+- Suggested branch:
+- Existing branch to use:
+
+## Active task update required
+
+- [ ] Yes
+- [ ] No
+
+## Handoff required now
+
+- [ ] Yes
+- [ ] No
+
+## Stop condition
+
+- _When the executor must stop instead of continuing._
+
+## Verification requirements
+
+### Code-level checks
+
+- _Examples: `dotnet build .ci/BeaverMania.CI.csproj`, targeted static review, no build required for docs-only changes._
+
+### Unity Editor checks
+
+- _Editor validation required or not required._
+
+### Play Mode checks
+
+- _Play Mode scenario required before claiming runtime behavior is fixed._
+
+### PR review checks
+
+- _Review focus, changed-file scope, regression risks, and final approval needs._
+
+## Next file to execute
+
+Choose one:
+
+- [ ] [AI_WORKFLOW/prompts/cursor-next.md](../prompts/cursor-next.md)
+- [ ] [AI_WORKFLOW/prompts/codex-next.md](../prompts/codex-next.md)
+- [ ] `AI_WORKFLOW/handoffs/cursor-to-codex.md`
+- [ ] `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+
+## Final approval owner
+
+- _User / GPT / Cursor / Codex / Maintainer_

--- a/AI_WORKFLOW/task-templates/bugfix-task.md
+++ b/AI_WORKFLOW/task-templates/bugfix-task.md
@@ -1,0 +1,63 @@
+# Bugfix Task Template
+
+## Bug title
+
+-
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Expected behavior
+
+-
+
+## Actual behavior
+
+-
+
+## Evidence
+
+- Video:
+- Screenshot:
+- Console log:
+- User report:
+
+## Suspected systems
+
+-
+
+## Codex investigation scope
+
+-
+
+## Cursor investigation scope
+
+-
+
+## Files/assets at risk
+
+-
+
+## Minimal fix principle
+
+- Smallest safe change that resolves the repro without broad behavior shifts.
+
+## Regression checks
+
+-
+
+## Verification checklist
+
+- Repro confirmed before fix.
+- Fix validated on target path.
+- Related gameplay/UI/audio/input regressions checked.
+- Remaining risks documented.
+
+## Handoff checklist
+
+- Active owner + phase updated in `AI_WORKFLOW/active-task.md`.
+- Cursor→Codex handoff created when script issue is suspected from Unity debugging.
+- Codex→Cursor handoff created when Editor/Inspector/scene follow-up is required.

--- a/AI_WORKFLOW/task-templates/feature-task.md
+++ b/AI_WORKFLOW/task-templates/feature-task.md
@@ -1,0 +1,73 @@
+# Feature Task Template
+
+## Feature name
+
+-
+
+## Player-facing goal
+
+-
+
+## Gameplay behavior
+
+- Trigger conditions:
+- In-game outcomes:
+- Failure/edge behavior:
+
+## Systems touched
+
+- Input:
+- Player/combat:
+- NPC/AI:
+- UI:
+- Audio:
+- Data/ScriptableObjects:
+- Scene/prefab integration:
+
+## Script work expected from Codex
+
+-
+
+## Unity integration expected from Cursor
+
+-
+
+## Data / ScriptableObject needs
+
+-
+
+## UI needs
+
+-
+
+## Animation/VFX/SFX needs
+
+-
+
+## Prefab/scene needs
+
+-
+
+## Acceptance criteria
+
+- [ ]
+
+## Verification checklist
+
+- Code compiles / static checks complete.
+- Required Inspector assignments applied.
+- Play Mode behavior matches acceptance criteria.
+- No critical regressions in related flows.
+
+## Handoff checklist
+
+- Ownership boundary documented in `AI_WORKFLOW/active-task.md`.
+- Required handoff file created if ownership changes.
+- Next owner and next action explicitly recorded.
+
+## Merge readiness checklist
+
+- Scope matches task intent.
+- Risks and limitations documented.
+- Verification evidence recorded.
+- User/Product Owner approval requested.

--- a/AI_WORKFLOW/task-templates/unity-verification.md
+++ b/AI_WORKFLOW/task-templates/unity-verification.md
@@ -1,0 +1,49 @@
+# Unity Verification Template
+
+## Scene to test
+
+-
+
+## Prefab(s) to inspect
+
+-
+
+## Inspector references to verify
+
+-
+
+## Play Mode checks
+
+-
+
+## UI checks
+
+-
+
+## Input checks
+
+-
+
+## Animation checks
+
+-
+
+## Audio checks
+
+-
+
+## Console checks
+
+-
+
+## Performance/FPS checks (if relevant)
+
+-
+
+## Result
+
+- Pass / Fail / Needs follow-up
+
+## Notes for Codex or Cursor
+
+-


### PR DESCRIPTION
### Motivation

- Introduce a lightweight, file-based routing/inbox layer to coordinate work handoffs between ChatGPT, Codex, and Cursor and reduce ambiguous ownership of Unity assets.
- Make ownership, handoffs, verification status, and merge readiness explicit to reduce Unity serialized-reference regressions.

### Description

- Add `AI_WORKFLOW/README.md` describing the workflow, communication, ownership, and routing inbox layer.
- Add routing and orchestration files: `AI_WORKFLOW/inbox/task-intake.md`, `AI_WORKFLOW/routing/current-routing.md`, and `AI_WORKFLOW/automation/README.md` to capture intake, routing decisions, and automation notes.
- Add reusable executor prompts: `AI_WORKFLOW/prompts/codex-next.md` and `AI_WORKFLOW/prompts/cursor-next.md` to standardize Codex- and Cursor-owned work execution and verification.
- Update `AGENTS.md` to reference the new lightweight routing inbox layer in `AI_WORKFLOW/README.md`.

### Testing

- No automated tests were run for this change because it is documentation-only and does not modify executable code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19dfdec418832abdfc0c74a3159a36)