### PR TITLE
chore: add AI workflow routing inbox and reset active-task template

### DIFF
--- a/AI_WORKFLOW/README.md
+++ b/AI_WORKFLOW/README.md
@@ -33,3 +33,10 @@
 - For cross-boundary work (scripts + Unity Editor), lock next owner explicitly in `active-task.md`.
 - Runtime Unity behavior claims require Play Mode verification.
 - Script-level validation alone is not sufficient for serialized wiring outcomes.
+
+## Routing Inbox Layer
+- Use `AI_WORKFLOW/inbox/task-intake.md` to capture raw requests, evidence, constraints, and initial owner guesses.
+- Use `AI_WORKFLOW/routing/current-routing.md` to record the routing decision, execution order, verification requirements, and stop condition.
+- Use `AI_WORKFLOW/prompts/cursor-next.md` for prepared Cursor execution instructions.
+- Use `AI_WORKFLOW/prompts/codex-next.md` for prepared Codex execution instructions.
+- See `AI_WORKFLOW/automation/README.md` for the semi-automatic ChatGPT → GitHub/AI_WORKFLOW → Codex/Cursor pipeline.

--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -1,66 +1,54 @@
 # Active Task
 
 ## Task title
-- UI/UX and game-feel improvements
+- TBD
 
 ## Type
-- Feature
+- Feature / Bugfix / Review / Refactor / Documentation / Release
 
 ## Owner
-- Mixed (code complete; Unity verification pending)
+- User / Codex / Cursor / Mixed
 
 ## Current phase
-- Verification and merge readiness
+- TBD
 
 ## Goal
-- Improve HUD clarity, tips, objectives, footstep feedback, and carried-log game feel without replacing pause, input, movement, or combat systems.
+- TBD
 
 ## Scope
-- All five implementation phases (HUD, tips, objectives, footsteps, log weight) plus pause-menu collectibles summary.
+- TBD
 
 ## Out of scope
-- Scene placement of `TipTriggerZone` until Unity Editor follow-up.
-- Combat-speed penalty wiring (`GroundBeat`/`AirBeat` are not attack gates).
-- Dialogue, shop, animation, and input-action rewrites.
+- TBD
 
 ## Relevant files/assets
-- `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
-- `Assets/Scripts/Player/BeaverPlayerBehaviour.cs`, `Carry.cs`, `SoundScripts/AudioScript.cs`
-- `Assets/Scripts/UI/UIMenu.cs`, `DebugReference.cs`, `Menus/PauseCollectiblesSummary.cs`
-- `Assets/Scripts/UI/Tips/*`, `Assets/Scripts/Data/Tips/*`
-- `Assets/Scripts/UI/Objectives/ObjectiveTrackerPresenter.cs`
-- `Assets/Scripts/Display/FootstepVfxEmitter.cs`, `Assets/Scripts/Data/Display/FootstepSurfaceEffectProfile.cs`
-- `Assets/Scripts/Objects/Newbridge/NewConstructor.cs`
+- TBD
 
 ## Risk level
-- High (prefab + runtime UI + movement penalties)
+- Low / Medium / High
 
 ## Branch
-- `cursor/feature-ui-ux-gamefeel-improvements-75e4` (local commits present; remote upstream deleted — re-push before PR)
+- TBD
 
 ## Codex responsibilities
-- Done: script-level implementation and handoff notes.
+- TBD
 
 ## Cursor responsibilities
-- Run Unity Play Mode checklist (below).
-- Re-push branch and open/refresh PR if merging.
+- TBD
 
 ## Required verification
-- Code-level: `dotnet build .ci/BeaverMania.CI.csproj` (requires Unity managed DLL paths on the machine; failed locally without Unity install — use Unity Editor compile or CI with Unity refs).
-- Unity Editor / Play Mode: Level 1 Remastered, `PlayerCanvas`, pause/tips/objectives/footsteps/carry flows.
+- Code-level: TBD
+- Unity Editor / Play Mode: TBD
 
 ## Current status
-- Phase 1–5 implementation complete on branch.
-- Pause-menu collectibles summary implemented.
-- PR review fixes applied (bridge hint, footstep material/player gating, carry rebase/penalty readout).
+- TBD
 
 ## Next action
-- Owner: User / Unity Editor
-- Action: Complete Play Mode checklist; re-push branch; merge when verified.
+- Owner: TBD
+- Action: TBD
 
 ## Open questions
-- Hide compact HUD collectibles after pause summary is accepted?
-- Which scenes get authored `TipDefinition` + `TipTriggerZone` placements?
+- TBD
 
 ## Handoff needed
-- No further code handoff unless Play Mode finds regressions.
+- Yes / No

--- a/AI_WORKFLOW/automation/README.md
+++ b/AI_WORKFLOW/automation/README.md
@@ -1,0 +1,20 @@
+# AI Workflow Automation
+
+This repository uses a semi-automatic routing pipeline:
+
+- ChatGPT is the router/orchestrator.
+- GitHub plus `AI_WORKFLOW/` acts as the command bus and shared memory.
+- Codex and Cursor execute from prepared repo files instead of reinterpreting the original task.
+- The user still manually launches Codex or Cursor when needed, but does not need to rethink or rewrite the task.
+- Full remote execution of Cursor from ChatGPT is not assumed.
+- Unity Play Mode remains the source of truth for runtime and editor verification.
+
+## Practical flow
+
+1. User describes task to ChatGPT.
+2. ChatGPT fills or proposes `AI_WORKFLOW/inbox/task-intake.md`.
+3. ChatGPT writes `AI_WORKFLOW/routing/current-routing.md`.
+4. ChatGPT prepares `AI_WORKFLOW/prompts/cursor-next.md` and/or `AI_WORKFLOW/prompts/codex-next.md`.
+5. User launches the selected tool and tells it to execute the matching prompt file.
+6. Tool updates the handoff file or final report.
+7. ChatGPT reviews the PR/output and routes the next step.

--- a/AI_WORKFLOW/inbox/task-intake.md
+++ b/AI_WORKFLOW/inbox/task-intake.md
@@ -1,0 +1,41 @@
+# Task Intake
+
+## Raw user request
+- TBD
+
+## Task type
+- Feature / Bugfix / Review / Refactor / Documentation / Release / Unknown
+
+## Problem / goal
+- TBD
+
+## Observed behavior
+- TBD
+
+## Expected behavior
+- TBD
+
+## Evidence
+- Video: TBD
+- Screenshot: TBD
+- Console log: TBD
+- Files: TBD
+- User report: TBD
+
+## Constraints
+- TBD
+
+## Known affected systems
+- TBD
+
+## Risk notes
+- TBD
+
+## Desired outcome
+- TBD
+
+## Deadline / priority
+- TBD
+
+## Initial owner guess
+- GPT / Codex / Cursor / Mixed / Unknown

--- a/AI_WORKFLOW/prompts/codex-next.md
+++ b/AI_WORKFLOW/prompts/codex-next.md
@@ -1,0 +1,53 @@
+# Codex Next Prompt
+
+## Task summary
+- Read `AGENTS.md`.
+- Read `AI_WORKFLOW/README.md`.
+- Read `AI_WORKFLOW/active-task.md`.
+- Read `AI_WORKFLOW/routing/current-routing.md`.
+- Execute only the Codex-owned part of the task.
+
+## Codex ownership
+- Own script/code changes, documentation, code-level review, diff analysis, and PR-ready summaries when routed to Codex.
+
+## Allowed scope
+- Prefer minimal script/code changes.
+- Preserve Unity serialized references.
+- Work only inside the scope assigned in `AI_WORKFLOW/active-task.md` and `AI_WORKFLOW/routing/current-routing.md`.
+
+## Forbidden scope
+- Do not execute Cursor-owned Unity Editor work.
+- Avoid scene, prefab, animation, and UI YAML edits.
+- Do not rename or remove serialized fields unless migration is explicitly in scope.
+- Do not claim Unity runtime behavior is fixed without Play Mode verification.
+
+## Required files to inspect
+- `AGENTS.md`
+- `AI_WORKFLOW/README.md`
+- `AI_WORKFLOW/active-task.md`
+- `AI_WORKFLOW/routing/current-routing.md`
+- Any task-specific files listed in the active task or routing decision.
+
+## Implementation / review instructions
+- Keep changes focused on the routed task.
+- Avoid unrelated cleanup.
+- State assumptions, Unity serialization risks, and manual follow-up requirements.
+
+## Code-level verification
+- Run available code-level validation if applicable.
+- For C# changes, prefer `cd /workspace/BeaverMania/.ci && dotnet build BeaverMania.CI.csproj` when the environment supports it.
+- State when Unity Play Mode verification is still required.
+
+## Handoff trigger
+- If code changes require Inspector, prefab, scene, UI, animation, audio, or Play Mode follow-up, update `AI_WORKFLOW/handoffs/codex-to-cursor.md`.
+- Include changed files, required Unity checks, expected runtime behavior, and risk notes.
+
+## Expected final report
+- Changed files.
+- Behavior changed.
+- Risk level.
+- Code-level verification performed.
+- Unity Play Mode verification status.
+- Inspector or prefab assignments required.
+- Assumptions, risks, and limitations.
+- Next owner and next action.

--- a/AI_WORKFLOW/prompts/cursor-next.md
+++ b/AI_WORKFLOW/prompts/cursor-next.md
@@ -1,0 +1,51 @@
+# Cursor Next Prompt
+
+## Task summary
+- Read `AGENTS.md`.
+- Read `AI_WORKFLOW/README.md`.
+- Read `AI_WORKFLOW/active-task.md`.
+- Read `AI_WORKFLOW/routing/current-routing.md`.
+- Execute only the Cursor-owned part of the task.
+
+## Cursor ownership
+- Own Unity Editor integration, scene/prefab/UI/animation/input/audio wiring, Inspector assignments, and visual/runtime verification when explicitly routed to Cursor.
+
+## Allowed scope
+- Work only inside the scope assigned in `AI_WORKFLOW/active-task.md` and `AI_WORKFLOW/routing/current-routing.md`.
+- Prefer Plan mode for Unity scene, prefab, UI, animation, input, audio, or multi-system tasks.
+- Use Agent only for narrow, clearly scoped implementation.
+
+## Forbidden scope
+- Do not execute Codex-owned work.
+- Do not make broad C# refactors.
+- Do not edit Unity assets outside explicit scope.
+- Do not claim runtime behavior is fixed without Play Mode verification.
+
+## Required files to inspect
+- `AGENTS.md`
+- `AI_WORKFLOW/README.md`
+- `AI_WORKFLOW/active-task.md`
+- `AI_WORKFLOW/routing/current-routing.md`
+- Any task-specific files listed in the active task or routing decision.
+
+## Unity Editor work
+- Record every scene, prefab, UI hierarchy, Animator, animation, audio, or Inspector asset touched.
+- Preserve serialized references unless the active task explicitly requires a change.
+
+## Play Mode verification
+- Record Unity verification status.
+- Document tested scene(s), scenario(s), expected result, actual result, and remaining gaps.
+- State clearly when Play Mode was not run or was blocked.
+
+## Handoff trigger
+- If a script-level issue is discovered outside safe local scope, stop and update `AI_WORKFLOW/handoffs/cursor-to-codex.md`.
+- Include reproduction details, suspected files, Unity evidence, and the exact next Codex action requested.
+
+## Expected final report
+- Changed files/assets.
+- Behavior changed.
+- Verification performed.
+- Play Mode status.
+- Inspector/prefab/scene assignments required.
+- Risks and limitations.
+- Next owner and next action.

--- a/AI_WORKFLOW/routing/current-routing.md
+++ b/AI_WORKFLOW/routing/current-routing.md
@@ -1,0 +1,50 @@
+# Current Routing Decision
+
+## Routing decision ID
+- TBD
+
+## Source task
+- TBD
+
+## Classification
+- Cursor-owned / Codex-owned / Mixed / User decision required
+
+## Reasoning summary
+- TBD
+
+## First executor
+- TBD
+
+## Second executor if needed
+- TBD
+
+## Mode recommendation
+- Cursor: Plan / Agent / Multitask
+- Codex: Plan / Agent / Review
+
+## Branch recommendation
+- TBD
+
+## Active task update required
+- Yes / No
+
+## Handoff required now
+- Yes / No
+
+## Stop condition
+- TBD
+
+## Verification requirements
+- Code-level checks: TBD
+- Unity Editor checks: TBD
+- Play Mode checks: TBD
+- PR review checks: TBD
+
+## Next file to execute
+- `AI_WORKFLOW/prompts/cursor-next.md`
+- `AI_WORKFLOW/prompts/codex-next.md`
+- `AI_WORKFLOW/handoffs/cursor-to-codex.md`
+- `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+
+## Final approval owner
+- TBD


### PR DESCRIPTION
### Motivation
- `AI_WORKFLOW/active-task.md` contained stale UI/game-feel task state and must be reset to a neutral reusable template to avoid carrying task-specific state between workflows.  
- Add a lightweight routing/inbox layer so ChatGPT can capture intake and produce deterministic routing decisions and prepared prompts for Codex/Cursor.  
- Keep all changes Markdown-only to avoid risk to Unity serialized assets, scenes, prefabs, scripts, or `.meta` files.  

### Description
- Reset `AI_WORKFLOW/active-task.md` to a neutral template containing fields for `Task title`, `Type`, `Owner`, `Current phase`, `Goal`, `Scope`, `Out of scope`, `Relevant files/assets`, `Risk level`, `Branch`, `Codex responsibilities`, `Cursor responsibilities`, `Required verification`, `Current status`, `Next action`, `Open questions`, and `Handoff needed`.  
- Added routing/inbox/automation artifacts: `AI_WORKFLOW/inbox/task-intake.md`, `AI_WORKFLOW/routing/current-routing.md`, `AI_WORKFLOW/prompts/cursor-next.md`, `AI_WORKFLOW/prompts/codex-next.md`, and `AI_WORKFLOW/automation/README.md`.  
- Updated `AI_WORKFLOW/README.md` to include a concise `Routing Inbox Layer` section referencing the new files while preserving existing content.  
- Branch created: `chore/ai-workflow-routing-inbox-clean`, and the commit contains only the listed Markdown files and changes.  

### Testing
- Verified presence of foundation files with a file-existence check and ensured no required foundations were removed, and the Markdown templates contain required headings via a Python sanity check which passed (`Markdown template sanity OK`).  
- Performed git checks including `git status --short --branch`, `git diff --name-only`, pattern checks for disallowed file types (scanned for `.unity`, `.prefab`, `.anim`, `.meta`, `.cs`, media files) which found none, and grep for stale task terms in `AI_WORKFLOW/active-task.md` which returned no matches; all checks passed.  
- Commit succeeded (`chore: add AI workflow routing inbox`) and final verification confirms changed files are limited to `AI_WORKFLOW/active-task.md`, `AI_WORKFLOW/README.md`, and the five new files listed above, Unity/editor/Play Mode was not run, and overall risk level is `Low`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ebc7c134832a8976cb08f207a842)