### PR TITLE
Harden input pause flow

### DIFF
--- a/Assets/Scripts/Core/GameFlow/PauseController.cs
+++ b/Assets/Scripts/Core/GameFlow/PauseController.cs
@@ -72,7 +72,11 @@ namespace Beavermania.Core.GameFlow
             if (!isBound)
                 return;
 
-            if (PlayerInputReader.WasPausePressed())
+            bool toggleRequested = ActivePause
+                ? PlayerInputReader.WasResumePressed()
+                : PlayerInputReader.WasPausePressed();
+
+            if (toggleRequested)
                 ChangeBolean();
         }
 

--- a/Assets/Scripts/Core/Input/PlayerInputReader.cs
+++ b/Assets/Scripts/Core/Input/PlayerInputReader.cs
@@ -48,6 +48,12 @@ namespace Beavermania.Core.Input
                 || UnityEngine.Input.GetKeyDown(KeyCode.BackQuote);
         }
 
+        /// <summary>Pause menu resume uses the same down-edge as pause to avoid hold/release double toggles.</summary>
+        public static bool WasResumePressed()
+        {
+            return WasPausePressed();
+        }
+
         public static bool IsSprintHeld()
         {
             return UnityEngine.Input.GetKey(KeyCode.LeftShift);

--- a/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
+++ b/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
@@ -2109,7 +2109,11 @@ namespace Beavermania.Player
         }
         public void Start()
         {
+            Player = GetComponent<Rigidbody>();
             CacheMainCamera();
+            if (!ValidateRequiredStartupReferences())
+                return;
+
             BindHudState();
             if (boostChargeController == null)
                 boostChargeController = GetComponent<Combat.BoostChargeController>();
@@ -2124,7 +2128,6 @@ namespace Beavermania.Player
             ClearAllAimMarkSources();
             if (MunitionDisplay != null)
                 MunitionDisplay.SetActive(false);
-            Player = GetComponent<Rigidbody>();
             var gmObject = GameObject.FindGameObjectWithTag("GM");
             if (gmObject != null)
             {
@@ -2240,6 +2243,41 @@ namespace Beavermania.Player
             SyncHudState();
             UpdateSwordGlareAvailability();
         }
+
+        bool ValidateRequiredStartupReferences()
+        {
+            bool valid = true;
+
+            if (Player == null)
+            {
+                LogMissingRequiredStartupReference("Rigidbody component");
+                valid = false;
+            }
+
+            if (Otter == null)
+            {
+                LogMissingRequiredStartupReference(nameof(Otter));
+                valid = false;
+            }
+
+            if (cachedMainCamera == null)
+            {
+                LogMissingRequiredStartupReference("Camera.main");
+                valid = false;
+            }
+
+            if (valid)
+                return true;
+
+            enabled = false;
+            return false;
+        }
+
+        void LogMissingRequiredStartupReference(string referenceName)
+        {
+            Debug.LogError($"{nameof(BeaverPlayerBehaviour)} on '{name}' is missing required reference '{referenceName}'. Disabling this component to prevent repeated input-loop NullReferenceExceptions.", this);
+        }
+
         [System.Obsolete]
         public void Update()
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds an explicit resume input edge alongside the existing pause edge for the current legacy input reader on `main`.
- Routes pause menu close/open through pause vs resume reader methods while preserving one key-down toggle behavior.
- Validates required player runtime references at startup and disables the player component with a clear error if critical input-loop dependencies are missing.

### Validation
- Passed: `dotnet build BeaverMania.CI.csproj` from `.ci`.
- Passed: targeted conflict-marker scan for touched input-flow scripts.
- Passed: targeted scan confirmed the requested generated Input System symbols/classes (`BeaverInputSystem`, `SetCallbacks(this)`, `InputActionPhase.Canceled`, `InputReader`, `PlayerController`, `GameManager`) are absent on current `main`.
- Blocked: Unity batch-mode/Play Mode smoke test could not run because Unity license activation is missing in Cursor Cloud (`Failed to activate/update license Missing or bad username or password`).

### Play Mode follow-up
- Needs Unity Play Mode verification: pause key opens the pause menu once, resume closes it once, movement/jump/sprint do not double-fire, and no NullReferenceException is emitted from `PlayerInputReader`, `PauseController`, or `BeaverPlayerBehaviour`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f546a3b9-ecf2-4819-af78-ac186e541306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f546a3b9-ecf2-4819-af78-ac186e541306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

