### PR TITLE
Preserve FreeLook.m_LookAt when locking cursor; use gameplay anchor

### DIFF
--- a/Assets/Scripts/Display/PlayerCursorRules.cs
+++ b/Assets/Scripts/Display/PlayerCursorRules.cs
@@ -9,7 +9,7 @@ namespace Beavermania.Display
     public interface IPlayerCursorPresentation
     {
         void ApplyUnlockedVisible();
-        void ApplyLockedHidden(Transform root);
+        void ApplyLockedHidden(Transform lookTarget = null);
     }
 
     /// <summary>Cinemachine-backed implementation; safe if <see cref="CinemachineFreeLook"/> is null (cursor still locks).</summary>
@@ -24,8 +24,8 @@ namespace Beavermania.Display
 
         public void ApplyUnlockedVisible() => PlayerCursorPresentationCore.ApplyUnlockedVisible();
 
-        public void ApplyLockedHidden(Transform root) =>
-            PlayerCursorPresentationCore.ApplyLockedHidden(freeLook, root);
+        public void ApplyLockedHidden(Transform lookTarget = null) =>
+            PlayerCursorPresentationCore.ApplyLockedHidden(freeLook, lookTarget);
     }
 
     /// <summary>Static entry points for call sites that pass <see cref="CinemachineFreeLook"/> each time.</summary>
@@ -33,8 +33,8 @@ namespace Beavermania.Display
     {
         public static void ApplyUnlockedVisible() => PlayerCursorPresentationCore.ApplyUnlockedVisible();
 
-        public static void ApplyLockedHidden(CinemachineFreeLook freeLook, Transform root) =>
-            PlayerCursorPresentationCore.ApplyLockedHidden(freeLook, root);
+        public static void ApplyLockedHidden(CinemachineFreeLook freeLook, Transform lookTarget = null) =>
+            PlayerCursorPresentationCore.ApplyLockedHidden(freeLook, lookTarget);
     }
 
     static class PlayerCursorPresentationCore
@@ -45,10 +45,10 @@ namespace Beavermania.Display
             Cursor.visible = true;
         }
 
-        internal static void ApplyLockedHidden(CinemachineFreeLook freeLook, Transform root)
+        internal static void ApplyLockedHidden(CinemachineFreeLook freeLook, Transform lookTarget = null)
         {
-            if (freeLook != null && root != null)
-                freeLook.m_LookAt = root;
+            if (freeLook != null && lookTarget != null)
+                freeLook.m_LookAt = lookTarget;
 
             Cursor.lockState = CursorLockMode.Locked;
             Cursor.visible = false;

--- a/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
+++ b/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
@@ -1775,7 +1775,10 @@ namespace Beavermania.Player
         public void HideCursor()
         {
             BindGameplayCameraAnchors();
-            PlayerCursorRules.ApplyLockedHidden(FreeLook, GameplayCameraLookTarget);
+            var lookTarget = GameplayCameraLookTarget != null
+                ? GameplayCameraLookTarget
+                : FreeLook != null ? FreeLook.m_LookAt : null;
+            PlayerCursorRules.ApplyLockedHidden(FreeLook, lookTarget);
         }
 
         public void ApplyTraderOfferPresentation(Transform traderLookTarget)

--- a/Assets/Scripts/Player/Components/PlayerCursorController.cs
+++ b/Assets/Scripts/Player/Components/PlayerCursorController.cs
@@ -27,7 +27,7 @@ namespace Beavermania.Player
         public void HideCursor()
         {
             EnsurePresentation();
-            presentation.ApplyLockedHidden(Root);
+            presentation.ApplyLockedHidden(FreeLook != null ? FreeLook.m_LookAt : null);
         }
 
         void EnsurePresentation()


### PR DESCRIPTION
### Motivation
- Prevent cursor lock/visibility from forcing `CinemachineFreeLook.m_LookAt` to the player root and prefer a stable gameplay look anchor when available.

### Description
- Changed `PlayerCursorRules.ApplyLockedHidden` to accept an optional `Transform lookTarget` and only set `freeLook.m_LookAt` when a non-null target is provided (`Assets/Scripts/Display/PlayerCursorRules.cs`).
- Updated `BeaverPlayerBehaviour.HideCursor()` to pass `GameplayCameraLookTarget` when present or preserve the existing `FreeLook.m_LookAt` fallback (`Assets/Scripts/Player/BeaverPlayerBehaviour.cs`).
- Updated `PlayerCursorController.HideCursor()` to preserve the current `FreeLook.m_LookAt` instead of passing the player `Root` (`Assets/Scripts/Player/Components/PlayerCursorController.cs`).

### Testing
- Ran `git diff --check` with no issues reported.
- Attempted `cd /workspace/BeaverMania/.ci && dotnet build BeaverMania.CI.csproj` but it failed due to `dotnet` not being available in the environment, so C# compilation check could not be completed.
- Note: changes are script-only and require Unity Play Mode verification for runtime camera/anchor behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bf65b56d0832a93a931b93a9cd7d6)