### PR TITLE
Add PlayerPack prefab builder

### DIFF
--- a/Assets/Editor/PlayerPackPrefabBuilder.cs
+++ b/Assets/Editor/PlayerPackPrefabBuilder.cs
@@ -1,0 +1,94 @@
+#if UNITY_EDITOR
+using Cinemachine;
+using UnityEditor;
+using UnityEngine;
+
+namespace Beavermania.EditorTools
+{
+    public static class PlayerPackPrefabBuilder
+    {
+        private const string PlayerPrefabPath = "Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab";
+        private const string PlayerPackPrefabPath = "Assets/Prefabs/OtterPlayer/PlayerPack.prefab";
+
+        [MenuItem("Beavermania/Build PlayerPack Prefab")]
+        public static void BuildPlayerPackPrefab()
+        {
+            GameObject root = null;
+
+            try
+            {
+                var playerPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(PlayerPrefabPath);
+                if (playerPrefab == null)
+                {
+                    Debug.LogError($"Player prefab not found: {PlayerPrefabPath}");
+                    return;
+                }
+
+                root = new GameObject("PlayerPack");
+
+                var player = (GameObject)PrefabUtility.InstantiatePrefab(playerPrefab);
+                player.name = playerPrefab.name;
+                player.transform.SetParent(root.transform, false);
+                player.transform.localPosition = Vector3.zero;
+                player.transform.localRotation = Quaternion.identity;
+                player.transform.localScale = Vector3.one;
+
+                var freeLook = player.GetComponentInChildren<CinemachineFreeLook>(true);
+                if (freeLook == null)
+                {
+                    Debug.LogError("No CinemachineFreeLook found in Player prefab instance.");
+                    return;
+                }
+
+                freeLook.Priority = 10;
+                freeLook.enabled = true;
+
+                var mainCamera = new GameObject("Main Camera");
+                mainCamera.tag = "MainCamera";
+                mainCamera.transform.SetParent(root.transform, false);
+
+                var camera = mainCamera.AddComponent<Camera>();
+                camera.enabled = true;
+                mainCamera.AddComponent<CinemachineBrain>();
+
+                if (!HasEnabledAudioListener(root))
+                {
+                    mainCamera.AddComponent<AudioListener>();
+                }
+
+                PrefabUtility.SaveAsPrefabAsset(root, PlayerPackPrefabPath, out var success);
+                if (!success)
+                {
+                    Debug.LogError($"Failed to save prefab: {PlayerPackPrefabPath}");
+                    return;
+                }
+
+                AssetDatabase.SaveAssets();
+                AssetDatabase.Refresh();
+                Debug.Log($"Saved {PlayerPackPrefabPath}");
+            }
+            finally
+            {
+                if (root != null)
+                {
+                    Object.DestroyImmediate(root);
+                }
+            }
+        }
+
+        private static bool HasEnabledAudioListener(GameObject root)
+        {
+            var listeners = root.GetComponentsInChildren<AudioListener>(true);
+            for (var i = 0; i < listeners.Length; i++)
+            {
+                if (listeners[i] != null && listeners[i].enabled)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}
+#endif

--- a/Assets/Editor/PlayerPackPrefabBuilder.cs.meta
+++ b/Assets/Editor/PlayerPackPrefabBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b9dba4a8a714386aa910f29f5dc5a45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
### Motivation
- Provide an Editor-only, API-driven way to create `Assets/Prefabs/OtterPlayer/PlayerPack.prefab` so the package can be produced without hand-editing YAML or touching serialized prefab files directly.
- Ensure the Player prefab instance contains a gameplay `CinemachineFreeLook` set as the live virtual camera and a scene-level `Main Camera` with `Camera` + `CinemachineBrain` and correct tag/AudioListener policy.

### Description
- Added `Assets/Editor/PlayerPackPrefabBuilder.cs` which exposes `Beavermania/Build PlayerPack Prefab` and programmatically instantiates `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab`, parents it under a `PlayerPack` root, and saves `Assets/Prefabs/OtterPlayer/PlayerPack.prefab` via `PrefabUtility.SaveAsPrefabAsset`.
- The builder locates the `CinemachineFreeLook` on the player instance, sets `Priority = 10` and enables it, creates a pack-level `Main Camera` GameObject with a `Camera` component, adds `CinemachineBrain`, tags it `MainCamera`, and only adds an `AudioListener` if no enabled listener exists under the root.
- Added meta file `Assets/Editor/PlayerPackPrefabBuilder.cs.meta` to preserve Unity import metadata for the editor script.

### Testing
- Attempted environment checks: Unity executable check `/opt/unity/Editor/Unity` failed because Unity is not installed in this environment, so no Editor validation could run (failed).
- Attempted CI compile via `dotnet build .ci/BeaverMania.CI.csproj` which failed because `dotnet` is not available in this environment (failed).
- Commit/verification commands run locally in the repo succeeded (`git add`/`git commit` recorded the new files), but runtime and compilation verification require a Unity Editor environment.

Changed files: `Assets/Editor/PlayerPackPrefabBuilder.cs`, `Assets/Editor/PlayerPackPrefabBuilder.cs.meta`.
Behavior changed: adds an Editor tool to generate `PlayerPack.prefab` containing the Player prefab instance and a pack-level Main Camera.
Risk level: medium-high due to touching player/camera/audio composition; runtime validation required.
Verification performed and what it proves: repo-level checks and commits succeeded, but no C# compile or Unity Editor execution was possible here.
Manual Unity verification steps: open Unity 2021.3.3f1 and run the menu `Beavermania > Build PlayerPack Prefab` or run batch mode `-executeMethod Beavermania.EditorTools.PlayerPackPrefabBuilder.BuildPlayerPackPrefab` and confirm `Assets/Prefabs/OtterPlayer/PlayerPack.prefab` contains one Player instance and a pack-level `Main Camera` with `Camera`, `CinemachineBrain`, tag `MainCamera`, and no duplicate enabled `AudioListener`.
Whether Inspector/prefab assignments are required: none expected after builder run, but Play Mode checks are required.
Assumptions, risks, and limitations: assumes `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` exists and contains a `CinemachineFreeLook`; needs Unity Editor compile and Play Mode verification to ensure runtime behavior and serialization are correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bda23a778832a9e70a31afd76490e)