### PR TITLE
Set FreeLook Cinemachine binding mode to Lock To Target No Roll

### DIFF
--- a/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
+++ b/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
@@ -30989,7 +30989,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_BindingMode: 0
+  m_BindingMode: 2
   m_FollowOffset: {x: 0, y: 2.3, z: -6}
   m_XDamping: 2
   m_YDamping: 1.5
@@ -31601,7 +31601,7 @@ MonoBehaviour:
     m_RecenteringTime: 2
     m_LegacyHeadingDefinition: -1
     m_LegacyVelocityFilterStrength: -1
-  m_BindingMode: 0
+  m_BindingMode: 2
   m_SplineCurvature: 0.359
   m_Orbits:
   - m_Height: 4.5
@@ -31673,7 +31673,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_BindingMode: 0
+  m_BindingMode: 2
   m_FollowOffset: {x: 0, y: 2.3, z: -6}
   m_XDamping: 2
   m_YDamping: 1.5
@@ -31800,7 +31800,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9384ab8608cdc3d479fe89cd51eed48f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_BindingMode: 0
+  m_BindingMode: 2
   m_FollowOffset: {x: 0, y: 2.3, z: -6}
   m_XDamping: 2
   m_YDamping: 1.5


### PR DESCRIPTION
### Motivation
- Stabilize the gameplay camera by forcing the Cinemachine FreeLook and its rig transposers to `Lock To Target No Roll` to avoid unwanted roll during player movement.

### Description
- Edited `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` to set `m_BindingMode: 2` on the FreeLook component and all three rig `OrbitalTransposer` entries.
- Confirmed FreeLook `m_Lens.Dutch` remains `0` and `PlayerPack` does not contain a binding-mode override.
- Risk: High because a player prefab serialized asset was modified; no script or `.meta` GUIDs were changed.

### Testing
- Ran `git diff --check` with no reported issues.
- Executed Python verification that confirmed FreeLook and three rigs have `m_BindingMode: 2` and FreeLook Lens `Dutch: 0`, and that `PlayerPack` has no `m_BindingMode` override (passed).
- Attempted Unity batch-mode prefab edit and `dotnet build` but the environment lacked `/opt/unity/Editor/Unity` and `dotnet`, so Unity prefab workflow and Play Mode verification remain required before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bec2b5ef0832aa519c59fd0eb6f87)