### PR TITLE
Add player camera anchor targets

### DIFF
--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -24,7 +24,7 @@
 ## Inspector assignments required
 - On the player root/prefab, add `PlayerCameraAnchors` if not already present.
 - Assign `rootReference` to the stable player root reference used for camera follow.
-- Assign `faceReference` to a stable non-Cinemachine-target reference used only to position look anchors.
+- Optional: assign `faceReference` only to a stable non-animated reference; if unset, look anchors use their local offsets from `rootReference`.
 - Create/verify child hierarchy under player root:
   - `CameraAnchors`
   - `CameraAnchors/CameraFollowAnchor`
@@ -45,7 +45,7 @@
 
 ## Known limitations
 - Unity Editor/Play Mode was unavailable in this environment. Needs Unity Play Mode verification.
-- Runtime fallback creates missing anchor children if prefab wiring is absent, but serialized prefab hierarchy still needs Editor setup.
+- Runtime fallback creates missing anchor children and no longer defaults `faceReference` to `Face`; serialized prefab hierarchy still needs Editor setup.
 
 ## Risk notes
 - Player camera risk: Medium; gameplay camera target binding changed.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,6 +1,60 @@
 # Codex → Cursor Handoff
 
 ## Task
+- Player camera anchors: replace animated-bone/root Cinemachine targets with stable yaw-only anchor transforms.
+
+## Code changes made
+- Added `PlayerCameraAnchors` runtime component with `rootReference`, `faceReference`, `cameraFollowAnchor`, `gameplayLookAnchor`, and `closePovLookAnchor`.
+- `BeaverPlayerBehaviour` now binds gameplay `CinemachineFreeLook.m_Follow` to `CameraFollowAnchor` and `m_LookAt` to `GameplayLookAnchor` when anchors are available.
+- Close POV/crouch camera retargets to `ClosePovLookAnchor` instead of `Face`.
+- Boss dialogue camera restore retargets gameplay camera to `GameplayLookAnchor` instead of `Root`.
+
+## Files changed
+- `Assets/Scripts/Player/PlayerCameraAnchors.cs`
+- `Assets/Scripts/Player/PlayerCameraAnchors.cs.meta`
+- `Assets/Scripts/Player/BeaverPlayerBehaviour.cs`
+- `Assets/Scripts/Player/BossHandler.cs`
+- `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+
+## New or changed serialized fields
+- New serialized `PlayerCameraAnchors cameraAnchors` reference on `BeaverPlayerBehaviour`.
+- New public `Transform` fields on `PlayerCameraAnchors`: `rootReference`, `faceReference`, `cameraFollowAnchor`, `gameplayLookAnchor`, `closePovLookAnchor`.
+- No existing serialized fields were renamed or removed.
+
+## Inspector assignments required
+- On the player root/prefab, add `PlayerCameraAnchors` if not already present.
+- Assign `rootReference` to the stable player root reference used for camera follow.
+- Assign `faceReference` to a stable non-Cinemachine-target reference used only to position look anchors.
+- Create/verify child hierarchy under player root:
+  - `CameraAnchors`
+  - `CameraAnchors/CameraFollowAnchor`
+  - `CameraAnchors/GameplayLookAnchor`
+  - `CameraAnchors/ClosePovLookAnchor`
+- Assign the three anchor child transforms to the matching `PlayerCameraAnchors` fields.
+- Verify gameplay `CinemachineFreeLook` uses `CameraFollowAnchor` as Follow and `GameplayLookAnchor` as LookAt in Play Mode.
+
+## Prefab/scene/UI/Animator follow-up required
+- Apply the above player prefab/scene hierarchy changes in Unity Editor; Codex did not edit prefab YAML.
+- Do not assign `mixamorig:HeadTop_End`, `mixamorig:Head`, `Face`, `RootMovement`, spine bones, or other animated bones directly to active Cinemachine Follow/LookAt fields.
+
+## What Cursor should test in Play Mode
+- Enter gameplay scene, confirm FreeLook follow/look targets are the anchor children, not bones.
+- Move, sprint, crouch/close POV, and roll; confirm camera position/orientation remains stable and yaw-only/world-up.
+- Enter and exit boss/trader/dialogue camera states; confirm gameplay camera restores to anchor targets.
+- Check console for missing-reference or runtime-created-anchor warnings/errors.
+
+## Known limitations
+- Unity Editor/Play Mode was unavailable in this environment. Needs Unity Play Mode verification.
+- Runtime fallback creates missing anchor children if prefab wiring is absent, but serialized prefab hierarchy still needs Editor setup.
+
+## Risk notes
+- Player camera risk: Medium; gameplay camera target binding changed.
+- Serialization risk: Low-medium; new fields only, no renamed/removed fields.
+
+---
+
+
+## Task
 - UI/UX and game-feel improvements — Phase 1 HUD cleanup, Phase 2 tips, Phase 3 objective tracker, Phase 4 footstep feedback, Phase 5 carried-log weight
 
 ## Code changes made

--- a/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
+++ b/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
@@ -2735,9 +2735,6 @@ namespace Beavermania.Player
 
             if (cameraAnchors.rootReference == null)
                 cameraAnchors.rootReference = Root != null ? Root : transform;
-            if (cameraAnchors.faceReference == null)
-                cameraAnchors.faceReference = Face != null ? Face : cameraAnchors.rootReference;
-
             cameraAnchors.EnsureRuntimeAnchorHierarchy();
             BindGameplayCameraAnchors();
         }

--- a/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
+++ b/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
@@ -246,6 +246,7 @@ namespace Beavermania.Player
         bool loggedRuntimeHudStateFallback;
         public CinemachineFreeLook FreeLook;
         public CinemachineFreeLook CamForTraders;
+        [SerializeField] PlayerCameraAnchors cameraAnchors;
         [SerializeField] PlayerCheckpointRespawn checkpointRespawn;
         public float ChangeSpeech = 0.55f;
         Vector3 stableCameraForwardXZ = Vector3.forward;
@@ -254,6 +255,10 @@ namespace Beavermania.Player
         const float LookRotationEpsilon = 0.0001f;
 
         public PlayerCombatBalanceData CombatBalance => combatBalance;
+        public PlayerCameraAnchors CameraAnchors => cameraAnchors;
+        public Transform GameplayCameraFollowTarget => cameraAnchors != null ? cameraAnchors.GameplayFollowTarget : null;
+        public Transform GameplayCameraLookTarget => cameraAnchors != null ? cameraAnchors.GameplayLookTarget : null;
+        public Transform ClosePovCameraLookTarget => cameraAnchors != null ? cameraAnchors.ClosePovLookTarget : null;
 
         float EffectiveScorpionLightDamage => combatBalance != null ? combatBalance.scorpionLightDamage : 15f;
         float EffectiveScorpionHeavyDamage => combatBalance != null ? combatBalance.scorpionHeavyDamage : 30f;
@@ -1769,7 +1774,8 @@ namespace Beavermania.Player
 
         public void HideCursor()
         {
-            PlayerCursorRules.ApplyLockedHidden(FreeLook, Root);
+            BindGameplayCameraAnchors();
+            PlayerCursorRules.ApplyLockedHidden(FreeLook, GameplayCameraLookTarget);
         }
 
         public void ApplyTraderOfferPresentation(Transform traderLookTarget)
@@ -2109,6 +2115,7 @@ namespace Beavermania.Player
         {
             CacheMainCamera();
             BindHudState();
+            BindCameraAnchors();
             if (boostChargeController == null)
                 boostChargeController = GetComponent<Combat.BoostChargeController>();
             if (arrowModel != null)
@@ -2388,9 +2395,9 @@ namespace Beavermania.Player
             {
             //Crouch action - Place Logs
             {
-                if (PlayerInputReader.IsRollHeld() && FreeLook.m_Lens.FieldOfView<20)
+                if (PlayerInputReader.IsRollHeld() && FreeLook != null && FreeLook.m_Lens.FieldOfView<20)
                 {
-                    FreeLook.m_LookAt = Face;
+                    FreeLook.m_LookAt = ClosePovCameraLookTarget;
                 }
 
                 if (PlayerInputReader.IsRollHeld() && grounded == true && Rolling == false && !PlayerInputReader.IsJumpHeld())
@@ -2716,6 +2723,39 @@ namespace Beavermania.Player
             {
                 keepLooking = false;
             }
+        }
+
+
+        void BindCameraAnchors()
+        {
+            if (cameraAnchors == null)
+                cameraAnchors = GetComponent<PlayerCameraAnchors>();
+            if (cameraAnchors == null)
+                cameraAnchors = gameObject.AddComponent<PlayerCameraAnchors>();
+
+            if (cameraAnchors.rootReference == null)
+                cameraAnchors.rootReference = Root != null ? Root : transform;
+            if (cameraAnchors.faceReference == null)
+                cameraAnchors.faceReference = Face != null ? Face : cameraAnchors.rootReference;
+
+            cameraAnchors.EnsureRuntimeAnchorHierarchy();
+            BindGameplayCameraAnchors();
+        }
+
+        void BindGameplayCameraAnchors()
+        {
+            if (cameraAnchors == null)
+                return;
+
+            cameraAnchors.UpdateAnchors();
+
+            if (FreeLook == null)
+                return;
+
+            if (cameraAnchors.GameplayFollowTarget != null)
+                FreeLook.m_Follow = cameraAnchors.GameplayFollowTarget;
+            if (cameraAnchors.GameplayLookTarget != null)
+                FreeLook.m_LookAt = cameraAnchors.GameplayLookTarget;
         }
 
         void CacheMainCamera()

--- a/Assets/Scripts/Player/BossHandler.cs
+++ b/Assets/Scripts/Player/BossHandler.cs
@@ -59,8 +59,8 @@ namespace Beavermania.Player.Combat
                 player.FreeLook.m_Orbits[1].m_Radius = 6;
                 player.FreeLook.m_XAxis.m_MaxSpeed = 300;
                 player.FreeLook.m_YAxis.m_MaxSpeed = 2;
-                if (player.Root != null)
-                    player.FreeLook.m_LookAt = player.Root;
+                if (player.GameplayCameraLookTarget != null)
+                    player.FreeLook.m_LookAt = player.GameplayCameraLookTarget;
             }
         }
 

--- a/Assets/Scripts/Player/PlayerCameraAnchors.cs
+++ b/Assets/Scripts/Player/PlayerCameraAnchors.cs
@@ -13,6 +13,8 @@ namespace Beavermania.Player
         const string FollowAnchorName = "CameraFollowAnchor";
         const string GameplayLookAnchorName = "GameplayLookAnchor";
         const string ClosePovLookAnchorName = "ClosePovLookAnchor";
+        static readonly Vector3 DefaultGameplayLookOffset = new Vector3(0f, 1.25f, 0f);
+        static readonly Vector3 DefaultClosePovLookOffset = new Vector3(0f, 1.45f, 0f);
 
         public Transform rootReference;
         public Transform faceReference;
@@ -51,6 +53,8 @@ namespace Beavermania.Player
             cameraFollowAnchor = FindOrCreateChild(container, FollowAnchorName);
             gameplayLookAnchor = FindOrCreateChild(container, GameplayLookAnchorName);
             closePovLookAnchor = FindOrCreateChild(container, ClosePovLookAnchorName);
+            InitializeLocalPosition(gameplayLookAnchor, DefaultGameplayLookOffset);
+            InitializeLocalPosition(closePovLookAnchor, DefaultClosePovLookOffset);
             UpdateAnchors();
         }
 
@@ -68,12 +72,12 @@ namespace Beavermania.Player
         public void UpdateAnchors()
         {
             var root = rootReference != null ? rootReference : transform;
-            var face = faceReference != null ? faceReference : root;
+            var stableLookReference = IsUnsafeAnimatedReference(faceReference) ? null : faceReference;
             var yawRotation = ResolveYawRotation(root);
 
             SetAnchor(cameraFollowAnchor, root.position, yawRotation);
-            SetAnchor(gameplayLookAnchor, face.position, yawRotation);
-            SetAnchor(closePovLookAnchor, face.position, yawRotation);
+            SetAnchor(gameplayLookAnchor, ResolveLookPosition(root, stableLookReference, DefaultGameplayLookOffset), yawRotation);
+            SetAnchor(closePovLookAnchor, ResolveLookPosition(root, stableLookReference, DefaultClosePovLookOffset), yawRotation);
         }
 
         void ResolveExistingAnchors()
@@ -90,10 +94,37 @@ namespace Beavermania.Player
                 closePovLookAnchor = container.Find(ClosePovLookAnchorName);
         }
 
+        static void InitializeLocalPosition(Transform anchor, Vector3 fallbackLocalPosition)
+        {
+            if (anchor != null && anchor.localPosition.sqrMagnitude < 0.000001f)
+                anchor.localPosition = fallbackLocalPosition;
+        }
+
+        static Vector3 ResolveLookPosition(Transform root, Transform stableLookReference, Vector3 fallbackLocalOffset)
+        {
+            if (stableLookReference != null)
+                return stableLookReference.position;
+
+            return root != null ? root.TransformPoint(fallbackLocalOffset) : fallbackLocalOffset;
+        }
+
         static void SetAnchor(Transform anchor, Vector3 position, Quaternion rotation)
         {
             if (anchor != null)
                 anchor.SetPositionAndRotation(position, rotation);
+        }
+
+        static bool IsUnsafeAnimatedReference(Transform reference)
+        {
+            if (reference == null)
+                return false;
+
+            var name = reference.name;
+            return name == "Face"
+                || name == "RootMovement"
+                || name == "mixamorig:Head"
+                || name == "mixamorig:HeadTop_End"
+                || name.IndexOf("spine", System.StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         Quaternion ResolveYawRotation(Transform root)

--- a/Assets/Scripts/Player/PlayerCameraAnchors.cs
+++ b/Assets/Scripts/Player/PlayerCameraAnchors.cs
@@ -1,0 +1,129 @@
+using UnityEngine;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Beavermania.Player
+{
+    [DisallowMultipleComponent]
+    public sealed class PlayerCameraAnchors : MonoBehaviour
+    {
+        const string ContainerName = "CameraAnchors";
+        const string FollowAnchorName = "CameraFollowAnchor";
+        const string GameplayLookAnchorName = "GameplayLookAnchor";
+        const string ClosePovLookAnchorName = "ClosePovLookAnchor";
+
+        public Transform rootReference;
+        public Transform faceReference;
+        public Transform cameraFollowAnchor;
+        public Transform gameplayLookAnchor;
+        public Transform closePovLookAnchor;
+
+        public Transform GameplayFollowTarget => cameraFollowAnchor;
+        public Transform GameplayLookTarget => gameplayLookAnchor;
+        public Transform ClosePovLookTarget => closePovLookAnchor != null ? closePovLookAnchor : gameplayLookAnchor;
+
+        void Reset()
+        {
+            rootReference = transform;
+            ResolveExistingAnchors();
+        }
+
+        void OnValidate()
+        {
+            if (rootReference == null)
+                rootReference = transform;
+
+            ResolveExistingAnchors();
+            UpdateAnchors();
+        }
+
+        void LateUpdate()
+        {
+            UpdateAnchors();
+        }
+
+        [ContextMenu("Create Missing Camera Anchor Hierarchy")]
+        public void CreateMissingAnchorHierarchy()
+        {
+            var container = FindOrCreateChild(transform, ContainerName);
+            cameraFollowAnchor = FindOrCreateChild(container, FollowAnchorName);
+            gameplayLookAnchor = FindOrCreateChild(container, GameplayLookAnchorName);
+            closePovLookAnchor = FindOrCreateChild(container, ClosePovLookAnchorName);
+            UpdateAnchors();
+        }
+
+        public void EnsureRuntimeAnchorHierarchy()
+        {
+            if (rootReference == null)
+                rootReference = transform;
+
+            if (cameraFollowAnchor == null || gameplayLookAnchor == null || closePovLookAnchor == null)
+                CreateMissingAnchorHierarchy();
+            else
+                UpdateAnchors();
+        }
+
+        public void UpdateAnchors()
+        {
+            var root = rootReference != null ? rootReference : transform;
+            var face = faceReference != null ? faceReference : root;
+            var yawRotation = ResolveYawRotation(root);
+
+            SetAnchor(cameraFollowAnchor, root.position, yawRotation);
+            SetAnchor(gameplayLookAnchor, face.position, yawRotation);
+            SetAnchor(closePovLookAnchor, face.position, yawRotation);
+        }
+
+        void ResolveExistingAnchors()
+        {
+            var container = transform.Find(ContainerName);
+            if (container == null)
+                return;
+
+            if (cameraFollowAnchor == null)
+                cameraFollowAnchor = container.Find(FollowAnchorName);
+            if (gameplayLookAnchor == null)
+                gameplayLookAnchor = container.Find(GameplayLookAnchorName);
+            if (closePovLookAnchor == null)
+                closePovLookAnchor = container.Find(ClosePovLookAnchorName);
+        }
+
+        static void SetAnchor(Transform anchor, Vector3 position, Quaternion rotation)
+        {
+            if (anchor != null)
+                anchor.SetPositionAndRotation(position, rotation);
+        }
+
+        Quaternion ResolveYawRotation(Transform root)
+        {
+            var forward = root != null ? root.forward : transform.forward;
+            forward.y = 0f;
+
+            if (forward.sqrMagnitude < 0.000001f)
+                forward = transform.forward;
+            forward.y = 0f;
+
+            if (forward.sqrMagnitude < 0.000001f)
+                forward = Vector3.forward;
+
+            return Quaternion.LookRotation(forward.normalized, Vector3.up);
+        }
+
+        static Transform FindOrCreateChild(Transform parent, string childName)
+        {
+            var child = parent.Find(childName);
+            if (child != null)
+                return child;
+
+            var childObject = new GameObject(childName);
+#if UNITY_EDITOR
+            if (!Application.isPlaying)
+                Undo.RegisterCreatedObjectUndo(childObject, $"Create {childName}");
+#endif
+            childObject.transform.SetParent(parent, false);
+            return childObject.transform;
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerCameraAnchors.cs.meta
+++ b/Assets/Scripts/Player/PlayerCameraAnchors.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 939d14b0afb74aa6bb2c7ad3db5f0ed9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Replace animated/bone Cinemachine targets with stable yaw-only anchor transforms to avoid camera jitter and prevent using animated bones like `mixamorig:Head`, `Face`, `RootMovement`, or spine bones as active camera targets.
- Provide a runtime-safe fallback that creates/updates anchor children when prefab wiring is missing so scenes don't break at runtime.

### Description
- Add `PlayerCameraAnchors` (`Assets/Scripts/Player/PlayerCameraAnchors.cs`) exposing `rootReference`, `faceReference`, `cameraFollowAnchor`, `gameplayLookAnchor`, and `closePovLookAnchor`, plus a context-menu/runtime method to create the `CameraAnchors` child hierarchy and an `UpdateAnchors()` method that forces yaw-only/world-up orientation.
- Wire `BeaverPlayerBehaviour` to hold a serialized `cameraAnchors` reference and new helpers (`BindCameraAnchors()` / `BindGameplayCameraAnchors()`) that set `CinemachineFreeLook.m_Follow` to `CameraFollowAnchor` and `m_LookAt` to `GameplayLookAnchor`, and route close-POV/crouch logic to `ClosePovLookAnchor`.
- Replace direct gameplay/boss retargeting to `Root`/`Face` with anchor-based targets (updated `BossHandler` to use `GameplayCameraLookTarget`).
- Record required Unity Editor follow-up in the Codex → Cursor handoff (`AI_WORKFLOW/handoffs/codex-to-cursor.md`) and ensure no existing serialized fields were renamed or removed.

### Testing
- Ran `git diff --check`, which reported no whitespace/conflict errors and succeeded. 
- Searched for camera target assignments with `rg` (`m_LookAt` / `m_Follow` patterns) to verify retargets, and the grep checks succeeded. 
- `dotnet build` was not run because `dotnet` is not available in this environment, so full C# compilation check was not performed. 
- Unity Editor / Play Mode verification was not possible here because the Unity binary is not present and must be performed manually in the Editor to confirm prefab hierarchy and runtime camera behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be1bbe43c832a8391d45db42952cc)