### PR TITLE
Move active AudioListener from Player root to PlayerPack Main Camera

### DIFF
--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -6,18 +6,22 @@
 ## Files changed
 - `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab`
 - `Assets/Prefabs/OtterPlayer/PlayerPack.prefab`
+- `Assets/Scenes/ShadowRevenantTestArena.unity`
+- `Assets/Scenes/Level 1 - Remastered - Steam.unity`
 - `AI_WORKFLOW/handoffs/codex-to-cursor.md`
 
 ## Prefab changes made
 - Disabled the root `Player` `AudioListener` in `Player.prefab`.
 - Added/enabled one `AudioListener` on `PlayerPack/Main Camera` in `PlayerPack.prefab`.
+- Kept direct-`Player` scenes covered by overriding the prefab listener enabled in `ShadowRevenantTestArena.unity` and `Level 1 - Remastered - Steam.unity`.
 
 ## Inspector assignments required
 - None expected.
 
 ## What Cursor should test in Play Mode
 - Open the target test scene using `PlayerPack`.
-- Enter Play Mode and confirm exactly one active `AudioListener` is present.
+- Open `ShadowRevenantTestArena.unity` and `Level 1 - Remastered - Steam.unity`.
+- Enter Play Mode and confirm exactly one active `AudioListener` is present in each scene.
 - Confirm the Console has no duplicate `AudioListener` warning.
 - Confirm camera audio still follows `PlayerPack/Main Camera`.
 
@@ -25,7 +29,7 @@
 - Unity Editor/Play Mode was unavailable in this environment. Needs Unity Play Mode verification.
 
 ## Risk notes
-- Player/audio prefab risk: Medium; serialized prefab YAML changed in high-risk player assets, but only `AudioListener` enable/component state changed.
+- Player/audio prefab risk: Medium; serialized prefab/scene YAML changed in high-risk player assets/scenes, but only `AudioListener` enable/component state changed.
 
 ---
 

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,6 +1,36 @@
 # Codex → Cursor Handoff
 
 ## Task
+- AudioListener ownership: move active listener from root player prefab to PlayerPack/Main Camera.
+
+## Files changed
+- `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab`
+- `Assets/Prefabs/OtterPlayer/PlayerPack.prefab`
+- `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+
+## Prefab changes made
+- Disabled the root `Player` `AudioListener` in `Player.prefab`.
+- Added/enabled one `AudioListener` on `PlayerPack/Main Camera` in `PlayerPack.prefab`.
+
+## Inspector assignments required
+- None expected.
+
+## What Cursor should test in Play Mode
+- Open the target test scene using `PlayerPack`.
+- Enter Play Mode and confirm exactly one active `AudioListener` is present.
+- Confirm the Console has no duplicate `AudioListener` warning.
+- Confirm camera audio still follows `PlayerPack/Main Camera`.
+
+## Known limitations
+- Unity Editor/Play Mode was unavailable in this environment. Needs Unity Play Mode verification.
+
+## Risk notes
+- Player/audio prefab risk: Medium; serialized prefab YAML changed in high-risk player assets, but only `AudioListener` enable/component state changed.
+
+---
+
+
+## Task
 - Player camera anchors: replace animated-bone/root Cinemachine targets with stable yaw-only anchor transforms.
 
 ## Code changes made

--- a/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
+++ b/Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab
@@ -30209,7 +30209,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4580562239172740874}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!65 &6562972538239049110
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/OtterPlayer/PlayerPack.prefab
+++ b/Assets/Prefabs/OtterPlayer/PlayerPack.prefab
@@ -43,6 +43,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9001000000000000101}
   - component: {fileID: 9001000000000000102}
+  - component: {fileID: 9001000000000000104}
   - component: {fileID: 9001000000000000103}
   m_Layer: 0
   m_Name: Main Camera
@@ -109,6 +110,14 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!81 &9001000000000000104
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9001000000000000100}
+  m_Enabled: 1
 --- !u!114 &9001000000000000103
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 1 - Remastered - Steam.unity
+++ b/Assets/Scenes/Level 1 - Remastered - Steam.unity
@@ -7026,6 +7026,10 @@ PrefabInstance:
       propertyPath: m_YAxis.m_MaxSpeed
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8605846543303424432, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
 --- !u!114 &743935456 stripped

--- a/Assets/Scenes/ShadowRevenantTestArena.unity
+++ b/Assets/Scenes/ShadowRevenantTestArena.unity
@@ -175,6 +175,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 8605846543303424432, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5d8d44b62c5985c459198b5da41071a1, type: 3}
 --- !u!1001 &100100


### PR DESCRIPTION
### Motivation
- Prevent duplicate `AudioListener` warnings when scenes instantiate the player prefab by moving the active listener to the camera owner (`PlayerPack/Main Camera`).
- Ensure audio follows the camera hierarchy used by runtime `PlayerPack` instances instead of the player root.

### Description
- Disabled the root `AudioListener` in `Assets/Prefabs/OtterPlayer/Otter_Shapekeys/Player.prefab` by setting its `m_Enabled` to `0`.
- Added an `AudioListener` component to `Assets/Prefabs/OtterPlayer/PlayerPack.prefab` on the `Main Camera` and appended it to the camera's component list so the camera has one enabled listener.
- Updated `AI_WORKFLOW/handoffs/codex-to-cursor.md` with a Codex→Cursor handoff describing the prefab change and the required Unity Play Mode verification steps.

### Testing
- Ran `git diff --check` with no whitespace/format issues reported.
- Ran a custom Python prefab parser that confirmed `Player.prefab` has the `AudioListener` disabled and `PlayerPack.prefab` has an enabled `AudioListener` on `PlayerPack/Main Camera` (expected state matched).
- Attempted `dotnet build` and `Unity -version` checks but `dotnet` and the Unity Editor were unavailable in this environment, so Play Mode verification was not possible and remains required (Needs Unity Play Mode verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bee7e90d8832a8973443fef8150fb)