### PR TITLE
Fix player jump SFX throttle and strafe/roll pitch distortion

### DIFF
--- a/.agents/skills/gameplay-audio-throttling/SKILL.md
+++ b/.agents/skills/gameplay-audio-throttling/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: gameplay-audio-throttling
+description: Use this skill when a Unity gameplay sound effect repeats too frequently, overlaps aggressively, clips, restarts, stacks, or becomes too loud during repeated player/enemy actions such as jump, slash, sword attacks, footsteps, magic attacks, pickup sounds, damage sounds, or ability effects. Also use it when implementing cooldown-based SFX playback, one-shot audio guards, per-action audio rate limiting, or safe AudioSource.PlayOneShot behavior in gameplay scripts.
+---
+
+# Gameplay Audio Throttling
+
+Use this skill for Unity C# gameplay audio fixes where sound effects are triggered too frequently or overlap in a way that hurts game feel.
+
+## Scope
+
+This skill is for script-level audio throttling only.
+
+Allowed:
+- C# gameplay scripts.
+- Audio playback guards.
+- Cooldown timers.
+- `AudioSource.PlayOneShot(...)` safety.
+- Preventing repeated SFX spam.
+- Per-sound or per-action cooldown logic.
+- Lightweight helper methods/classes.
+- Localized changes with low regression risk.
+
+Not allowed unless explicitly requested:
+- Editing scenes.
+- Editing prefabs.
+- Editing Audio Mixer assets.
+- Editing animation clips.
+- Editing generated files.
+- Editing `.meta` files.
+- Replacing existing audio architecture with a large new system.
+- Changing music playlist logic unless the user explicitly asks.
+
+## Core Rule
+
+Never let a gameplay action trigger the same sound every frame or every animation/event tick without a cooldown, state check, or one-shot guard.
+
+Bad patterns:
+- Calling audio playback directly inside `Update()` without a state transition.
+- Calling jump/slash/footstep sounds every frame while a boolean is true.
+- Re-triggering the same ability SFX every animation frame.
+- Creating new `AudioSource` objects repeatedly at runtime.
+- Starting the same looping sound repeatedly without checking if it is already playing.
+- Using `Play()` for short repeated SFX when `PlayOneShot()` is more appropriate.
+
+Preferred patterns:
+- Track the last play time per sound/action.
+- Use a small cooldown per gameplay action.
+- Trigger sounds only on input/action transitions.
+- Use `PlayOneShot()` for short SFX.
+- Use `isPlaying` checks only for looping or long sounds.
+- Keep cooldown values serialized when tuning is expected.
+- Keep defaults conservative and easy to tune in Inspector.
+
+## Implementation Pattern
+
+Prefer a minimal helper method inside the relevant script first:
+
+```csharp
+[SerializeField] private AudioSource sfxSource;
+[SerializeField] private AudioClip jumpClip;
+[SerializeField] private float jumpSfxCooldown = 0.12f;
+
+private float _lastJumpSfxTime = -999f;
+
+private void PlayJumpSfx()
+{
+    if (sfxSource == null || jumpClip == null)
+        return;
+
+    if (Time.time - _lastJumpSfxTime < jumpSfxCooldown)
+        return;
+
+    _lastJumpSfxTime = Time.time;
+    sfxSource.PlayOneShot(jumpClip);
+}
+```
+
+For multiple related sounds, use named cooldown fields rather than a generic over-engineered manager unless the codebase already has an audio manager.
+
+Example:
+
+```csharp
+[SerializeField] private float attackSfxCooldown = 0.18f;
+[SerializeField] private float footstepSfxCooldown = 0.1f;
+[SerializeField] private float damageSfxCooldown = 0.25f;
+
+private float _lastAttackSfxTime = -999f;
+private float _lastFootstepSfxTime = -999f;
+private float _lastDamageSfxTime = -999f;
+```
+
+## When Fixing Existing Bugs
+
+Before editing:
+
+1. Identify where the sound is triggered.
+2. Check if it is called from `Update`, animation events, input callbacks, collision callbacks, or coroutines.
+3. Check whether the trigger can fire repeatedly.
+4. Check whether the current implementation uses `Play`, `PlayOneShot`, `loop`, `isPlaying`, or instantiated audio objects.
+5. Determine whether the correct fix is:
+   - cooldown,
+   - state transition guard,
+   - input phase guard,
+   - animation event cleanup,
+   - loop start/stop guard,
+   - or null/reference safety.
+
+## Unity Input / Action Audio Rules
+
+For input-driven sounds:
+
+- Trigger sound on `Performed`, not continuously.
+- Do not play sound on every input callback if the callback receives `Started`, `Performed`, and `Canceled`.
+- For held actions like sprint, shield, charge, or ability hold:
+  - play start sound once,
+  - optionally play loop sound once,
+  - stop loop sound on cancel,
+  - do not replay every frame.
+
+## Animation Event Audio Rules
+
+For animation-event sounds:
+
+- Do not assume animation events fire only once.
+- Add cooldown if the animation can blend, replay, interrupt, or loop.
+- Keep event methods small and safe.
+- Never throw if an AudioSource or AudioClip is missing.
+- Prefer warning only when useful; avoid logging every frame.
+
+## Footstep Audio Rules
+
+For footsteps:
+
+- Use distance, grounded state, movement state, or animation event timing.
+- Never play footsteps directly every `Update()` while moving.
+- Use cooldown or stride interval.
+- Do not play footsteps while airborne.
+- Do not stack multiple footstep systems unless the user explicitly asks for layered audio.
+
+## Combat / Ability Audio Rules
+
+For attack sounds:
+
+- Separate input trigger from hit detection.
+- The swing/slash sound should usually play once per attack start.
+- Hit impact sounds should play when a valid hit is detected, with a separate cooldown if multiple colliders can report the same hit.
+- Ability sounds such as fire, hurricane, electric, wind, slash, or sword glare should not restart every frame while active.
+- If an ability is blocked due to insufficient HP/stamina/resources, stop or skip its SFX cleanly.
+
+## Beavermania-Specific Guidance
+
+In Beavermania:
+
+- Prefer localized script changes.
+- Preserve existing namespaces such as:
+  - `Beavermania.Audio`
+  - `Beavermania.Player`
+  - `Beavermania.Player.Combat`
+  - `Beavermania.Core.Input`
+- Do not edit `BeaverInputSystem.cs`; it is generated by Unity Input System.
+- Do not edit `.meta` files.
+- Do not change prefabs or scene references unless explicitly requested.
+- If serialized fields are added, list them clearly in the final response so they can be assigned in Unity Inspector.
+- If the fix requires Inspector wiring, say exactly which GameObject/Component/Field needs assignment.
+
+## Validation Checklist
+
+After implementing a throttling fix, report:
+
+1. Which sound/action was throttled.
+2. Which script changed.
+3. Which cooldown/state guard was added.
+4. Whether any serialized fields were added.
+5. Whether Inspector assignment is required.
+6. How to test manually in Unity Play Mode.
+
+Manual test examples:
+
+- Press jump repeatedly and confirm jump SFX does not stack or clip.
+- Hold attack/ability input and confirm sound does not restart every frame.
+- Spam slash/hurricane/fire/electric and confirm SFX remains controlled.
+- Walk/run and confirm footsteps match movement without rapid spam.
+- Trigger damage/hit collisions and confirm impact sounds do not multiply from duplicate colliders.
+
+## Final Response Format
+
+When done, summarize briefly:
+
+- Files changed.
+- Audio issue fixed.
+- Throttle/cooldown values added.
+- Inspector fields to assign.
+- Manual Play Mode checks.
+
+Do not claim Unity Play Mode was tested unless it was actually run.
+Do not claim audio balance is final unless it was tested in the Unity Editor.

--- a/.agents/skills/unity-animation-event-audit/SKILL.md
+++ b/.agents/skills/unity-animation-event-audit/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: unity-animation-event-audit
+description: Use this skill when auditing, debugging, or fixing Unity Animation Events connected to gameplay actions, combat, movement, VFX, SFX, hitboxes, weapon activation, jump/slash timing, ability triggers, or animation-driven method calls. Use it when sounds, effects, colliders, attack windows, or gameplay actions trigger too early, too late, too often, not at all, or continue after an animation is interrupted.
+---
+
+# Unity Animation Event Audit
+
+Use this skill to inspect and fix Unity Animation Events safely.
+
+The goal is to verify that animation events call the correct methods, at the correct timing, exactly as intended, without creating duplicated gameplay triggers, audio spam, VFX leaks, stuck hitboxes, or broken prefab/scene references.
+
+## Scope
+
+Allowed:
+- Inspect animation clips.
+- Inspect Animator Controllers.
+- Inspect scripts referenced by animation events.
+- Verify method names and signatures.
+- Fix C# methods called by animation events.
+- Add safe guards to event receiver methods.
+- Add cooldown/state protection when animation events can fire repeatedly.
+- Report required Unity Editor changes clearly.
+
+Allowed only when explicitly requested:
+- Editing animation clips.
+- Moving animation event timestamps.
+- Adding/removing animation events.
+- Editing prefabs.
+- Editing scene object hierarchy.
+- Replacing Animator Controllers.
+- Reworking the animation state machine.
+
+Not allowed:
+- Editing generated files.
+- Editing `.meta` files.
+- Replacing clips/controllers instead of fixing them.
+- Creating a new animation system.
+- Performing broad animation refactors unless explicitly requested.
+
+## Audit Checklist
+
+When investigating an Animation Event issue, check:
+
+1. Which animation clip contains the event.
+2. Which frame/time the event fires on.
+3. Which method name is called.
+4. Which GameObject receives the event.
+5. Which component contains the target method.
+6. Whether the method exists.
+7. Whether the method signature is valid for Unity Animation Events.
+8. Whether the method can safely be called more than once.
+9. Whether the animation can loop, blend, interrupt, transition, or replay.
+10. Whether the event triggers gameplay, SFX, VFX, hitboxes, particles, damage, input state, or object activation.
+11. Whether the event depends on serialized fields that may be missing.
+12. Whether the event causes side effects that must be reset later.
+
+## Valid Unity Animation Event Method Forms
+
+Animation Event methods should usually be simple public or private instance methods on a MonoBehaviour attached to the animated GameObject or an appropriate parent/child receiver.
+
+Valid common forms:
+
+```csharp
+public void MethodName()
+public void MethodName(float value)
+public void MethodName(int value)
+public void MethodName(string value)
+public void MethodName(UnityEngine.Object value)
+public void MethodName(AnimationEvent animationEvent)
+```
+
+Avoid:
+
+```csharp
+static methods
+async animation event handlers
+methods requiring multiple parameters
+methods with complex gameplay branching
+methods that assume references are always assigned
+methods that instantiate repeatedly without limits
+```
+
+## Event Receiver Method Rules
+
+Animation Event receiver methods must be safe.
+
+Preferred pattern:
+
+```csharp
+public void OnAttackHitboxEnabled()
+{
+    if (!isActiveAndEnabled)
+        return;
+
+    if (attackHitbox == null)
+        return;
+
+    attackHitbox.SetActive(true);
+}
+```
+
+For paired enable/disable events:
+
+```csharp
+public void EnableAttackWindow()
+{
+    if (attackHitbox == null)
+        return;
+
+    attackHitbox.SetActive(true);
+}
+
+public void DisableAttackWindow()
+{
+    if (attackHitbox == null)
+        return;
+
+    attackHitbox.SetActive(false);
+}
+```
+
+For audio events:
+
+```csharp
+[SerializeField] private AudioSource sfxSource;
+[SerializeField] private AudioClip slashClip;
+[SerializeField] private float slashSfxCooldown = 0.15f;
+
+private float _lastSlashSfxTime = -999f;
+
+public void PlaySlashSfxFromAnimation()
+{
+    if (sfxSource == null || slashClip == null)
+        return;
+
+    if (Time.time - _lastSlashSfxTime < slashSfxCooldown)
+        return;
+
+    _lastSlashSfxTime = Time.time;
+    sfxSource.PlayOneShot(slashClip);
+}
+```
+
+For VFX events:
+
+```csharp
+public void EnableSlashVfx()
+{
+    if (slashVfx == null)
+        return;
+
+    if (!slashVfx.activeSelf)
+        slashVfx.SetActive(true);
+}
+
+public void DisableSlashVfx()
+{
+    if (slashVfx == null)
+        return;
+
+    if (slashVfx.activeSelf)
+        slashVfx.SetActive(false);
+}
+```
+
+## Common Problems To Detect
+
+Look specifically for:
+
+- Event method name typo.
+- Event method exists on the wrong GameObject.
+- Method was renamed but animation clip still calls the old name.
+- Event fires on both entry and looping frames.
+- Event fires during blend/transition more than expected.
+- Event triggers SFX repeatedly and causes audio spam.
+- Event enables VFX but no matching disable/reset exists.
+- Event enables hitbox but hitbox remains active after interruption.
+- Event spawns objects repeatedly.
+- Event applies damage multiple times per swing.
+- Event assumes references are assigned and throws NullReferenceException.
+- Event fires while the player has insufficient HP/stamina/resources.
+- Event calls gameplay logic that should be input-driven instead.
+- Event exists on duplicate animation clips but only one was updated.
+
+## Combat Animation Event Rules
+
+For combat:
+- Use animation events for timing windows, not high-level decision logic.
+- Attack start should usually be input/state driven.
+- Hitbox enable/disable can be animation-event driven.
+- Damage should be guarded against duplicate collider hits.
+- Swing SFX should usually fire once per swing.
+- Impact SFX should fire only on valid hit.
+- VFX should have clear enable/disable/reset behavior.
+- Interrupted attacks must clean up hitboxes and VFX.
+
+## Movement Animation Event Rules
+
+For movement:
+- Footstep events must not fire while airborne.
+- Footstep events should be guarded by grounded/movement checks.
+- Landing sounds should not stack with jump sounds.
+- Jump SFX should trigger from the jump action or a clearly timed animation event, not both unless intentionally layered.
+- Repeated run/idle transitions should not spam SFX.
+
+## Ability Animation Event Rules
+
+For abilities:
+- Resource checks must happen before starting the ability.
+- Animation events should not bypass HP/stamina/mana gates.
+- If an ability is cancelled, its VFX/SFX/hitboxes must be reset.
+- Looping ability animation events must not restart audio/VFX every loop unless designed that way.
+- Fire, wind, electric, hurricane, slash, sword glare, and similar effects must have clear lifecycle ownership.
+
+## Beavermania-Specific Guidance
+
+In Beavermania:
+- Prefer localized fixes.
+- Preserve existing namespaces:
+  - `Beavermania.Player`
+  - `Beavermania.Player.Combat`
+  - `Beavermania.Player.Movement`
+  - `Beavermania.Audio`
+  - `Beavermania.Display`
+  - `Beavermania.Core.Input`
+- Do not edit `BeaverInputSystem.cs`; it is generated by Unity Input System.
+- Do not edit `.meta` files.
+- Do not replace animation clips, prefabs, or Animator Controllers unless explicitly requested.
+- Be careful with player combat animations, sword VFX, FireBreath, Hurricane, slash effects, jump events, footsteps, and enemy hit reactions.
+- If serialized fields are added, list them clearly so they can be assigned in Unity Inspector.
+- If Unity Editor-only changes are required, do not pretend they were done in code. Report the exact clip/event/timestamp/object to update.
+
+## Required Investigation Output
+
+Before fixing, produce a short audit summary:
+
+```text
+Animation Event Audit:
+- Suspected clip:
+- Suspected event method:
+- Receiver GameObject/component:
+- Current symptom:
+- Likely cause:
+- Safe fix:
+- Requires Unity Editor change: yes/no
+```
+
+## Fix Strategy
+
+Prefer this order:
+
+1. Fix missing/null-safe C# receiver methods.
+2. Add state guards/cooldowns where repeated firing is possible.
+3. Add cleanup/reset methods for VFX/hitboxes.
+4. Only then recommend moving/adding/removing animation events in Unity Editor.
+5. Avoid large animation/controller refactors.
+
+## Validation Checklist
+
+After changes, report:
+
+1. Files changed.
+2. Animation event methods changed or added.
+3. Serialized fields added.
+4. Whether animation clips need manual Editor changes.
+5. Which gameplay action should be tested.
+6. Expected Play Mode behavior.
+
+Manual Play Mode test examples:
+- Trigger the animation once and confirm the event fires once.
+- Spam the action and confirm SFX/VFX/hitboxes do not stack.
+- Interrupt the animation and confirm hitboxes/VFX reset correctly.
+- Test transitions/blends and confirm no duplicate gameplay effects.
+- Confirm no NullReferenceException appears in Console.
+
+## Final Response Format
+
+When done, summarize:
+
+- Files changed.
+- Event receiver methods fixed.
+- Animation clip changes required, if any.
+- Inspector assignments required, if any.
+- Manual Unity Play Mode checks.
+
+Do not claim Unity Play Mode was tested unless it was actually run.
+Do not claim animation events were moved/added/removed unless the animation clip was actually edited.

--- a/.cursor/skills/unity-audio-source-inspection/SKILL.md
+++ b/.cursor/skills/unity-audio-source-inspection/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: unity-audio-source-inspection
+description: Use this skill when inspecting or debugging Unity AudioSource components, AudioClip assignments, Audio Mixer routing, SFX playback, music/SFX separation, spatial blend, Play On Awake, looping, volume, priority, duplicated AudioSources, missing references, or script-driven audio behavior in scenes, prefabs, and gameplay objects.
+---
+
+# Unity AudioSource Inspection
+
+Use this skill to inspect Unity AudioSource setup safely.
+
+The goal is to find and fix audio problems caused by incorrect AudioSource configuration, missing references, bad mixer routing, duplicate playback, incorrect 2D/3D settings, bad loop/play settings, or unsafe script-triggered audio behavior.
+
+## Scope
+
+Allowed:
+- Inspect AudioSource components.
+- Inspect AudioClip assignments.
+- Inspect Audio Mixer group routing.
+- Inspect prefabs and scene objects for audio configuration issues.
+- Inspect scripts that trigger AudioSource playback.
+- Detect duplicate or competing AudioSources.
+- Detect missing or null audio references.
+- Recommend Inspector changes clearly.
+- Make localized script fixes when requested.
+
+Allowed only when explicitly requested:
+- Editing prefabs.
+- Editing scene objects.
+- Changing AudioSource serialized values.
+- Changing Audio Mixer assets.
+- Changing AudioClip import settings.
+- Replacing audio architecture.
+- Creating new audio managers.
+- Reassigning clips or mixer groups.
+
+Not allowed:
+- Editing `.meta` files.
+- Replacing existing prefabs.
+- Creating broad audio refactors without approval.
+- Changing unrelated UI, gameplay, animation, or VFX logic.
+- Claiming Unity Play Mode audio was tested unless it actually was.
+
+## Inspection Checklist
+
+When investigating an AudioSource issue, check:
+
+1. Which GameObject owns the AudioSource.
+2. Whether the AudioSource is on a scene object, prefab, child object, or runtime-instantiated object.
+3. Whether the AudioSource has an assigned AudioClip.
+4. Whether the script uses `Play`, `PlayOneShot`, `Stop`, `Pause`, `UnPause`, or `clip = ...`.
+5. Whether `Play On Awake` is enabled correctly.
+6. Whether `Loop` is enabled correctly.
+7. Whether the AudioSource is routed to the correct Audio Mixer Group.
+8. Whether the source is meant to be Music, SFX, UI, Ambience, Voice, or Ability audio.
+9. Whether `Spatial Blend` should be 2D or 3D.
+10. Whether volume/pitch/priority settings are sane.
+11. Whether min/max distance and rolloff are correct for 3D audio.
+12. Whether multiple AudioSources play the same sound at once.
+13. Whether audio playback is triggered every frame or too frequently.
+14. Whether missing serialized references can cause NullReferenceException.
+15. Whether the object is disabled/destroyed before the clip can finish.
+16. Whether pooling affects playback lifecycle.
+17. Whether an AudioListener exists and is not duplicated.
+
+## Common Problems To Detect
+
+Look specifically for:
+
+- Missing AudioClip reference.
+- Missing AudioSource reference in script.
+- AudioSource exists but is disabled.
+- AudioSource GameObject is inactive.
+- `Play On Awake` enabled on SFX that should only play on action.
+- `Play On Awake` disabled on ambience/music that should start automatically.
+- `Loop` enabled on one-shot SFX.
+- `Loop` disabled on music/ambience/continuous ability audio.
+- SFX routed to Music mixer group.
+- Music routed to SFX mixer group.
+- UI sound routed to world SFX group.
+- 3D sound configured as 2D.
+- UI/global sound configured as 3D.
+- Very high volume causing clipping.
+- Multiple AudioSources on parent/child playing the same effect.
+- Duplicate AudioListeners.
+- `Play()` called repeatedly and restarting the clip.
+- `PlayOneShot()` called too frequently and stacking.
+- Runtime-created AudioSources not cleaned up.
+- AudioSource destroyed before clip finishes.
+- Same clip assigned to several gameplay systems unintentionally.
+- Animation Events and scripts both trigger the same sound.
+
+## AudioSource Configuration Rules
+
+Use these defaults unless the project clearly requires otherwise.
+
+### One-shot gameplay SFX
+
+Recommended:
+- `Play On Awake`: false
+- `Loop`: false
+- `Spatial Blend`: usually 0 for UI/global, 1 for world-positioned SFX
+- Playback method: `PlayOneShot`
+- Add cooldown/throttle if the action can repeat quickly
+- Route to SFX mixer group
+
+### Music
+
+Recommended:
+- Dedicated AudioSource
+- `Loop`: depends on playlist system
+- `Spatial Blend`: 0
+- Route to Music mixer group
+- Do not restart music unnecessarily between scenes unless intended
+- Do not use gameplay SFX sources for music
+
+### UI sounds
+
+Recommended:
+- `Spatial Blend`: 0
+- `Play On Awake`: false
+- `Loop`: false
+- Route to UI or SFX mixer group
+- Trigger from UI events only
+
+### Ambience
+
+Recommended:
+- Usually looped
+- Usually 2D for global ambience or 3D for positional ambience
+- Route to Ambience or SFX mixer group
+- Avoid many overlapping ambience sources in the same location
+
+### Ability / combat looping sounds
+
+Recommended:
+- Start once when ability begins
+- Stop once when ability ends/cancels
+- Do not restart every frame
+- Guard with `isPlaying` or explicit state flag
+- Route to SFX or Ability mixer group
+
+## Script Inspection Rules
+
+When inspecting scripts, look for these patterns:
+
+Bad:
+```csharp
+private void Update()
+{
+    audioSource.Play();
+}
+```
+
+Bad:
+```csharp
+private void Update()
+{
+    if (isAttacking)
+        audioSource.PlayOneShot(attackClip);
+}
+```
+
+Better:
+```csharp
+[SerializeField] private AudioSource sfxSource;
+[SerializeField] private AudioClip attackClip;
+[SerializeField] private float attackSfxCooldown = 0.18f;
+
+private float _lastAttackSfxTime = -999f;
+
+private void PlayAttackSfx()
+{
+    if (sfxSource == null || attackClip == null)
+        return;
+
+    if (Time.time - _lastAttackSfxTime < attackSfxCooldown)
+        return;
+
+    _lastAttackSfxTime = Time.time;
+    sfxSource.PlayOneShot(attackClip);
+}
+```
+
+For looping audio:
+```csharp
+private void StartAbilityLoop()
+{
+    if (abilitySource == null)
+        return;
+
+    if (abilitySource.isPlaying)
+        return;
+
+    abilitySource.loop = true;
+    abilitySource.Play();
+}
+
+private void StopAbilityLoop()
+{
+    if (abilitySource == null)
+        return;
+
+    if (!abilitySource.isPlaying)
+        return;
+
+    abilitySource.Stop();
+}
+```
+
+## Mixer Routing Rules
+
+When inspecting mixer routing:
+
+- Music should route to Music.
+- Player SFX should route to SFX or PlayerSFX.
+- Enemy SFX should route to SFX or EnemySFX.
+- UI sounds should route to UI or SFX.
+- Ambience should route to Ambience or SFX.
+- Do not leave important runtime AudioSources unrouted if the project uses Audio Mixer volume sliders.
+- If a UI slider controls SFX but a sound ignores it, check whether the AudioSource is routed to the correct mixer group.
+
+If the correct Audio Mixer Group cannot be confirmed:
+- Do not guess silently.
+- Report the source and current routing.
+- Recommend the expected group based on sound type.
+
+## Duplicate AudioSource Audit
+
+Check for duplicate playback sources:
+
+- Same sound triggered from both script and Animation Event.
+- Same clip assigned to parent and child objects.
+- Multiple AudioSources on the same GameObject with overlapping responsibility.
+- Prefab variant adds an AudioSource while base prefab already has one.
+- Runtime instantiation creates a new AudioSource every time an action is used.
+- Object pooling reuses sources without stopping previous playback.
+
+When duplicates are found, report:
+```text
+Duplicate AudioSource Risk:
+- GameObject:
+- Components:
+- Clip:
+- Trigger path:
+- Why it may duplicate:
+- Safe fix:
+```
+
+## 2D / 3D Spatial Audio Rules
+
+Use 2D audio for:
+- Music
+- UI sounds
+- Global feedback sounds
+- Non-positional player feedback
+- Menu sounds
+
+Use 3D audio for:
+- Enemy sounds
+- World pickups
+- Environmental objects
+- Positional combat impacts
+- Localized ambience
+- Trader/NPC voice or interaction sounds if positional
+
+For 3D audio, inspect:
+- Spatial Blend
+- Min Distance
+- Max Distance
+- Rolloff Mode
+- Doppler Level
+- Spread
+- Priority
+
+Avoid extreme Doppler unless specifically desired.
+
+## Beavermania-Specific Guidance
+
+In Beavermania:
+- Prefer localized fixes.
+- Preserve existing namespaces:
+  - `Beavermania.Audio`
+  - `Beavermania.Player`
+  - `Beavermania.Player.Combat`
+  - `Beavermania.Player.Movement`
+  - `Beavermania.UI`
+  - `Beavermania.Core.Input`
+- Do not edit `BeaverInputSystem.cs`; it is generated by Unity Input System.
+- Do not edit `.meta` files.
+- Do not replace prefabs or scene objects unless explicitly requested.
+- Be careful with:
+  - player jump SFX
+  - slash SFX
+  - Hurricane / wind sounds
+  - FireBreath sounds
+  - electric ability sounds
+  - footsteps
+  - pickup sounds
+  - hurt/damage sounds
+  - music continuing from Menu into gameplay
+  - SFX volume slider behavior
+- If serialized fields are added, list them clearly so they can be assigned in Unity Inspector.
+- If mixer routing requires Inspector changes, report exact GameObject, AudioSource, and expected Output Mixer Group.
+
+## Required Investigation Output
+
+Before fixing, produce a short inspection summary:
+
+```text
+AudioSource Inspection:
+- Suspected GameObject:
+- AudioSource/component:
+- Clip:
+- Current symptom:
+- Current trigger path:
+- Current mixer routing:
+- 2D/3D setup:
+- Likely cause:
+- Safe fix:
+- Requires Unity Editor change: yes/no
+```
+
+## Fix Strategy
+
+Prefer this order:
+
+1. Fix missing/null-safe script references.
+2. Add cooldown/throttle if playback repeats too frequently.
+3. Fix `Play`, `PlayOneShot`, `Stop`, or loop lifecycle logic.
+4. Recommend AudioSource Inspector changes.
+5. Recommend Audio Mixer routing changes.
+6. Only then suggest broader audio architecture changes.
+
+Avoid large refactors unless the user explicitly asks.
+
+## Validation Checklist
+
+After changes, report:
+
+1. Files changed.
+2. AudioSources inspected.
+3. Audio issue found.
+4. Script changes made.
+5. Inspector changes required.
+6. Mixer routing changes required.
+7. Manual Play Mode checks.
+
+Manual Play Mode test examples:
+- Trigger the sound once and confirm it plays once.
+- Spam the action and confirm audio does not stack or clip.
+- Confirm SFX slider affects the sound if expected.
+- Confirm music slider does not affect SFX unless designed.
+- Confirm 3D sound attenuates correctly with distance.
+- Confirm UI/global sounds are not affected by player position.
+- Confirm no NullReferenceException appears in Console.
+- Confirm no duplicate AudioListener warnings appear.
+
+## Final Response Format
+
+When done, summarize:
+
+- Files changed.
+- GameObjects/AudioSources inspected.
+- AudioSource issues found.
+- Script fixes applied.
+- Inspector assignments required.
+- Mixer routing changes required.
+- Manual Unity Play Mode checks.
+
+Do not claim Unity Play Mode was tested unless it was actually run.
+Do not claim Inspector or Audio Mixer changes were made unless they were actually edited.

--- a/AI_CONTEXT/CURRENT_STATUS.md
+++ b/AI_CONTEXT/CURRENT_STATUS.md
@@ -14,3 +14,9 @@ Steam release candidate stability.
 - FPS and rendering optimization.
 
 Large architecture work should be deferred unless it directly stabilizes the Steam release candidate.
+
+## Recent Branch Activity (`fix/player-jump-sfx-throttle`, as of 2026-06-11)
+
+- Jump SFX throttling and pitch-distortion fixes committed (`2ea52146`, `1a9fc660`); Play Mode QA pending.
+- Level 1 Remastered scene overrides, fence/otter materials, and an OtterAnim2 `Consume` transition condition committed (`232d5edd`).
+- A roll-animation pipeline (RollBall3.0 Blender export, import fixer, Shapekeys_Anim rewiring, airborne/inertia roll gameplay logic) was prototyped and then **fully reverted**; see `AI_WORKFLOW/active-task.md` for retained findings if revisited.

--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -1,51 +1,58 @@
 # Active Task
 
 ## Task title
-- Audio Mixer prefab/scene wiring
+- Player jump audio pitch fix (strafe/roll → jump transitions)
 
 ## Type
-- Mixed (scripts + prefab wiring + Play Mode verification)
+- Mixed (script hardening + prefab verification + Play Mode audio QA)
 
 ## Owner
-- **Cursor** — prefab wiring, EditMode audit tests, Unity MCP verification
-- **User** — final Play Mode slider QA confirmation
+- **Codex/Cursor** — `AudioScript.cs` jump API unification, static prefab audit
+- **User** — Play Mode ear verification in Level 1 Remastered - Steam
 
 ## Current phase
-- Implementation complete; merged `origin/main` (objective flow). EditMode + partial Play Mode verification done.
+- Jump pitch transition fix implemented. Play Mode QA pending user ear check.
 
 ## Goal
-- Ensure all priority AudioSources and AudioVolumeSettings catalog references are assigned to NewAudioMixer groups; validate with EditMode tests and Play Mode slider QA in Level 1 - Remastered - Steam.
+- Ensure jump SFX (`Leap.mp3`) plays once per jump input with no duplicate triggers from animation events or dual throttle channels.
+
+## Audit findings (static)
+- No player animation clips/events call `Jump`, `PlayJumpSound`, or similar.
+- Single live trigger: `BeaverPlayerBehaviour.Update` → `Sound.PlayPlayerJumpSfx()`.
+- `Jump.fbx` (Midair) has zero animation events.
+- `NewSwordJump.anim` has combat events only (misleading name).
 
 ## Changes made
 
 ### Scripts
-- `Assets/Editor/AudioRoutingPrefabAudit.cs` — allowlist prefab scan for null mixer groups
-- `Assets/Editor/AudioRoutingEditModeTests.cs` — `AllowlistedPrefabs_HaveRoutedEnabledAudioSources` test
+- `Assets/Scripts/Player/SoundScripts/AudioScript.cs` — unified jump API; jump plays 2D with doppler disabled during one-shot; suppresses `Step`/`Roll` SFX same frame and 0.12s after jump.
+- `Assets/Scripts/SceneScripts/GameplayAudio.cs` — `WasChannelPlayedWithin()` for movement/jump overlap guards.
+- `Assets/Editor/GameplayAudioThrottleTests.cs` — test for `WasChannelPlayedWithin`.
 
-### Prefabs
-- `Assets/Prefabs/Objects/UI/GameMusic.prefab` — full AudioVolumeSettings group catalog (Music/SFX/Enemies/UI)
-- `Assets/Prefabs/Player/Otter_Shapekeys/Player.prefab` — disabled orphan AudioSource → Effects
+### Prefabs (verified, no edits required)
+- `Assets/Prefabs/Player/Otter_Shapekeys/Player.prefab`
+  - `AudioScript.audioClip[0]` = Leap.mp3
+  - `audioSource` → OTTER_ShapekeysIdle (Player mixer, clip empty, Play On Awake off)
+  - `audioEffects` → AudioEffects child (Effects mixer, clip empty, Play On Awake off)
+  - `HammerLeft` AudioSource disabled (orphan)
 
-### Verified unchanged (already wired)
-- ShadowRevenant → Boss (×2)
-- ShadowRevenantShadeMinion → Enemies
-- ScorpionBoss → Boss (×2)
-- PlayerCanvas → UI (×5)
-- FirstLift → Elevator/Button
-- Electric Effect → Effects
+## Manual Play Mode jump audio checklist (Level 1 Remastered - Steam)
+- [ ] Single jump (Space once): exactly one Leap sound, no Console errors
+- [ ] Double jump: two sounds spaced by ~0.16s cooldown (expected)
+- [ ] Spam Space on ground: throttle prevents stack/clipping
+- [ ] Jump then air slash (`NewSwordJump`): jump once; sword/wind separate
+- [ ] SFX slider affects jump; music slider does not
+- [ ] Pause/resume: jump still single per press
+- [ ] Carry logs / goblet boost: jump still single per press
+- [ ] Console: no `AnimationEvent 'Jump' ... has no receiver` warnings
+- [ ] Console: no duplicate AudioListener warnings
 
-## Manual Play Mode validation checklist (Level 1 Remastered - Steam)
-- [x] EditMode prefab audit passes (`AllowlistedPrefabs_HaveRoutedEnabledAudioSources`)
-- [x] EditMode routing tests pass (Music/Sfx/Enemy/UI EnsureRoute + prefab audit)
-- [x] SFX slider updates SfxVolume + EnemiesVolume at runtime (console evidence during Play Mode)
-- [x] MusicVolume unchanged while SFX slider moved (console evidence)
-- [ ] Music slider audible-only QA (human ear check)
-- [ ] Master slider affects all categories (human ear check)
-- [ ] Volume settings persist after scene reload
-- [ ] No `[AudioSourceRouting]` warnings during combat
+## Verification performed
+- Static scan of player `.anim` / FBX `.meta` animation events
+- Serialized prefab AudioSource + AudioScript wiring review
+- IDE linter: no issues on `AudioScript.cs`
+- `dotnet build .ci/BeaverMania.CI.csproj`: failed locally (UnityEngine refs missing in this shell — environment limitation)
+- Unity MCP: no Editor instance connected; Play Mode not run
 
----
-
-## Merged from main (objective flow — complete, no code conflicts)
-
-Objective flow Remastered wiring landed via PR #175 and merged cleanly with audio routing (`BeaverPlayerBehaviour`, `Static_Hive` auto-merged). Status on main: complete with PlayMode tests passing.
+## Risk
+- Low. Behavior change: `NewConstructor.Construction.Jump()` now shares `player.jump` throttle with player (prevents latent duplicate if both fired near-simultaneously on same AudioScript instance).

--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -1,58 +1,59 @@
 # Active Task
 
 ## Task title
-- Player jump audio pitch fix (strafe/roll → jump transitions)
+- No active task — branch stable after roll-animation work was reverted
 
-## Type
-- Mixed (script hardening + prefab verification + Play Mode audio QA)
-
-## Owner
-- **Codex/Cursor** — `AudioScript.cs` jump API unification, static prefab audit
-- **User** — Play Mode ear verification in Level 1 Remastered - Steam
+## Branch
+- `fix/player-jump-sfx-throttle` (pushed to `origin`)
 
 ## Current phase
-- Jump pitch transition fix implemented. Play Mode QA pending user ear check.
+- Idle. Last committed work awaiting final Play Mode QA (see checklists below).
 
-## Goal
-- Ensure jump SFX (`Leap.mp3`) plays once per jump input with no duplicate triggers from animation events or dual throttle channels.
+## Branch state (verified 2026-06-11)
 
-## Audit findings (static)
-- No player animation clips/events call `Jump`, `PlayJumpSound`, or similar.
-- Single live trigger: `BeaverPlayerBehaviour.Update` → `Sound.PlayPlayerJumpSfx()`.
-- `Jump.fbx` (Midair) has zero animation events.
-- `NewSwordJump.anim` has combat events only (misleading name).
+Working tree is clean. Committed work on this branch:
 
-## Changes made
+| Commit | Summary | Status |
+| --- | --- | --- |
+| `2ea52146` | Throttle player jump SFX | Committed |
+| `1a9fc660` | Fix jump SFX pitch distortion on strafe and roll transitions | Committed, Play Mode QA pending |
+| `232d5edd` | Level 1 scene overrides, fence/otter materials, OtterAnim2 Consume transition condition | Committed, Play Mode QA pending |
 
-### Scripts
-- `Assets/Scripts/Player/SoundScripts/AudioScript.cs` — unified jump API; jump plays 2D with doppler disabled during one-shot; suppresses `Step`/`Roll` SFX same frame and 0.12s after jump.
-- `Assets/Scripts/SceneScripts/GameplayAudio.cs` — `WasChannelPlayedWithin()` for movement/jump overlap guards.
-- `Assets/Editor/GameplayAudioThrottleTests.cs` — test for `WasChannelPlayedWithin`.
+## Reverted work (do not assume it exists)
 
-### Prefabs (verified, no edits required)
-- `Assets/Prefabs/Player/Otter_Shapekeys/Player.prefab`
-  - `AudioScript.audioClip[0]` = Leap.mp3
-  - `audioSource` → OTTER_ShapekeysIdle (Player mixer, clip empty, Play On Awake off)
-  - `audioEffects` → AudioEffects child (Effects mixer, clip empty, Play On Awake off)
-  - `HammerLeft` AudioSource disabled (orphan)
+The following was implemented in-session on 2026-06-10/11 and then **fully reverted by the user**. None of it is present on the branch:
 
-## Manual Play Mode jump audio checklist (Level 1 Remastered - Steam)
+- Inertia/airborne roll gameplay logic in `BeaverPlayerBehaviour.cs` (`PlayerInertiaRoll`, `PlayerAirborneRoll`, roll layer weights, landing-slide defer).
+- Roll SFX routing in `AudioScript.cs` (ground roll cooldown channel, airborne roll wind).
+- `RollBall3.0.fbx` animation export, `RollBall2.0.fbx`, and `Assets/SourceArt/BlenderScripts/export_rollball3.py`.
+- Editor tooling: `RollBallFbxImportFixer.cs`, `BallRollFbxImportFixer.cs`, `BallRollAnimationExporter.cs`, `ShapekeysAnimControllerMigrator.cs`.
+- `Shapekeys_Anim.controller` rewiring (RollBall3 motion on LowerBody Roll) and Roll-state transition normalization on LowerBody/UpperBody layers.
+
+### Knowledge worth keeping if roll work is revisited
+
+- `RollBall2.0.fbx` has a malformed armature: the armature object is named `mixamorig:Hips` with root-level bones and **no** `mixamorig:Hips` bone; avatar copy fails against it.
+- Working Blender pipeline: import `NewRoll.fbx` (clean hierarchy), retarget RollBall2's `BallRoll` action by **rotation-only** per-bone copy (hips location only), export with `bake_anim=False`, `apply_scale_options='FBX_SCALE_NONE'`, `apply_unit_scale=False`. Do **not** run `transform_apply` on the armature (bakes the 0.01 scale into bone lengths, ~100x rig errors).
+- Unity import: Humanoid, copy avatar from `Shapekeys_Model.fbx` (GUID `d49a26fadbee3d34ba8722eafdaf215a`), `motionNodeName = "Armature"`. This produced a warning-free import.
+- `ModelImporterClipAnimation` in Unity 2021.3 has no `loopBlendOrientation`/`loopBlendPositionY`/`loopBlendPositionXZ` properties; setting them is a compile error.
+
+## Pending Play Mode QA (committed work)
+
+### Jump SFX pitch fix (`1a9fc660`) — Level 1 Remastered - Steam
 - [ ] Single jump (Space once): exactly one Leap sound, no Console errors
 - [ ] Double jump: two sounds spaced by ~0.16s cooldown (expected)
 - [ ] Spam Space on ground: throttle prevents stack/clipping
-- [ ] Jump then air slash (`NewSwordJump`): jump once; sword/wind separate
+- [ ] Jump from strafe and from roll: no pitch distortion
 - [ ] SFX slider affects jump; music slider does not
-- [ ] Pause/resume: jump still single per press
-- [ ] Carry logs / goblet boost: jump still single per press
-- [ ] Console: no `AnimationEvent 'Jump' ... has no receiver` warnings
-- [ ] Console: no duplicate AudioListener warnings
 
-## Verification performed
-- Static scan of player `.anim` / FBX `.meta` animation events
-- Serialized prefab AudioSource + AudioScript wiring review
-- IDE linter: no issues on `AudioScript.cs`
-- `dotnet build .ci/BeaverMania.CI.csproj`: failed locally (UnityEngine refs missing in this shell — environment limitation)
-- Unity MCP: no Editor instance connected; Play Mode not run
+### Scene/animator commit (`232d5edd`)
+- [ ] Level 1 Remastered - Steam loads with no missing references
+- [ ] Camera FOV override (45 → 40) looks correct in Play Mode
+- [ ] OtterAnim2 transition gated by `Consume` condition behaves correctly (no unintended early exit)
+- [ ] Fence brick and otter eye/moustache materials render correctly
 
-## Risk
-- Low. Behavior change: `NewConstructor.Construction.Jump()` now shares `player.jump` throttle with player (prevents latent duplicate if both fired near-simultaneously on same AudioScript instance).
+## Ownership
+- **Cursor + Unity Editor** — Play Mode QA above
+- **Codex** — none pending
+
+## Notes
+- `Shapekeys_Anim.controller` and `Level 1 - Remastered - Steam.unity` are high-risk assets; any future edits need explicit scope and Play Mode verification.

--- a/Assets/Editor/GameplayAudioThrottleTests.cs
+++ b/Assets/Editor/GameplayAudioThrottleTests.cs
@@ -1,0 +1,173 @@
+#if UNITY_EDITOR
+using System.Reflection;
+using Beavermania.Audio;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Audio;
+
+namespace Beavermania.Tests.Audio
+{
+    public sealed class GameplayAudioThrottleTests
+    {
+        const string MixerPath = "Assets/Scripts/SceneScripts/NewAudioMixer.mixer";
+        const string AudioMixerFieldName = "audioMixer";
+        const string MusicGroupFieldName = "musicGroup";
+        const string SfxGroupFieldName = "sfxGroup";
+        const string EnemiesGroupFieldName = "enemiesGroup";
+        const string UiGroupFieldName = "uiGroup";
+        const string InstanceBackingFieldName = "<Instance>k__BackingField";
+        const string PlayerJumpChannel = "player.jump";
+        const string SwordSwingChannel = "player.swordswing";
+        const string WindChannel = "player.wind";
+
+        AudioMixer mixer;
+        AudioVolumeSettings settings;
+        AudioVolumeSettings previousInstance;
+        GameObject settingsGameObject;
+        GameObject sourceAGameObject;
+        GameObject sourceBGameObject;
+        AudioClip clip;
+
+        [SetUp]
+        public void SetUp()
+        {
+            mixer = AssetDatabase.LoadAssetAtPath<AudioMixer>(MixerPath);
+            Assert.That(mixer, Is.Not.Null, $"Expected mixer asset at '{MixerPath}'.");
+
+            GameplayAudio.ClearAllThrottles();
+            previousInstance = GetRegisteredInstance();
+
+            settingsGameObject = new GameObject("GameplayAudioThrottleTestsHost");
+            settings = settingsGameObject.AddComponent<AudioVolumeSettings>();
+            SetObjectReference(settings, AudioMixerFieldName, mixer);
+            SetObjectReference(settings, MusicGroupFieldName, GetMixerGroup("Music"));
+            SetObjectReference(settings, SfxGroupFieldName, GetMixerGroup("SFX"));
+            SetObjectReference(settings, EnemiesGroupFieldName, GetMixerGroup("Enemies"));
+            SetObjectReference(settings, UiGroupFieldName, GetMixerGroup("UI"));
+            RegisterInstance(settings);
+
+            clip = AudioClip.Create("GameplayAudioThrottleClip", 4410, 1, 44100, false);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            GameplayAudio.ClearAllThrottles();
+            RegisterInstance(previousInstance);
+
+            if (clip != null)
+                Object.DestroyImmediate(clip);
+
+            if (sourceAGameObject != null)
+                Object.DestroyImmediate(sourceAGameObject);
+
+            if (sourceBGameObject != null)
+                Object.DestroyImmediate(sourceBGameObject);
+
+            if (settingsGameObject != null)
+                Object.DestroyImmediate(settingsGameObject);
+        }
+
+        [Test]
+        public void TryPlayOneShot_ThrottlesRepeatedPlayerJumpKey()
+        {
+            AudioSource source = CreateRoutedSource("JumpSource", ref sourceAGameObject);
+
+            bool first = GameplayAudio.TryPlayOneShot(source, clip, PlayerJumpChannel, 0.16f, 0.42f, 0.8f);
+            bool second = GameplayAudio.TryPlayOneShot(source, clip, PlayerJumpChannel, 0.16f, 0.42f, 0.8f);
+
+            Assert.That(first, Is.True);
+            Assert.That(second, Is.False);
+        }
+
+        [Test]
+        public void TryPlayOneShot_AllowsPlayerJumpAndSwordSwingInSameFrame()
+        {
+            AudioSource jumpSource = CreateRoutedSource("JumpSource", ref sourceAGameObject);
+            AudioSource swordSource = CreateRoutedSource("SwordSource", ref sourceBGameObject);
+
+            bool jumpPlayed = GameplayAudio.TryPlayOneShot(jumpSource, clip, PlayerJumpChannel, 0.16f, 0.42f, 0.8f);
+            bool swordPlayed = GameplayAudio.TryPlayOneShot(swordSource, clip, SwordSwingChannel, 0.12f, 0.95f, 1f);
+
+            Assert.That(jumpPlayed, Is.True);
+            Assert.That(swordPlayed, Is.True);
+        }
+
+        [Test]
+        public void TryPlayOneShot_AllowsPlayerJumpAndWindInSameFrame()
+        {
+            AudioSource jumpSource = CreateRoutedSource("JumpSource", ref sourceAGameObject);
+            AudioSource windSource = CreateRoutedSource("WindSource", ref sourceBGameObject);
+
+            bool jumpPlayed = GameplayAudio.TryPlayOneShot(jumpSource, clip, PlayerJumpChannel, 0.16f, 0.42f, 0.8f);
+            bool windPlayed = GameplayAudio.TryPlayOneShot(windSource, clip, WindChannel, 0.15f, 0.9f, 1f);
+
+            Assert.That(jumpPlayed, Is.True);
+            Assert.That(windPlayed, Is.True);
+        }
+
+        [Test]
+        public void ClearChannel_AllowsImmediateReplayOfPlayerJump()
+        {
+            AudioSource source = CreateRoutedSource("JumpSource", ref sourceAGameObject);
+
+            bool first = GameplayAudio.TryPlayOneShot(source, clip, PlayerJumpChannel, 0.16f, 0.42f, 0.8f);
+            bool throttled = GameplayAudio.TryPlayOneShot(source, clip, PlayerJumpChannel, 0.16f, 0.42f, 0.8f);
+            GameplayAudio.ClearChannel(PlayerJumpChannel);
+            bool replayed = GameplayAudio.TryPlayOneShot(source, clip, PlayerJumpChannel, 0.16f, 0.42f, 0.8f);
+
+            Assert.That(first, Is.True);
+            Assert.That(throttled, Is.False);
+            Assert.That(replayed, Is.True);
+        }
+
+        static AudioVolumeSettings GetRegisteredInstance()
+        {
+            FieldInfo field = typeof(AudioVolumeSettings).GetField(InstanceBackingFieldName, BindingFlags.Static | BindingFlags.NonPublic);
+            return field != null ? field.GetValue(null) as AudioVolumeSettings : null;
+        }
+
+        static void RegisterInstance(AudioVolumeSettings instance)
+        {
+            FieldInfo field = typeof(AudioVolumeSettings).GetField(InstanceBackingFieldName, BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null, "Expected AudioVolumeSettings instance backing field.");
+            field.SetValue(null, instance);
+        }
+
+        static void SetObjectReference(Object target, string propertyName, Object value)
+        {
+            SerializedObject serializedObject = new SerializedObject(target);
+            SerializedProperty property = serializedObject.FindProperty(propertyName);
+            Assert.That(property, Is.Not.Null, $"Expected serialized property '{propertyName}'.");
+            property.objectReferenceValue = value;
+            serializedObject.ApplyModifiedPropertiesWithoutUndo();
+        }
+
+        AudioMixerGroup GetMixerGroup(string groupName)
+        {
+            Object[] assets = AssetDatabase.LoadAllAssetsAtPath(MixerPath);
+            for (int i = 0; i < assets.Length; i++)
+            {
+                if (assets[i] is AudioMixerGroup group && group.name == groupName)
+                    return group;
+            }
+
+            Assert.Fail($"Expected mixer group '{groupName}' in '{MixerPath}'.");
+            return null;
+        }
+
+        static AudioSource CreateRoutedSource(string sourceName, ref GameObject host)
+        {
+            if (host != null)
+                Object.DestroyImmediate(host);
+
+            host = new GameObject(sourceName);
+            AudioSource source = host.AddComponent<AudioSource>();
+            bool routed = AudioSourceRouting.EnsureRoute(source, AudioSourceRoute.Sfx);
+            Assert.That(routed, Is.True, $"Expected AudioSource '{sourceName}' to resolve an SFX route.");
+            return source;
+        }
+    }
+}
+#endif

--- a/Assets/Editor/GameplayAudioThrottleTests.cs
+++ b/Assets/Editor/GameplayAudioThrottleTests.cs
@@ -108,6 +108,20 @@ namespace Beavermania.Tests.Audio
         }
 
         [Test]
+        public void WasChannelPlayedWithin_ReturnsTrueUntilWindowExpires()
+        {
+            AudioSource source = CreateRoutedSource("JumpSource", ref sourceAGameObject);
+
+            bool played = GameplayAudio.TryPlayOneShot(source, clip, PlayerJumpChannel, 0.16f, 0.42f, 0.8f);
+
+            Assert.That(played, Is.True);
+            Assert.That(GameplayAudio.WasChannelPlayedWithin(PlayerJumpChannel, 0.16f), Is.True);
+            Assert.That(GameplayAudio.WasChannelPlayedWithin("other.channel", 0.16f), Is.False);
+            GameplayAudio.ClearChannel(PlayerJumpChannel);
+            Assert.That(GameplayAudio.WasChannelPlayedWithin(PlayerJumpChannel, 0.16f), Is.False);
+        }
+
+        [Test]
         public void ClearChannel_AllowsImmediateReplayOfPlayerJump()
         {
             AudioSource source = CreateRoutedSource("JumpSource", ref sourceAGameObject);

--- a/Assets/Editor/GameplayAudioThrottleTests.cs.meta
+++ b/Assets/Editor/GameplayAudioThrottleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90f7d4874364b5a4395bf61f0012dedc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Objects/Bridge/StairsBridge.prefab
+++ b/Assets/Prefabs/Objects/Bridge/StairsBridge.prefab
@@ -449,7 +449,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3254111133986252792}
-  m_LocalRotation: {x: -0.5067578, y: 0.49314964, z: 0.49314964, w: 0.5067578}
+  m_LocalRotation: {x: -0.52572054, y: 0.47288257, z: 0.47288257, w: 0.52572054}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Assets/Prefabs/Objects/Others/Fences/Materials/brick.mat
+++ b/Assets/Prefabs/Objects/Others/Fences/Materials/brick.mat
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: brick
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords:
+  - _NORMALMAP
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Prefabs/Objects/Others/Fences/Materials/brick.mat.meta
+++ b/Assets/Prefabs/Objects/Others/Fences/Materials/brick.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b23e69272233c284fae053cbd652593c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/EyeDiffuse.mat
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/EyeDiffuse.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: EyeDiffuse
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 736c65b2946beae4d80b1637a0a563eb, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/EyeDiffuse.mat.meta
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/EyeDiffuse.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b3ed4f9a1361a44cbd0d9596bffda80
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/Moustach.mat
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/Moustach.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Moustach
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5204311, g: 0.5204311, b: 0.5204311, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/Moustach.mat.meta
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/Moustach.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e6a013bdf857bdc4b9e23b4d01e37ff7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/OTTER_Eyelid.mat
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/OTTER_Eyelid.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: OTTER_Eyelid
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/OTTER_Eyelid.mat.meta
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/OTTER_Eyelid.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 06a2227a527495940af75c5d03dc1ee2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/Otter_Material_BaseMap 1.mat
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/Otter_Material_BaseMap 1.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Otter_Material_BaseMap 1
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 742be0ba1481c6f43b33f2c9474cb09c, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/Otter_Material_BaseMap 1.mat.meta
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/Otter_Material_BaseMap 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 386d2b771f4f10d40aa257c2cd01ceb8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/OuterEye.mat
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/OuterEye.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: OuterEye
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Prefabs/Player/OtterAnimations/Materials/OuterEye.mat.meta
+++ b/Assets/Prefabs/Player/OtterAnimations/Materials/OuterEye.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ebc8911c89b182f4bbcffa016f0814ed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player/OtterAnimations/OtterAnim2.controller
+++ b/Assets/Prefabs/Player/OtterAnimations/OtterAnim2.controller
@@ -3300,7 +3300,10 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Consume
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -1540430096626818971}
   m_Solo: 0

--- a/Assets/Scenes/Level 1 - Remastered - Steam.unity
+++ b/Assets/Scenes/Level 1 - Remastered - Steam.unity
@@ -6772,11 +6772,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 935453363210249030, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -15.484375
+      value: -15.483887
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845917, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: field of view
-      value: 40
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845917, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: near clip plane
@@ -6796,19 +6796,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.8175189
+      value: 0.8176343
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.04702457
+      value: 0.0449738
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.5730315
+      value: 0.5731124
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.03296138
+      value: -0.031523924
       objectReference: {fileID: 0}
     - target: {fileID: 1105702949010364755, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_IsActive
@@ -7160,51 +7160,47 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9983476
+      value: 0.9984885
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.057426024
+      value: 0.054921634
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0020929577
+      value: 0.0020933154
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00012038649
+      value: -0.00011514687
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677789, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 40
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677789, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
-      value: 1.9961612
+      value: 1.519393
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401701884423, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 2.46664
+      value: 3.390648
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401701884423, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.954577
+      value: -5.461732
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402168899005, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 2.46664
+      value: 3.390648
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402168899005, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.954577
+      value: -5.461732
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402263606164, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 40
-      objectReference: {fileID: 0}
-    - target: {fileID: 5220285402263606164, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
-      propertyPath: m_Lens.m_SensorSize.x
-      value: 1.9961612
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402263606165, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7232,35 +7228,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9992251
+      value: 0.9994089
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.039305102
+      value: 0.034314428
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.002094865
+      value: 0.0020951629
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00008239784
+      value: -0.00007193722
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102637, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 40
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102637, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
-      value: 1.9961612
+      value: 1.519393
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402922294815, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 2.46664
+      value: 3.390648
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402922294815, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.954577
+      value: -5.461732
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7280,23 +7276,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.075575955
+      value: 0.07557596
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0020903947
+      value: 0.002090454
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00015844406
+      value: -0.00015844034
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118829, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 40
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118829, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
-      value: 1.9961612
+      value: 1.519393
       objectReference: {fileID: 0}
     - target: {fileID: 5499620694491381217, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_RootOrder
@@ -7434,16 +7430,6 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 8166189033518523906, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
-      propertyPath: m_WarningMessage
-      value: "\nBinding warning: Some generic clip(s) animate transforms that are
-        already bound by a Humanoid avatar. These transforms can only be changed
-        by Humanoid clips.\n\tTransform 'mixamorig:Hips'\n\tTransform 'mixamorig:RightFoot'\n\tTransform
-        'mixamorig:LeftLeg'\n\tTransform 'mixamorig:LeftHand'\n\tTransform 'mixamorig:LeftToeBase'\n\tTransform
-        'mixamorig:Spine1'\n\tTransform 'mixamorig:Spine2'\n\tTransform 'mixamorig:RightUpLeg'\n\tTransform
-        'mixamorig:LeftHandIndex3'\n\tTransform 'mixamorig:RightForeArm'\n\tand more
-        ...\n\tFrom animation clip 'BallRoll'\n\tFrom animation clip 'BallRoll'"
-      objectReference: {fileID: 0}
     - target: {fileID: 8214714245245483286, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6.55
@@ -7491,10 +7477,6 @@ PrefabInstance:
     - target: {fileID: 9155236689507022576, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9155236689715297517, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 6.800171
       objectReference: {fileID: 0}
     - target: {fileID: 9155236690561687345, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Scenes/Level 1 - Remastered - Steam.unity
+++ b/Assets/Scenes/Level 1 - Remastered - Steam.unity
@@ -6772,11 +6772,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 935453363210249030, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -15.483887
+      value: -15.484375
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845917, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: field of view
-      value: 45
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845917, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: near clip plane
@@ -6796,19 +6796,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.8176343
+      value: 0.8175189
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0449738
+      value: 0.04702457
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.5731124
+      value: 0.5730315
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.031523924
+      value: -0.03296138
       objectReference: {fileID: 0}
     - target: {fileID: 1105702949010364755, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_IsActive
@@ -7160,47 +7160,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9984885
+      value: 0.9983476
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.054921634
+      value: 0.057426024
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0020933154
+      value: 0.0020929577
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00011514687
+      value: -0.00012038649
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677789, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 45
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677789, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
-      value: 1.519393
+      value: 1.9961612
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401701884423, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 3.390648
+      value: 2.46664
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401701884423, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.461732
+      value: -5.954577
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402168899005, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 3.390648
+      value: 2.46664
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402168899005, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.461732
+      value: -5.954577
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402263606164, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 45
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 5220285402263606164, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
+      propertyPath: m_Lens.m_SensorSize.x
+      value: 1.9961612
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402263606165, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7228,35 +7232,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9994089
+      value: 0.9992251
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.034314428
+      value: 0.039305102
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0020951629
+      value: 0.002094865
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00007193722
+      value: -0.00008239784
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102637, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 45
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102637, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
-      value: 1.519393
+      value: 1.9961612
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402922294815, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 3.390648
+      value: 2.46664
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402922294815, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.461732
+      value: -5.954577
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7276,23 +7280,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.07557596
+      value: 0.075575955
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.002090454
+      value: 0.0020903947
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00015844034
+      value: -0.00015844406
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118829, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
-      value: 45
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118829, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
-      value: 1.519393
+      value: 1.9961612
       objectReference: {fileID: 0}
     - target: {fileID: 5499620694491381217, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_RootOrder
@@ -7430,6 +7434,16 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 8
       objectReference: {fileID: 0}
+    - target: {fileID: 8166189033518523906, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
+      propertyPath: m_WarningMessage
+      value: "\nBinding warning: Some generic clip(s) animate transforms that are
+        already bound by a Humanoid avatar. These transforms can only be changed
+        by Humanoid clips.\n\tTransform 'mixamorig:Hips'\n\tTransform 'mixamorig:RightFoot'\n\tTransform
+        'mixamorig:LeftLeg'\n\tTransform 'mixamorig:LeftHand'\n\tTransform 'mixamorig:LeftToeBase'\n\tTransform
+        'mixamorig:Spine1'\n\tTransform 'mixamorig:Spine2'\n\tTransform 'mixamorig:RightUpLeg'\n\tTransform
+        'mixamorig:LeftHandIndex3'\n\tTransform 'mixamorig:RightForeArm'\n\tand more
+        ...\n\tFrom animation clip 'BallRoll'\n\tFrom animation clip 'BallRoll'"
+      objectReference: {fileID: 0}
     - target: {fileID: 8214714245245483286, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6.55
@@ -7477,6 +7491,10 @@ PrefabInstance:
     - target: {fileID: 9155236689507022576, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155236689715297517, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 6.800171
       objectReference: {fileID: 0}
     - target: {fileID: 9155236690561687345, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
+++ b/Assets/Scripts/Player/BeaverPlayerBehaviour.cs
@@ -2426,7 +2426,7 @@ namespace Beavermania.Player
                     }
                     OnPlatform = false;
                     Player.velocity = new Vector3(Player.velocity.x, JumpForce, Player.velocity.z);
-                    Sound.Jump();
+                    Sound?.PlayPlayerJumpSfx();
                     levitation = 10;
                     Otter.speed = AnimSpeed;
                     JumpNum--;

--- a/Assets/Scripts/Player/SoundScripts/AudioScript.cs
+++ b/Assets/Scripts/Player/SoundScripts/AudioScript.cs
@@ -8,15 +8,14 @@ namespace Beavermania.Audio
     public class AudioScript : MonoBehaviour
     {
         const int JumpClipIndex = 0;
-        const string GenericJumpChannel = "sfx.jump";
         const string PlayerJumpChannel = "player.jump";
-        const float GenericJumpCooldown = 0.2f;
-        const float GenericJumpVolumeScale = 0.55f;
-        const float GenericJumpPitch = 0.8f;
         const float PlayerJumpCooldown = 0.16f;
         const float PlayerJumpVolumeScale = 0.42f;
         const float PlayerJumpPitchMin = 0.78f;
         const float PlayerJumpPitchMax = 0.84f;
+        const float MovementSfxAfterJumpSuppression = 0.12f;
+
+        static int jumpMovementSuppressionFrame = -1;
 
         [SerializeField] AudioClip[] audioClip;
         [SerializeField] AudioSource audioSource;
@@ -163,6 +162,9 @@ namespace Beavermania.Audio
 
         public void Roll()
         {
+            if (ShouldSuppressMovementSfxAfterJump())
+                return;
+
             AudioSource source = ResolvePrimarySource();
             if (source == null || !TryGetClip(8, out AudioClip clip))
                 return;
@@ -248,6 +250,9 @@ namespace Beavermania.Audio
             if (footstepVfxEmitter != null)
                 footstepVfxEmitter.PlayStep();
 
+            if (ShouldSuppressMovementSfxAfterJump())
+                return;
+
             AudioSource source = ResolvePrimarySource();
             if (source == null || !TryGetClip(1, out AudioClip clip))
                 return;
@@ -260,16 +265,41 @@ namespace Beavermania.Audio
 
         public void Jump()
         {
-            TryPlayJumpSfx(GenericJumpChannel, GenericJumpCooldown, GenericJumpVolumeScale, GenericJumpPitch);
+            PlayPlayerJumpSfx();
         }
 
         public bool PlayPlayerJumpSfx()
         {
-            return TryPlayJumpSfx(
+            jumpMovementSuppressionFrame = Time.frameCount;
+
+            AudioSource source = ResolveEffectsSource();
+            if (source == null || !TryGetClip(JumpClipIndex, out AudioClip clip))
+                return false;
+
+            float dopplerLevel = source.dopplerLevel;
+            float spatialBlend = source.spatialBlend;
+            source.dopplerLevel = 0f;
+            source.spatialBlend = 0f;
+
+            bool played = GameplayAudio.TryPlayOneShot(
+                source,
+                clip,
                 PlayerJumpChannel,
                 PlayerJumpCooldown,
                 PlayerJumpVolumeScale,
                 SamplePitch(PlayerJumpPitchMin, PlayerJumpPitchMax));
+
+            source.dopplerLevel = dopplerLevel;
+            source.spatialBlend = spatialBlend;
+            return played;
+        }
+
+        static bool ShouldSuppressMovementSfxAfterJump()
+        {
+            if (Time.frameCount == jumpMovementSuppressionFrame)
+                return true;
+
+            return GameplayAudio.WasChannelPlayedWithin(PlayerJumpChannel, MovementSfxAfterJumpSuppression);
         }
 
         void EnsureRoutes()
@@ -305,17 +335,6 @@ namespace Beavermania.Audio
 
             clip = audioClip[index];
             return clip != null;
-        }
-
-        bool TryPlayJumpSfx(string channel, float minInterval, float volumeScale, float pitch)
-        {
-            AudioSource source = ResolveEffectsSource();
-            if (source == null || !TryGetClip(JumpClipIndex, out AudioClip clip))
-                return false;
-
-            source.clip = clip;
-            source.volume = 1f;
-            return GameplayAudio.TryPlayOneShot(source, clip, channel, minInterval, volumeScale, pitch);
         }
 
         static float SamplePitch(float minPitch, float maxPitch)

--- a/Assets/Scripts/Player/SoundScripts/AudioScript.cs
+++ b/Assets/Scripts/Player/SoundScripts/AudioScript.cs
@@ -7,6 +7,17 @@ namespace Beavermania.Audio
     [RequireComponent(typeof(AudioSource))]
     public class AudioScript : MonoBehaviour
     {
+        const int JumpClipIndex = 0;
+        const string GenericJumpChannel = "sfx.jump";
+        const string PlayerJumpChannel = "player.jump";
+        const float GenericJumpCooldown = 0.2f;
+        const float GenericJumpVolumeScale = 0.55f;
+        const float GenericJumpPitch = 0.8f;
+        const float PlayerJumpCooldown = 0.16f;
+        const float PlayerJumpVolumeScale = 0.42f;
+        const float PlayerJumpPitchMin = 0.78f;
+        const float PlayerJumpPitchMax = 0.84f;
+
         [SerializeField] AudioClip[] audioClip;
         [SerializeField] AudioSource audioSource;
         [SerializeField] AudioSource audioEffects;
@@ -249,13 +260,16 @@ namespace Beavermania.Audio
 
         public void Jump()
         {
-            AudioSource source = ResolveEffectsSource();
-            if (source == null || !TryGetClip(0, out AudioClip clip))
-                return;
+            TryPlayJumpSfx(GenericJumpChannel, GenericJumpCooldown, GenericJumpVolumeScale, GenericJumpPitch);
+        }
 
-            source.clip = clip;
-            source.volume = 0.65f;
-            GameplayAudio.TryPlayOneShot(source, clip, "player.jump", 0.2f, 0.55f, 0.8f);
+        public bool PlayPlayerJumpSfx()
+        {
+            return TryPlayJumpSfx(
+                PlayerJumpChannel,
+                PlayerJumpCooldown,
+                PlayerJumpVolumeScale,
+                SamplePitch(PlayerJumpPitchMin, PlayerJumpPitchMax));
         }
 
         void EnsureRoutes()
@@ -291,6 +305,22 @@ namespace Beavermania.Audio
 
             clip = audioClip[index];
             return clip != null;
+        }
+
+        bool TryPlayJumpSfx(string channel, float minInterval, float volumeScale, float pitch)
+        {
+            AudioSource source = ResolveEffectsSource();
+            if (source == null || !TryGetClip(JumpClipIndex, out AudioClip clip))
+                return false;
+
+            source.clip = clip;
+            source.volume = 1f;
+            return GameplayAudio.TryPlayOneShot(source, clip, channel, minInterval, volumeScale, pitch);
+        }
+
+        static float SamplePitch(float minPitch, float maxPitch)
+        {
+            return minPitch >= maxPitch ? minPitch : Random.Range(minPitch, maxPitch);
         }
     }
 }

--- a/Assets/Scripts/SceneScripts/GameplayAudio.cs
+++ b/Assets/Scripts/SceneScripts/GameplayAudio.cs
@@ -46,6 +46,17 @@ namespace Beavermania.Audio
             return true;
         }
 
+        public static bool WasChannelPlayedWithin(string channel, float withinSeconds)
+        {
+            if (string.IsNullOrEmpty(channel) || withinSeconds <= 0f)
+                return false;
+
+            if (!LastPlayTimeByChannel.TryGetValue(channel, out float lastPlay))
+                return false;
+
+            return Time.unscaledTime - lastPlay < withinSeconds;
+        }
+
         public static void ClearChannel(string channel)
         {
             if (string.IsNullOrEmpty(channel))


### PR DESCRIPTION
## Summary
- Route all player jump audio through a single `player.jump` throttle path in `AudioScript` and `BeaverPlayerBehaviour`.
- Fix low-pitch jump distortion when transitioning from strafe or roll by playing jump as 2D without doppler and suppressing overlapping `Step`/`Roll` animation SFX on the jump frame.
- Add `GameplayAudio.WasChannelPlayedWithin()` plus EditMode coverage for channel timing guards.
- Add agent/Cursor skills for gameplay audio throttling, animation event audit, and AudioSource inspection.

## Test plan
- [ ] Level 1 Remastered - Steam: single jump plays one Leap sound
- [ ] Strafe left/right then jump: jump pitch sounds normal (not muddy/low)
- [ ] Roll then jump: jump pitch sounds normal
- [ ] Spam jump on ground: throttle prevents audio stack/clipping
- [ ] Double jump: two sounds spaced by cooldown (~0.16s)
- [ ] Run EditMode test `GameplayAudioThrottleTests`
- [ ] Confirm SFX slider still affects jump volume
