### PR TITLE
Fix Shadow Revenant shade rigidbody movement

### DIFF
--- a/Assets/Eden/Terrain/Ground1.terrainlayer
+++ b/Assets/Eden/Terrain/Ground1.terrainlayer
@@ -6,15 +6,9 @@ TerrainLayer:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-<<<<<<<< HEAD:Beavermania/Assets/NewLayer 5.terrainlayer
-  m_Name: NewLayer 5
-  m_DiffuseTexture: {fileID: 2800000, guid: 1edc7cc525f7299418b71823a99a9776, type: 3}
-  m_NormalMapTexture: {fileID: 2800000, guid: f857da3d8b701944baaf2af770407084, type: 3}
-========
   m_Name: Ground1
   m_DiffuseTexture: {fileID: 2800000, guid: 42df4504925e3c6428d6c62cdba23147, type: 3}
   m_NormalMapTexture: {fileID: 2800000, guid: 4461133173c4c6f4699bb1d9e2d83ba4, type: 3}
->>>>>>>> Eden-2.0:Beavermania/Assets/Ground1.terrainlayer
   m_MaskMapTexture: {fileID: 0}
   m_TileSize: {x: 5, y: 5}
   m_TileOffset: {x: 0, y: 0}

--- a/Assets/Eden/Terrain/NewLayer 5.terrainlayer
+++ b/Assets/Eden/Terrain/NewLayer 5.terrainlayer
@@ -6,15 +6,9 @@ TerrainLayer:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-<<<<<<<< HEAD:Beavermania/Assets/NewLayer 5.terrainlayer
   m_Name: NewLayer 5
   m_DiffuseTexture: {fileID: 2800000, guid: 1edc7cc525f7299418b71823a99a9776, type: 3}
   m_NormalMapTexture: {fileID: 2800000, guid: f857da3d8b701944baaf2af770407084, type: 3}
-========
-  m_Name: Ground1
-  m_DiffuseTexture: {fileID: 2800000, guid: 42df4504925e3c6428d6c62cdba23147, type: 3}
-  m_NormalMapTexture: {fileID: 2800000, guid: 4461133173c4c6f4699bb1d9e2d83ba4, type: 3}
->>>>>>>> Eden-2.0:Beavermania/Assets/Ground1.terrainlayer
   m_MaskMapTexture: {fileID: 0}
   m_TileSize: {x: 5, y: 5}
   m_TileOffset: {x: 0, y: 0}

--- a/Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs
+++ b/Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs
@@ -26,6 +26,7 @@ namespace Beavermania.Core.GameFlow
         static void ResetStaticsForDomainReload()
         {
             s_activeTokens = FreezeToken.None;
+            Time.timeScale = RunningScale;
         }
 
         public static bool IsFrozen => s_activeTokens != FreezeToken.None;

--- a/Assets/Scripts/Core/GameFlow/PauseController.cs
+++ b/Assets/Scripts/Core/GameFlow/PauseController.cs
@@ -1,5 +1,6 @@
 using Beavermania.Audio;
 using Beavermania.Core.Input;
+using Beavermania.Display;
 using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -72,8 +73,15 @@ namespace Beavermania.Core.GameFlow
             if (!isBound)
                 return;
 
+            if (ActivePause)
+            {
+                if (PlayerInputReader.WasResumePressed())
+                    ResumeIfPaused();
+                return;
+            }
+
             if (PlayerInputReader.WasPausePressed())
-                ChangeBolean();
+                Pause();
         }
 
         void SetPaused(bool paused)
@@ -92,7 +100,7 @@ namespace Beavermania.Core.GameFlow
                 SetMenuVisible(true);
                 GameTimeScaleGate.SetFreeze(GameTimeScaleGate.FreezeToken.PauseMenu, true);
                 PauseBackgroundMusic();
-                player.ShowCursor();
+                ApplyPausedCursorState();
                 return;
             }
 
@@ -101,8 +109,18 @@ namespace Beavermania.Core.GameFlow
             SetQuestionVisible(false);
             ResumeBackgroundMusic();
 
-            if (!player.IsGameplayInputLocked())
-                player.HideCursor();
+            ApplyGameplayCursorStateIfUnlocked();
+        }
+
+        void ApplyPausedCursorState()
+        {
+            PlayerCursorRules.ApplyUnlockedVisible();
+        }
+
+        void ApplyGameplayCursorStateIfUnlocked()
+        {
+            if (player != null && !player.IsGameplayInputLocked())
+                PlayerCursorRules.ApplyLockedHidden(player.FreeLook, player.Root);
         }
 
         void PauseBackgroundMusic()
@@ -154,8 +172,7 @@ namespace Beavermania.Core.GameFlow
             GameTimeScaleGate.SetFreeze(GameTimeScaleGate.FreezeToken.PauseMenu, false);
             ResumeBackgroundMusic();
 
-            if (player != null && !player.IsGameplayInputLocked())
-                player.HideCursor();
+            ApplyGameplayCursorStateIfUnlocked();
         }
 
         void LogMissingReference(string referenceName, ref bool logged)

--- a/Assets/Scripts/Core/Input/PlayerInputReader.cs
+++ b/Assets/Scripts/Core/Input/PlayerInputReader.cs
@@ -44,6 +44,17 @@ namespace Beavermania.Core.Input
         /// <summary>Gameplay pause: Escape (primary) or backquote / tilde (alias).</summary>
         public static bool WasPausePressed()
         {
+            return WasPauseTogglePressed();
+        }
+
+        /// <summary>Pause-menu resume uses the same performed/down edge as pause.</summary>
+        public static bool WasResumePressed()
+        {
+            return WasPauseTogglePressed();
+        }
+
+        static bool WasPauseTogglePressed()
+        {
             return UnityEngine.Input.GetKeyDown(KeyCode.Escape)
                 || UnityEngine.Input.GetKeyDown(KeyCode.BackQuote);
         }

--- a/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantShadeMinion.cs
+++ b/Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantShadeMinion.cs
@@ -356,10 +356,13 @@ namespace Beavermania.NPC
                 shadeRigidbody.velocity = new Vector3(velocity.x, 0f, velocity.z);
                 shadeRigidbody.angularVelocity = Vector3.zero;
 
+                Vector3 currentPosition = shadeRigidbody.position;
                 float nextY = behaviorConfig.verticalSnapSpeed > 0f
-                    ? Mathf.MoveTowards(transform.position.y, targetY, behaviorConfig.verticalSnapSpeed * Time.fixedDeltaTime)
+                    ? Mathf.MoveTowards(currentPosition.y, targetY, behaviorConfig.verticalSnapSpeed * Time.fixedDeltaTime)
                     : targetY;
-                shadeRigidbody.MovePosition(new Vector3(transform.position.x, nextY, transform.position.z));
+                Vector3 nextPosition = currentPosition + velocity * Time.fixedDeltaTime;
+                nextPosition.y = nextY;
+                shadeRigidbody.MovePosition(nextPosition);
 
                 if (moveDirection.sqrMagnitude > DirectionEpsilon)
                     transform.rotation = Quaternion.LookRotation(moveDirection);

--- a/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
+++ b/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
@@ -1860,11 +1860,16 @@ namespace Beavermania.Player
             return false;
         }
 
-        bool IsPauseLikeFullscreenUi()
+        bool IsPauseUiActive()
         {
             PauseController activePauseController = ResolvePauseController();
-            if (activePauseController != null
-                && (activePauseController.ActivePause || activePauseController.IsPauseMenuVisible))
+            return activePauseController != null
+                && (activePauseController.ActivePause || activePauseController.IsPauseMenuVisible);
+        }
+
+        bool IsPauseLikeFullscreenUi()
+        {
+            if (IsPauseUiActive())
                 return true;
 
             if (LooseScreen != null && LooseScreen.activeSelf)
@@ -1874,7 +1879,16 @@ namespace Beavermania.Player
 
         void ApplyPauseLikeUiCameraState()
         {
-            if (IsPauseLikeFullscreenUi())
+            if (IsPauseUiActive())
+            {
+                if (FreeLook != null)
+                    FreeLook.enabled = false;
+                if (CamForTraders != null)
+                    CamForTraders.enabled = false;
+                return;
+            }
+
+            if (LooseScreen != null && LooseScreen.activeSelf)
             {
                 PlayerCursorRules.ApplyUnlockedVisible();
                 if (FreeLook != null)
@@ -2711,9 +2725,6 @@ namespace Beavermania.Player
         [Obsolete]
         public void LateUpdate()
         {
-            if (IsPauseLikeFullscreenUi())
-                PlayerCursorRules.ApplyUnlockedVisible();
-
             if (IsGameplayInputLocked())
                 return;
 


### PR DESCRIPTION
### Motivation
- Fix a bug where summoned shade minions could get stuck hovering in place because the vertical `MovePosition` call used `transform.position` X/Z and overwrote the horizontal movement applied via velocity.

### Description
- Modified `Assets/Scripts/NPC/ShadowRevenant/ShadowRevenantShadeMinion.cs` so `ApplyMovement` uses `shadeRigidbody.position`, computes the horizontal step as `currentPosition + velocity * Time.fixedDeltaTime`, snaps the Y using the existing vertical snap logic, and calls `shadeRigidbody.MovePosition(nextPosition)` to preserve both horizontal motion and hover height while keeping existing `shadeRigidbody.velocity`, `angularVelocity` resets, and rotation behavior.

### Testing
- Ran `git diff --check` which passed and committed the change; attempted `dotnet build .ci/BeaverMania.CI.csproj` but `dotnet` was not available in this environment so the compilation check could not be run; Unity Play Mode verification is still required (open `Assets/Scenes/ShadowRevenantTestArena.unity`, spawn shade minions, confirm they orbit/approach the player while maintaining hover height); no Inspector or prefab assignments were changed and risk is low-to-medium because this is a focused physics movement fix that still needs Play Mode validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a212be5c614832a83bfb86d05fed734)