### PR TITLE
Fix scorpion boss victory flow and reset game state safely

### DIFF
--- a/.agents/skills/playmode-boss-smoke-test/SKILL.md
+++ b/.agents/skills/playmode-boss-smoke-test/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: playmode-boss-smoke-test
+description: Run or define a Unity Play Mode smoke test for Beavermania boss death flows. Use when validating forced boss health to zero, delayed victory UI, control freeze, cursor state, boss bar hiding, lose precedence, or scene-specific boss wiring.
+---
+
+# PlayMode Boss Smoke Test
+
+Use this after code and scene wiring are complete. Static inspection is not enough for boss victory acceptance.
+
+## Required Setup
+
+1. Open the exact production scene named by the task.
+2. Confirm the active boss instance, player, `BossHandler`, `GameMaster`, and `PlayerCanvas` are present.
+3. Confirm the boss and UI serialized references are assigned before entering Play Mode.
+4. Clear the Console, then enter Play Mode.
+
+## Smoke Steps
+
+1. Reach or select the boss encounter state without unrelated scene edits.
+2. Force the boss health to zero through the safest available runtime path.
+3. Observe that boss UI hides immediately.
+4. Observe that victory does not appear until the configured delay has elapsed.
+5. After the delay, verify controls freeze or transition according to the owner flow.
+6. Verify cursor visibility and lock state.
+7. Verify the victory UI or victory scene appears once only.
+8. Repeat the delay window with lose screen already active if the task requires lose precedence.
+
+## Evidence
+
+Return:
+
+- scene name and boss instance tested
+- method used to force death
+- configured delay and observed behavior
+- boss UI behavior
+- control/camera/cursor state
+- victory UI/scene result
+- Console errors or warnings
+- whether the scene was saved after wiring

--- a/.agents/skills/playmode-boss-smoke-test/agents/openai.yaml
+++ b/.agents/skills/playmode-boss-smoke-test/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PlayMode Boss Smoke Test"
+  short_description: "Smoke-test boss death victory flow"
+  default_prompt: "Use -boss-smoke-test to validate a boss death victory flow in Unity Play Mode."

--- a/.agents/skills/unity-scene-reference-check/SKILL.md
+++ b/.agents/skills/unity-scene-reference-check/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: unity-scene-reference-check
+description: Inspect Unity scene and prefab serialized references for Beavermania before changing wiring. Use when a task mentions scene instances, prefab references, Inspector assignments, GameObject links, missing serialized references, or Level scene validation.
+---
+
+# Unity Scene Reference Check
+
+Use this before editing Unity scenes, prefabs, or Inspector wiring. Treat scene YAML as fragile serialized runtime data; prefer Unity Editor/MCP inspection over direct text edits.
+
+## Workflow
+
+1. Read the active handoff or task file first.
+2. Identify the exact target scene, prefab, component, and serialized fields.
+3. Inspect the prefab definition and every required scene instance separately.
+4. Record whether references are prefab defaults, scene overrides, missing links, or inactive UI objects.
+5. Change only the required fields, using Unity Editor tooling where available.
+6. Reinspect after saving to confirm the serialized links point to the intended objects.
+
+## Beavermania Rules
+
+- Use `GameMaster`, not `GameManager`, when searching this repo.
+- Do not rename `MonoBehaviour` classes, files, public fields, or serialized fields during a wiring pass.
+- Do not hand-edit `.unity` or `.prefab` YAML unless Unity tooling is unavailable and the target fileID/GUID relationship has been verified.
+- For Level 1 boss work, explicitly inspect `Assets/Scenes/Level 1 - Remastered - Steam.unity`; do not infer it is wired because another Level 1 scene is wired.
+
+## Report
+
+Return:
+
+- inspected scenes/prefabs
+- components and fields checked
+- fields changed
+- unresolved missing references
+- Unity Editor or Play Mode verification status
+- manual follow-up required

--- a/.agents/skills/unity-scene-reference-check/agents/openai.yaml
+++ b/.agents/skills/unity-scene-reference-check/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Unity Scene Reference Check"
+  short_description: "Audit Unity scene serialized references"
+  default_prompt: "Use -scene-reference-check to audit Unity scene and prefab references before wiring."

--- a/.agents/skills/victory-ui-wiring/SKILL.md
+++ b/.agents/skills/victory-ui-wiring/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: victory-ui-wiring
+description: Wire and verify Beavermania victory or end-game UI references. Use when assigning victory panels, end screens, boss-win UI, cursor/end-state behavior, PlayerCanvas links, or BossHandler.VictoryScreen.
+---
+
+# Victory UI Wiring
+
+Use this when connecting a gameplay victory trigger to UI. The purpose is to prove the correct UI object is shown by the correct owner, not to redesign the UI.
+
+## Workflow
+
+1. Locate the runtime owner that activates victory UI.
+2. Locate the dedicated victory/end-game object under `PlayerCanvas` or the scene UI root.
+3. Confirm the object starts inactive unless the existing flow requires otherwise.
+4. Assign the serialized field on the runtime owner to that dedicated object.
+5. Preserve existing lose, pause, boss bar, dialogue, and shop UI references.
+6. Verify cursor visibility/lock state and player control state in Play Mode.
+
+## Boss Victory Guardrails
+
+- `BossHandler.VictoryScreen` must point at a victory panel or victory scene-flow object, not a lose screen, boss bar, dialogue panel, or generic canvas root.
+- Victory should appear once after the configured boss delay.
+- If lose flow wins during the delay, victory must stay hidden.
+- The boss UI should hide immediately on boss death, before the victory delay completes.
+- Do not solve missing scene wiring by adding duplicate canvases, duplicate EventSystems, or duplicate manager objects.
+
+## Report
+
+Return:
+
+- selected victory UI object path
+- assigned owner/component/field
+- existing UI references preserved
+- cursor/control behavior observed
+- whether victory appeared once
+- whether lose-precedence behavior was checked

--- a/.agents/skills/victory-ui-wiring/agents/openai.yaml
+++ b/.agents/skills/victory-ui-wiring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Victory UI Wiring"
+  short_description: "Wire and verify victory UI references"
+  default_prompt: "Use -ui-wiring to wire the correct victory UI panel for a boss flow."

--- a/AI_WORKFLOW/active-task.md
+++ b/AI_WORKFLOW/active-task.md
@@ -1,137 +1,65 @@
 # Active Task
 
-## Task title
+> **Status (2026-06-13):** Active branch for this mixed task is `fix/scorpion-boss-victory-flow`. Codex implemented the runtime delayed-victory flow for the Scorpion boss. Cursor completed Unity wiring and Play Mode smoke validation for production scenes except the broken `BossDemo` backup scene.
 
-- Level 1 Remastered — north forest hotspot FPS fix (terrain + foliage + canopy fill-rate)
+## Current mixed task
 
-## Branch
+- Scorpion boss delayed victory flow after boss death
 
-- `fix/log-carry-animation-load`
+## Current owner split
 
-## Ownership
-
-- **Mixed.** Codex: scene-local performance-controller implementation, proxy asset creation, tests, and handoff. Cursor: Unity hierarchy verification, Play Mode / Stats proof, and any editor-only cleanup. User: final acceptance on the locked route.
+- **Mixed.** Codex: script-level defeat event, delayed victory trigger, time-scale token, and PlayMode coverage scaffold. Cursor: scene/prefab reference wiring plus Unity Play Mode validation. User: final acceptance on end-of-fight behavior.
 
 ## Current phase
 
-### 2026-06-13 branch rollback
+- **Cursor wiring + smoke validation complete (2026-06-13).** Awaiting user acceptance in-editor on the real boss encounter path.
 
-- Branch tip reset locally and on remote to `0da224eb` (`Refresh BeaverMania workflow and Cursor guidance docs`).
-- Removed commits:
-  - `8f0ed3cb` — player prefab carry serialization + camera lens edits
-  - `38596429` — camera prefab revert follow-up
-- **In scope on branch now:** `ce591d28` (Level 1 performance/canopy), `d636a525` (carry/presenter script hot-path), `0da224eb` (workflow docs).
-- **Out of scope again until revisited:** `Player.prefab` / `PlayerPack-Drop and Play.prefab` edits. `Carry.cs` script migration remains; prefab serialized tuning still needs a dedicated Unity pass.
-- Draft PR #180 updated to match the rolled-back branch history.
+## Wiring completed by Cursor
 
-### 2026-06-13 implementation update
+| Scene / asset                                      | BossHandler                                                                    | VictoryScreen                                     | BossBar / BossPanel  | ChatCollider                             | Play Mode smoke                                                                          |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------- | -------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `Assets/Scenes/Level 1 - Remastered - Steam.unity` | Added on `Player` (scene instance)                                             | `PlayerCanvas/Finish Game Panel `                 | Wired                | Left null (no boss chat source in scene) | **Pass** — delay 2s, victory once, freeze/cursor/control                                 |
+| `Assets/Scenes/Level 1.unity`                      | Added on `Player` (prefab instance; old prefab BossHandler override was stale) | `PlayerCanvas/Finish Game Panel `                 | Preserved / verified | `BossFight` (inactive Arena trigger)     | **Pass**                                                                                 |
+| `Assets/Scenes/BackUp Scene/BossDemo.unity`        | Not wired                                                                      | Not wired                                         | Stale overrides only | Unknown                                  | **Blocked** — `BlinkingPlayer` and `PlayerCanvas` prefab instances are missing in Editor |
+| `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`    | Not modified                                                                   | `Finish Game Panel ` exists (inactive by default) | Unchanged            | N/A                                      | N/A                                                                                      |
 
-- Codex implemented the scene-local canopy pass: `PerformanceBudgetProfile`, `FrameBudgetGovernor`, `Level1RemasteredPerformanceController`, a Beavermania-owned culled leaves shader/material, and a decorative `TheGivingTree` proxy prefab.
-- The remastered scene now contains `Perf_CanopyCluster_High`, `Perf_CanopyCluster_Proxy`, and `Level1RemasteredPerformanceController`.
-- Cursor is the next owner for Unity verification, locked-route FPS proof, and any editor-only cleanup.
+## Play Mode evidence (Cursor / Unity MCP)
 
-- **Implementation complete in Codex (2026-06-13).** The remastered scene now has a decorative canopy high/proxy split plus a scene-local adaptive performance controller with four fixed tiers.
-- **Next owner:** Cursor — follow A/B steps in `AI_WORKFLOW/handoffs/codex-to-cursor.md` (canopy disable test, Scene View Effects off, decorative proxy if positive).
-- **Codex handoff:** static review complete; no further script work unless Profiler shows CPU/script time.
+### Remastered + Level 1 (forced `handler.Boss.TakeDamage(999999999)`)
 
-## Problem
+- Immediate: boss HP `0`, boss object inactive, boss bar hidden, `Time.timeScale = 1`, victory panel hidden.
+- After `VictoryDelay = 2s`: exactly one `Finish Game Panel ` active, `Loose Menu Panel` inactive, `Time.timeScale = 0`, cursor visible/unlocked, `BeaverPlayerBehaviour.enabled = false`, `FreeLook.enabled = false`.
+- Lose precedence (remastered): with `LooseScreen` active before delay end, victory stayed hidden.
+- Console: no errors during smoke runs.
 
-### Original (2026-06-12 baseline)
+### Smoke-test note
 
-Standing in north forest (~119, 72, 266) yielded **~10–14 FPS** and **~100M triangles** (~21k batches). South/open reference (~149, 70, 167) was **~72–83 FPS**. Root cause: all 33 terrain tiles used **`m_TreeDistance: 5000`** plus dense grass details at **`m_DetailObjectDistance: 80`**.
+- Use `BossHandler.Boss`, not `FindObjectOfType<ScorpionScript>()`. Remastered scene has additional non-boss `ScorpionScript` instances; killing the wrong one does not trigger victory.
 
-### Remaining (2026-06-13 user report)
+## Manual Unity verification still recommended (user)
 
-Direction-specific FPS cliff when viewing **giant `TheGivingTree` canopies against open sky**. Suspected **alpha-cutout fill-rate / overdraw** (`SyntyStudios/VegitationShader`, `Cull Off`), not scripts. Scene has **no baked occlusion** (`m_OcclusionCullingData: {fileID: 0}`).
+- [ ] Reach the Scorpion boss through normal gameplay in `Level 1 - Remastered - Steam` and confirm the delayed victory feels correct in context (dialogue skip, arena entry, music stop, UI timing).
+- [ ] Repeat once in `Level 1.unity` if that scene remains a supported boss route.
+- [ ] Confirm boss dialogue trigger still works in `Level 1` with `ChatCollider -> BossFight`.
+- [ ] Skip `BossDemo` unless missing prefab GUIDs are repaired first.
 
-### Current implementation (2026-06-13)
+## Deferred / out of scope on this branch
 
-- Added `Perf_CanopyCluster_High` and `Perf_CanopyCluster_Proxy` roots in `Level 1 - Remastered - Steam`.
-- Added `ENV_TheGivingTree_PerfProxy.prefab` using a Beavermania-owned culled leaves shader/material.
-- Added `Level1RemasteredPerformanceController` and `Level1RemasteredPerformanceBudgetProfile`.
-- Targeted eight skyline/decorative `TheGivingTree` instances in the failing sightline for high/proxy swapping.
-
-## Reference-coordinate results (Unity MCP, 2026-06-12)
-
-Ground-snapped teleport, **8s settle** — valid for the **original** hotspot pass; may not cover the **canopy-facing** repro:
-
-| Zone         | Position             | FPS (before)  | Tris (before) | FPS (after pass 1) | Tris (after pass 1) |
-| ------------ | -------------------- | ------------- | ------------- | ------------------ | ------------------- |
-| **Bad ref**  | (119.6, 72.0, 266.1) | ~10.5–14.9    | ~80–105M      | **~34–39**         | **~5–21M**          |
-| **Good ref** | (149.1, 70.0, 167.5) | ~72–83 (user) | —             | **~72**            | **~14M**            |
-
-**Pass 1 acceptance (reference coords only):** bad ≥30 FPS ✓ | bad tris <50M ✓ | good ≥70 FPS ✓
-
-**Pass 2 acceptance (canopy-facing repro):** **not met** — user report pending Cursor A/B.
-
-## Scene changes — current working diff (`Level 1 - Remastered - Steam.unity`)
-
-Applied to **all 33 Terrain** components (verified in scene YAML):
-
-| Setting                     | Original | Current working diff |
-| --------------------------- | -------- | -------------------- |
-| `m_TreeDistance`            | 5000     | **200**              |
-| `m_TreeBillboardDistance`   | 50       | **30**               |
-| `m_TreeMaximumFullLODCount` | 50       | **25**               |
-| `m_DetailObjectDistance`    | 80       | **20**               |
-| `m_DetailObjectDensity`     | 1        | **1** (unchanged)    |
-| `m_HeightmapPixelError`     | 5        | **5** (unchanged)    |
-| `m_SplatMapDistance`        | 1000     | **600**              |
-| `m_DrawInstanced`           | 0        | **1**                |
-
-**Bad-zone decorative foliage (X 115–145, Y 70–79, Z 220–340):** `m_CastShadows: 0` on **52+** decorative `MeshRenderer` instances (including `TheGivingTree` clusters). No gameplay objects removed.
-
-> **Note:** An intermediate Cursor pass briefly set `m_DetailObjectDistance: 0` and `m_TreeMaximumFullLODCount: 15`; the **committed working diff** uses **20 / 25** instead.
-
-## Prior script work on same branch
-
-- Carry animation multiplier fix (`Carry.cs`) — script only; prefab serialization not applied after rollback
-- Dialogue host teardown fix (`NpcDialoguePresenter.cs`)
-- FPS script quick wins (`BeaverPlayerBehaviour`, `Carry`, `NpcDialoguePresenter`)
-
-## Verification performed
-
-- Unity MCP Play Mode (2026-06-12): reference-coordinate sampling at bad/good refs
-- Codex static review (2026-06-13): shader/material/occlusion audit — see `codex-to-cursor.md`
-- Play Mode enter/exit: no cleanup errors after presenter shutdown fix
-
-## Manual Unity verification (user / Cursor)
-
-### Locked route
-
-- [ ] Confirm `Perf_CanopyCluster_High`, `Perf_CanopyCluster_Proxy`, and `Level1RemasteredPerformanceController` are present and wired in the remastered scene
-- [ ] Hold 5 seconds at good ref `(149.1, 70.0, 167.5)` and stay at or above `60 FPS`
-- [ ] Hold 5 seconds at bad ref `(119.6, 72.0, 266.1)` and stay at or above `60 FPS`
-- [ ] Hold 5 seconds at the exact canopy-facing screenshot repro transform and stay at or above `60 FPS`
-- [ ] Traverse south-to-north through the hotspot for 20 seconds and never sustain below `58 FPS`
-- [ ] Scene View no longer shows a large direction-specific cliff at the canopy repro
-
-- [ ] Reproduce canopy-facing FPS cliff from user screenshot direction
-- [ ] A/B: disable nearest giant `TheGivingTree` renderer(s) in sightline — FPS jump?
-- [ ] A/B: Scene View **Effects** off — post/sky vs geometry split
-- [ ] Reference coords still ≥30 FPS bad / ≥70 FPS good after any canopy fix
-- [ ] Trader camp, log route, bridge build zone intact
-- [ ] Exit Play Mode — console clean
-
-## Deferred
-
-- Per-tile tree distance tuning
-- Selective grass re-enable on play tile only (detail distance 15–25)
-- Occlusion bake for open-vista directions
-- Decorative canopy proxy / LOD variant / culling-friendly leaf material
-- Carry prefab serialization alignment + feel pass (after FPS stable; rolled back with `8f0ed3cb`)
+- `BossDemo.unity` repair (missing prefab GUIDs `b922004aea0ae754c917e6abedafb749`, `d6e224836b570c644b9ae086cef28f39`).
+- Level 1 Remastered FPS / canopy work (separate branch `fix/log-carry-animation-load`).
+- NPC presenter wiring (historical handoff section in `codex-to-cursor.md`).
 
 ## Handoff files
 
-- Cursor → Codex: `AI_WORKFLOW/handoffs/cursor-to-codex.md`
-- Codex → Cursor (active A/B): `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+- Codex → Cursor: `AI_WORKFLOW/handoffs/codex-to-cursor.md`
+- Cursor → Codex: `AI_WORKFLOW/handoffs/cursor-to-codex.md` (FPS task; not updated for this boss flow)
 
-## Suggested commit message (when pass 2 complete)
+## Suggested commit message (when user approves)
 
 ```
-Reduce Level 1 north forest geometry and canopy fill cost at FPS hotspots
+Wire Scorpion boss victory UI and validate delayed end-game flow
 
-Lower terrain tree/detail draw, disable decorative shadows in the bad zone,
-and address giant-canopy overdraw in the open-sky sightline without
-south-zone regression.
+Assign BossHandler.VictoryScreen to Finish Game Panel in Level 1 and
+Remastered scenes, restore Level 1 boss handler wiring, and verify
+delayed victory, lose precedence, and control freeze in Play Mode.
 ```

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -1,5 +1,121 @@
 # Codex to Cursor Handoff
 
+> **Status (2026-06-13):** Active mixed-task handoff is now the **Scorpion boss delayed victory flow** on branch `fix/scorpion-boss-victory-flow`. The older FPS and dialogue sections below remain historical context.
+
+## Active implementation handoff - Scorpion boss delayed victory flow
+
+### What Codex changed
+
+- Updated `Assets/Scripts/NPC/Scorpion/ScorpionScript.cs`
+  - added serialized `victoryDelay`
+  - exposed clamped `VictoryDelay`
+  - added one-shot `Defeated` event raised from `Death()`
+- Updated `Assets/Scripts/Player/BossHandler.cs`
+  - added `VictoryScreen`
+  - subscribed to `ScorpionScript.Defeated`
+  - added one-shot delayed victory coroutine
+  - hides boss UI immediately on defeat
+  - aborts delayed victory if lose screen is already active when the delay ends
+  - freezes gameplay, unlocks cursor, disables player gameplay control, and shows `VictoryScreen`
+- Updated `Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs`
+  - added `FreezeToken.VictoryScreen`
+- Added `Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs`
+  - coverage for defeat-once, delayed victory, boss-bar hide, and lose-precedence
+
+### Runtime flow now expected
+
+1. `ScorpionScript.ReceiveDamage()` reaches `CurrentHealth <= 0`.
+2. `ScorpionScript.Death()` exits early if `deathHandled` is already set, otherwise marks dead, applies drops/VFX, raises `Defeated`, and deactivates the boss object.
+3. `BossHandler` receives `Defeated`, hides `BossBar` / `BossPanel`, disables the boss chat trigger, and starts one realtime delay coroutine.
+4. After `Boss.VictoryDelay`, `BossHandler` checks `player.LooseScreen`.
+5. If lose is already active, victory is skipped.
+6. Otherwise `BossHandler` freezes through `GameTimeScaleGate.FreezeToken.VictoryScreen`, stops music if available, shows the cursor, disables player cameras/control, and activates `VictoryScreen`.
+
+### What Cursor must wire in Unity
+
+1. Inspect the Scorpion boss scene instance / prefab and the active `BossHandler`.
+2. Assign `BossHandler.VictoryScreen` to the correct dedicated victory panel on `PlayerCanvas`.
+3. Verify `BossHandler.BossBar`, `BossHandler.BossPanel`, and `BossHandler.ChatCollider` still point at the intended scene/prefab objects after the script change.
+4. Check these assets/scenes specifically:
+   - `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab`
+   - `Assets/Scenes/Level 1.unity`
+   - `Assets/Scenes/BackUp Scene/BossDemo.unity`
+   - `Assets/Scenes/Level 1 - Remastered - Steam.unity`
+5. Use `GameMaster` terminology in scene inspection; there is no `GameManager` script in this repo.
+
+### Codex static preflight before Unity wiring
+
+- Unity MCP was not connected in the Codex session, so no Inspector assignments or Play Mode checks were performed.
+- Added local embedded skill files for this handoff:
+  - `.agents/skills/unity-scene-reference-check/SKILL.md`
+  - `.agents/skills/victory-ui-wiring/SKILL.md`
+  - `.agents/skills/playmode-boss-smoke-test/SKILL.md`
+- Static scan found `ScorpionBoss` prefab usage in:
+  - `Assets/Prefabs/Scorpion/ScorpionBoss.prefab`
+  - `Assets/Scenes/Level 1.unity`
+  - `Assets/Scenes/BackUp Scene/BossDemo.unity`
+  - `Assets/Scenes/Level 1 - Remastered - Steam.unity`
+- Static scan found existing `BossHandler` scene overrides for `Boss`, `BossBar`, `BossPanel`, and `ChatCollider` in `Assets/Scenes/Level 1.unity`.
+- Static scan found existing boss-related scene overrides for `Boss`, `BossBar`, and `BossPanel` in `Assets/Scenes/BackUp Scene/BossDemo.unity`; re-check `ChatCollider` in the Editor because the text scan did not show the same field there.
+- Static scan did not find a `VictoryScreen` serialized override in `Level 1`, `BossDemo`, or `Level 1 - Remastered - Steam`.
+- Static scan of `Assets/Scenes/Level 1 - Remastered - Steam.unity` only found the `ScorpionBoss` prefab instance by name; it did not show `PlayerCanvas`, `GameMaster`, or `BossHandler` boss/UI overrides by text search. Treat remastered boss/UI wiring as unverified until inspected in Unity.
+- `Assets/Prefabs/Objects/UI/PlayerCanvas.prefab` contains `Loose Menu Panel`, `BossPanel`, and `Boss HP Panel`, but the text scan did not identify a clearly named dedicated victory panel. In Unity, choose the actual dedicated victory/end-game UI object; do not wire `VictoryScreen` to `Loose Menu Panel`, `BossPanel`, `Boss HP Panel`, or the root `PlayerCanvas`.
+
+### Codex retry wiring and Play Mode result
+
+- Unity MCP retry connected to `BeaverProject@d3b470b190d10be0` with active scene `Assets/Scenes/Level 1 - Remastered - Steam.unity`.
+- The remastered scene had `ScorpionBoss`, `PlayerCanvas`, and `GameMaster`, but no `BossHandler` component before wiring.
+- Added `BossHandler` to the remastered scene's `Player` instance and assigned:
+  - `player` -> `Player`
+  - `Boss` -> `ScorpionBoss`
+  - `BossBar` -> `PlayerCanvas/Boss HP Panel`
+  - `BossPanel` -> `PlayerCanvas/Dialogues/BossPanel`
+  - `VictoryScreen` -> `PlayerCanvas/Finish Game Panel `
+  - `ChatCollider` left null because no boss chat trigger/source object was present in the remastered scene inspection.
+- Saved the active scene through Unity `File/Save`.
+- Play Mode smoke tested the remastered scene by calling `ScorpionScript.TakeDamage(999999999)` on `ScorpionBoss`.
+- Immediate post-kill sample:
+  - `delay=2`
+  - victory panel was hidden before death and still hidden immediately after death
+  - boss object became inactive
+  - boss health became `0`
+  - boss HP panel remained hidden
+  - `Time.timeScale` remained `1` immediately after death
+- Post-delay sample:
+  - exactly one `Finish Game Panel ` existed and exactly one was active
+  - `Loose Menu Panel` was inactive
+  - `Time.timeScale=0`
+  - cursor visible and unlocked
+  - `BeaverPlayerBehaviour.enabled=false`
+  - `FreeLook.enabled=false`
+  - Unity Console had no warnings or errors after the smoke run.
+- `GameMaster` exists in the remastered scene as `PlayerPack-Drop and Play/GameMaster`, but is tagged `Music`, not `GM`. Codex did not change this because the player already has its `GM` reference assigned and retagging could affect legacy music-tag assumptions.
+- `git diff --check` currently reports Unity-generated trailing whitespace on empty YAML scalar lines in `Level 1 - Remastered - Steam.unity`; Codex left those untouched to avoid manual YAML churn.
+
+### Play Mode validation Cursor owns
+
+- Force Scorpion boss health to zero.
+- Confirm the configured delay is respected before victory appears.
+- Confirm `BossBar` hides immediately on death and does not reappear.
+- Confirm controls stop after victory.
+- Confirm cursor becomes visible and unlocked.
+- Confirm the victory UI appears once only.
+- Confirm if the player lose screen is already active when the delay ends, victory does not appear.
+- Re-verify the remastered scene explicitly; static scan did not show the same boss/UI override evidence there as clearly as `Level 1` and `BossDemo`.
+
+### Verification completed by Codex
+
+- Static code review of the death path, boss handler, lose flow, and time-scale ownership.
+- `git diff --check` passed aside from existing Git line-ending warnings on touched files.
+- Detached-worktree Unity batch import confirmed the new PlayMode test no longer violates the test asmdef boundary pattern; remaining batch verification is blocked by unrelated Input System package compilation failures in the detached worktree environment.
+- Direct batch run against the live project remains blocked while another Unity instance has the project open.
+
+### Verification still blocked / limited
+
+- No clean Play Mode pass was completed end-to-end from Codex in this session.
+- The detached worktree currently fails on unrelated baseline compile errors under `Assets/Scripts/Core/Input/*` because `UnityEngine.InputSystem` did not resolve in that temporary import.
+- Needs Unity Play Mode verification.
+
 > **Status (2026-06-13 rollback):** Branch `fix/log-carry-animation-load` was reset to `0da224eb`. Removed player prefab commits `8f0ed3cb` and `38596429`; shared player camera prefabs match merge-base again. `Carry.cs` script changes from `d636a525` remain, but prefab serialized carry tuning is deferred. Remote branch force-pushed to match.
 
 > **Status (2026-06-13):** Codex implemented the scene-local canopy mitigation pass for `Level 1 - Remastered - Steam`. Cursor now owns Unity-side hierarchy verification, locked-route performance proof, and gameplay sanity checks on the supported minimum-spec machine.

--- a/AI_WORKFLOW/handoffs/codex-to-cursor.md
+++ b/AI_WORKFLOW/handoffs/codex-to-cursor.md
@@ -385,3 +385,89 @@ No serialized or public fields were removed in this pass.
 - Prompt and shared panel behavior are code-complete but not Unity-verified yet.
 - Legacy traders and NPCs still depend on prefab/scene references being repointed to the shared `PlayerCanvas` structure.
 - Needs Unity Play Mode verification.
+
+---
+
+# Codex Follow-up - Scorpion Boss Victory Review Blockers
+
+Date: 2026-06-13 16:34 +03:00
+
+Status: Codex took over because Cursor was unavailable. The file-level review blockers below were handled directly in the workspace. The remaining manual item is Unity Play Mode validation of the normal player-to-boss encounter route.
+
+## Goal
+
+Make the Scorpion Boss delayed victory-flow branch safe to merge by removing unrelated serialized asset churn, fixing merge hygiene issues, and validating the real Level 1 Remastered gameplay path.
+
+## Context
+
+Codex reviewed branch `fix/scorpion-boss-victory-flow` after the Level 1 Remastered wiring pass. The forced boss-death Play Mode smoke test passed: after killing `ScorpionBoss`, the configured delay elapsed, the finish panel appeared once, controls/camera froze, cursor was visible and unlocked, lose panel stayed inactive, and Unity Console showed no warnings/errors.
+
+Review originally found unrelated prefab churn and whitespace check failures. Those file-level blockers are fixed in the working tree. The smoke test and focused PlayMode tests use forced damage, so the real player-to-boss encounter path still needs manual Unity verification before merge.
+
+## Files / Areas to Inspect
+
+- `Assets/Prefabs/Objects/Bridge/StairsBridge.prefab`
+- `Assets/Scenes/Level 1 - Remastered - Steam.unity`
+- `Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs.meta`
+- `Assets/Scripts/Player/BossHandler.cs`
+- `Assets/Scripts/NPC/Scorpion/ScorpionScript.cs`
+
+## Constraints
+
+- Keep changes minimal.
+- Do not reformat unrelated Unity YAML.
+- Do not rename prefab-bound scripts, fields, GameObjects, or scene objects.
+- Do not change gameplay feel outside the Scorpion Boss victory-flow scope.
+- Do not retag `GameMaster` unless you confirm the tag change is safe for the music/game-flow systems.
+- Do not commit until the branch passes the validation below.
+
+## Required Fixes
+
+1. Revert or explicitly justify the unrelated `StairsBridge.prefab` rotation change.
+   - Review reference: `Assets/Prefabs/Objects/Bridge/StairsBridge.prefab:452`
+   - The current branch changes `m_LocalRotation` on a bridge prefab. This is outside the boss victory scope and should not ship in this PR unless separately validated and documented.
+   - Codex result: reverted to match `origin/main`.
+
+2. Fix `git diff --check origin/main...HEAD` failures.
+   - Current failures are trailing whitespace in `Assets/Scenes/Level 1 - Remastered - Steam.unity` and `Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs.meta`.
+   - Prefer a minimal Unity-safe cleanup. Do not normalize the whole scene or create broad YAML churn.
+   - Codex result: fixed in the working tree. `git diff --check origin/main` passes with only Git LF/CRLF warnings.
+
+3. Verify the real Level 1 Remastered boss encounter path.
+   - `BossHandler.ChatCollider` is currently null in the remastered scene wiring: `Assets/Scenes/Level 1 - Remastered - Steam.unity:9463`.
+   - If that is intentional, document why no chat collider is needed for this scene.
+   - If the encounter depends on boss dialogue/proximity before combat, wire the correct scene object and validate the path.
+   - Codex result: left null intentionally after Unity scene inspection. The remastered scene has no `Arena`/`BossFight` trigger or chat/dialogue object to assign, and assigning `ScorpionBoss` or `Player` would be unsafe because `BossHandler.SkipBossChat` deactivates `ChatCollider`. The victory path does not require this reference; it only affects optional boss dialogue prompt registration.
+
+## Validation
+
+- Run:
+  - `git diff --check origin/main`
+- In Unity Play Mode using `Assets/Scenes/Level 1 - Remastered - Steam.unity`:
+  - Start from the normal player route, not only an execute-code forced kill.
+  - Reach or trigger the Scorpion Boss encounter.
+  - Confirm boss UI appears at the correct time.
+  - Kill the boss normally or force health to zero after the encounter has started.
+  - Confirm the configured delay occurs before victory.
+  - Confirm controls/camera freeze or transition correctly.
+  - Confirm cursor is visible and unlocked on victory.
+  - Confirm exactly one finish/victory UI appears.
+  - Confirm lose UI does not appear at the same time.
+  - Confirm Unity Console has no new warnings/errors.
+
+## Report Back
+
+List:
+
+- Files changed
+- Whether `StairsBridge.prefab` was reverted or justified
+- Whether `ChatCollider` was intentionally left null or wired
+- `git diff --check` result
+- Play Mode validation result
+- Any remaining merge risk
+
+## Codex Validation Completed
+
+- `ScorpionBossVictoryFlowPlayModeTests`: passed 3/3 in Unity Play Mode.
+- `git diff --check origin/main`: passed; only Git LF/CRLF warnings remain.
+- `StairsBridge.prefab`: no longer differs from `origin/main`.

--- a/AI_WORKFLOW/handoffs/cursor-to-codex.md
+++ b/AI_WORKFLOW/handoffs/cursor-to-codex.md
@@ -15,12 +15,15 @@
 
 ## Problem summary
 
+
 | Issue                   | Symptom                                                             | Status                                                               |
 | ----------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | Global terrain overdraw | ~100M tris, ~10–15 FPS at bad ref coords                            | **Improved** (~34–39 FPS, ~5–21M tris at ref coords, 2026-06-12 MCP) |
 | Canopy-facing fill-rate | Severe FPS in Edit + Play when camera faces giant canopy / open sky | **Open** — Codex hypothesis: `TheGivingTree` alpha-cutout overdraw   |
 
+
 ## Current scene diff — terrain (all 33 tiles, verified in YAML)
+
 
 | Setting                     | Original | Current working diff |
 | --------------------------- | -------- | -------------------- |
@@ -33,27 +36,30 @@
 | `m_SplatMapDistance`        | 1000     | **600**              |
 | `m_DrawInstanced`           | 0        | **1**                |
 
+
 **Decorative foliage (bad bbox X 115–145, Y 70–79, Z 220–340):** `m_CastShadows: 0` on 52+ hand-placed renderers. No gameplay objects removed.
 
 ## Reference-coordinate before / after (MCP, 2026-06-12)
+
 
 | Zone                    | FPS before | Tris before | FPS after | Tris after |
 | ----------------------- | ---------- | ----------- | --------- | ---------- |
 | Bad (119.6, 72, 266.1)  | ~10.5–14.9 | ~80–105M    | ~34–39    | ~5–21M     |
 | Good (149.1, 70, 167.5) | ~72–83     | —           | ~72       | ~14M       |
 
+
 Does **not** certify the canopy-facing repro — that remains user-reported open.
 
 ## Prior script work on same branch (for Codex review)
 
-1. **`Carry.cs`** — independent movement vs animation multipliers; gated penalty refresh
-2. **`NpcDialoguePresenter.cs`** — shutdown guard; idle tick throttle
-3. **`BeaverPlayerBehaviour.cs`** — HUD / life-icon string caching
+1. `**Carry.cs`** — independent movement vs animation multipliers; gated penalty refresh
+2. `**NpcDialoguePresenter.cs`** — shutdown guard; idle tick throttle
+3. `**BeaverPlayerBehaviour.cs**` — HUD / life-icon string caching
 
 ## What Codex should do
 
 - [x] Static review of canopy shader/material path (done — see `codex-to-cursor.md`)
-- [ ] Optional: diff review of three scripts above when preparing merge
+- [x] Optional: diff review of three scripts above when preparing merge
 - [ ] Run `dotnet build .ci/BeaverMania.CI.csproj` if Unity managed refs available
 - [ ] PR summary after Cursor completes pass 2 A/B
 

--- a/Assets/Prefabs/Objects/Bridge/StairsBridge.prefab
+++ b/Assets/Prefabs/Objects/Bridge/StairsBridge.prefab
@@ -449,7 +449,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3254111133986252792}
-  m_LocalRotation: {x: -0.47121593, y: 0.52721494, z: 0.52721494, w: 0.47121593}
+  m_LocalRotation: {x: -0.52572054, y: 0.47288257, z: 0.47288257, w: 0.52572054}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Assets/Prefabs/Objects/Bridge/StairsBridge.prefab
+++ b/Assets/Prefabs/Objects/Bridge/StairsBridge.prefab
@@ -449,7 +449,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3254111133986252792}
-  m_LocalRotation: {x: -0.52572054, y: 0.47288257, z: 0.47288257, w: 0.52572054}
+  m_LocalRotation: {x: -0.47121593, y: 0.52721494, z: 0.52721494, w: 0.47121593}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Assets/Scenes/Level 1 - Remastered - Steam.unity
+++ b/Assets/Scenes/Level 1 - Remastered - Steam.unity
@@ -152,7 +152,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 125
+  m_RootOrder: 126
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &15992013
 PrefabInstance:
@@ -179,7 +179,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -384,8 +384,20 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 128
+  m_RootOrder: 129
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!134 &27838247
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ' (Instance)'
+  dynamicFriction: 0.6
+  staticFriction: 0.6
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 0
 --- !u!1 &38035844
 GameObject:
   m_ObjectHideFlags: 0
@@ -481,7 +493,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 31
+  m_RootOrder: 32
   m_LocalEulerAnglesHint: {x: 0, y: -14.703, z: 0}
 --- !u!1001 &47511939
 PrefabInstance:
@@ -496,7 +508,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 66
+      value: 67
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -585,7 +597,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 36
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -954,7 +966,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 120
+      value: 121
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1040,7 +1052,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 119
+      value: 120
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1269,7 +1281,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 130
+  m_RootOrder: 131
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &112633675
 PrefabInstance:
@@ -1280,7 +1292,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 71
+      value: 72
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1337,7 +1349,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1040850931279014532, guid: 11c80d5bf0fb6624eba4429b8c584d5d, type: 3}
       propertyPath: m_RootOrder
-      value: 88
+      value: 89
       objectReference: {fileID: 0}
     - target: {fileID: 1040850931279014532, guid: 11c80d5bf0fb6624eba4429b8c584d5d, type: 3}
       propertyPath: m_LocalScale.x
@@ -1427,7 +1439,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 78
+      value: 79
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -1512,7 +1524,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 50
+      value: 51
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1701,7 +1713,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1754,7 +1766,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1815,7 +1827,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 91
+      value: 92
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1876,7 +1888,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 79
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -1953,7 +1965,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 73
+      value: 74
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -2022,7 +2034,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 104
+      value: 105
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2079,7 +2091,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 64
+      value: 65
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2136,7 +2148,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 35
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2201,7 +2213,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b0ea4d3f7274ce14ea02560e718eb6fb, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 101
+      value: 102
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -2270,7 +2282,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 102
+      value: 103
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2343,7 +2355,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 37
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2536,7 +2548,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b0ea4d3f7274ce14ea02560e718eb6fb, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 45
+      value: 46
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -2605,7 +2617,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2670,7 +2682,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 81
+      value: 82
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -2739,7 +2751,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 110
+      value: 111
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2874,7 +2886,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 77
+      value: 78
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2935,7 +2947,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 54
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3098,7 +3110,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 126
+  m_RootOrder: 127
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &403897995
 PrefabInstance:
@@ -3109,7 +3121,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3166,7 +3178,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 70
+      value: 71
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3727,7 +3739,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 51
+      value: 52
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4018,7 +4030,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 117
+      value: 118
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4071,7 +4083,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 113
+      value: 114
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4124,6 +4136,68 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6107630362012945906, guid: 12333afb052a5d44eb6a7bd09ccd4c07, type: 3}
   m_PrefabInstance: {fileID: 787714881}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &531746582 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9155236688877285533, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
+  m_PrefabInstance: {fileID: 912990848}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &544397262
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8497600843494159890, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_Name
+      value: ArmorBundle
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 733.59485
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 70.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 261.99582
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8497600843494159893, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 80532d36533f4d5458f46e671fb8ea29, type: 3}
 --- !u!1001 &551575829
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4133,7 +4207,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2546736939327218311, guid: 231991aabb568a143b480c4e6638d511, type: 3}
       propertyPath: m_RootOrder
-      value: 111
+      value: 112
       objectReference: {fileID: 0}
     - target: {fileID: 2546736939327218311, guid: 231991aabb568a143b480c4e6638d511, type: 3}
       propertyPath: m_LocalScale.x
@@ -4214,7 +4288,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 108
+      value: 109
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -4443,7 +4517,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 84
+      value: 85
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4528,7 +4602,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 122
+      value: 123
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4742,7 +4816,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3744310324738383381, guid: 9a9a7159ff50ac546bee7767fa9538fb, type: 3}
       propertyPath: m_RootOrder
-      value: 105
+      value: 106
       objectReference: {fileID: 0}
     - target: {fileID: 3744310324738383381, guid: 9a9a7159ff50ac546bee7767fa9538fb, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4816,7 +4890,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3635493143600522279, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
   m_PrefabInstance: {fileID: 912990848}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1276241195}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8c489014c99e2174688db9b08f27a14e, type: 3}
@@ -4836,7 +4910,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 43
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4913,7 +4987,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 133
+  m_RootOrder: 134
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &636730828
 PrefabInstance:
@@ -4924,7 +4998,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1040850931279014532, guid: 11c80d5bf0fb6624eba4429b8c584d5d, type: 3}
       propertyPath: m_RootOrder
-      value: 58
+      value: 59
       objectReference: {fileID: 0}
     - target: {fileID: 1040850931279014532, guid: 11c80d5bf0fb6624eba4429b8c584d5d, type: 3}
       propertyPath: m_LocalScale.x
@@ -5006,7 +5080,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 24
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5141,7 +5215,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3744310324738383381, guid: 9a9a7159ff50ac546bee7767fa9538fb, type: 3}
       propertyPath: m_RootOrder
-      value: 41
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 3744310324738383381, guid: 9a9a7159ff50ac546bee7767fa9538fb, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5533,7 +5607,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5590,7 +5664,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 38
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5652,7 +5726,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 33
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5709,7 +5783,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 62
+      value: 63
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5791,7 +5865,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 132
+  m_RootOrder: 133
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &765436982
 PrefabInstance:
@@ -5978,7 +6052,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 93
+  m_RootOrder: 94
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &769650969
 GameObject:
@@ -6083,6 +6157,10 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -10.75
       objectReference: {fileID: 0}
+    - target: {fileID: 3561575782887557094, guid: 12333afb052a5d44eb6a7bd09ccd4c07, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 1461571723}
     - target: {fileID: 4047390275912104287, guid: 12333afb052a5d44eb6a7bd09ccd4c07, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -6097,7 +6175,7 @@ PrefabInstance:
       objectReference: {fileID: 622077645}
     - target: {fileID: 6107630362012945906, guid: 12333afb052a5d44eb6a7bd09ccd4c07, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6107630362012945906, guid: 12333afb052a5d44eb6a7bd09ccd4c07, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6170,7 +6248,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 80
+      value: 81
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6438,7 +6516,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 48
+  m_RootOrder: 50
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &834004124
 GameObject:
@@ -6502,7 +6580,7 @@ Transform:
   - {fileID: 1452062318}
   - {fileID: 1115031705}
   m_Father: {fileID: 0}
-  m_RootOrder: 96
+  m_RootOrder: 98
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &837617546
 PrefabInstance:
@@ -6513,7 +6591,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6648,7 +6726,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8440594398049331139, guid: 6566e9a37c11d844ba0dd05e39e15e3c, type: 3}
       propertyPath: m_RootOrder
-      value: 74
+      value: 75
       objectReference: {fileID: 0}
     - target: {fileID: 8440594398049331139, guid: 6566e9a37c11d844ba0dd05e39e15e3c, type: 3}
       propertyPath: m_LocalScale.x
@@ -6717,7 +6795,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3247474872940375630, guid: faa232351140d09468c55b9d5a0ec242, type: 3}
       propertyPath: m_RootOrder
-      value: 103
+      value: 104
       objectReference: {fileID: 0}
     - target: {fileID: 3247474872940375630, guid: faa232351140d09468c55b9d5a0ec242, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6770,7 +6848,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 98
+      value: 99
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6867,7 +6945,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -5.6315384
+      value: 610.28845
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.y
@@ -6875,23 +6953,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -2.070221
+      value: 42.309784
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.8175189
+      value: 0.81751895
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.047024567
+      value: 0.047024466
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.5730315
+      value: 0.57303154
       objectReference: {fileID: 0}
     - target: {fileID: 1000556504309845918, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.032961383
+      value: -0.03296133
       objectReference: {fileID: 0}
     - target: {fileID: 1105702949010364755, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_IsActive
@@ -7043,7 +7121,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2632195211733470617, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 2632195211733470617, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7107,11 +7185,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3635493143600522712, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 615.92
       objectReference: {fileID: 0}
     - target: {fileID: 3635493143600522712, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 44.38
       objectReference: {fileID: 0}
     - target: {fileID: 3635493143600522712, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.w
@@ -7133,6 +7211,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: 69.816
       objectReference: {fileID: 0}
+    - target: {fileID: 3635493143600522715, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 1406379261}
     - target: {fileID: 3647759001035296367, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_RootOrder
       value: 7
@@ -7235,15 +7317,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.057426024
+      value: 0.057425924
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0020929577
+      value: 0.0020931663
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677778, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00012039208
+      value: -0.00012040325
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677789, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
@@ -7251,23 +7333,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401154677789, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
-      value: 1.3689065
+      value: 1.7092084
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401701884423, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 0.7170544
+      value: 1.888381
       objectReference: {fileID: 0}
     - target: {fileID: 5220285401701884423, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.659385
+      value: -6.046711
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402168899005, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 0.7170544
+      value: 1.888381
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402168899005, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.659385
+      value: -6.046711
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402263606164, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
@@ -7279,7 +7361,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402263606165, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.0000067949295
+      value: 0.000005841255
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402263606165, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.y
@@ -7287,7 +7369,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402263606165, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -6.0000024
+      value: -5.9999943
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7307,15 +7389,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.039305095
+      value: 0.039305013
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0020948055
+      value: 0.002095044
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102626, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.0000823997
+      value: -0.00008240902
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102637, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
@@ -7323,43 +7405,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402831102637, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
-      value: 1.3689065
+      value: 1.7092084
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402922294815, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.y
-      value: 0.7170544
+      value: 1.888381
       objectReference: {fileID: 0}
     - target: {fileID: 5220285402922294815, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_FollowOffset.z
-      value: -5.659385
+      value: -6.046711
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 0.0000029802322
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.4116211
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -0.046691418
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.99713784
+      value: 0.9990904
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.07557596
+      value: 0.04259223
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.002090454
+      value: 0.0020788314
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118818, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00015844034
+      value: -0.000088619076
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118829, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.FieldOfView
@@ -7367,7 +7449,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5220285403158118829, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Lens.m_SensorSize.x
-      value: 1.3689065
+      value: 1.7092084
       objectReference: {fileID: 0}
     - target: {fileID: 5499620694491381217, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_RootOrder
@@ -7453,13 +7535,17 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6266455513764544185, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 27838247}
     - target: {fileID: 6361804713551845010, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Intensity
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6555864611225620117, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -4.358429
+      value: -0.76476455
       objectReference: {fileID: 0}
     - target: {fileID: 6555864611225620117, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.y
@@ -7467,7 +7553,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6555864611225620117, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 4.123599
+      value: 5.9510427
       objectReference: {fileID: 0}
     - target: {fileID: 6770926800000908136, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7700,7 +7786,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 42
+      value: 43
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8248,7 +8334,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3744310324738383381, guid: 9a9a7159ff50ac546bee7767fa9538fb, type: 3}
       propertyPath: m_RootOrder
-      value: 83
+      value: 84
       objectReference: {fileID: 0}
     - target: {fileID: 3744310324738383381, guid: 9a9a7159ff50ac546bee7767fa9538fb, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8325,7 +8411,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 90
+      value: 91
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -8554,7 +8640,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 107
+      value: 108
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8615,7 +8701,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3247474872940375630, guid: faa232351140d09468c55b9d5a0ec242, type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 3247474872940375630, guid: faa232351140d09468c55b9d5a0ec242, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8668,7 +8754,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 87
+      value: 88
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9102,7 +9188,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 68
+      value: 69
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9197,7 +9283,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 118
+      value: 119
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9250,7 +9336,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4024942761368907222, guid: 12fb6e1e10242fc4cb47f391aadead31, type: 3}
       propertyPath: m_RootOrder
-      value: 32
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 4024942761368907222, guid: 12fb6e1e10242fc4cb47f391aadead31, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9307,7 +9393,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9355,6 +9441,40 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
+--- !u!1 &1276241195 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3635493143600522277, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
+  m_PrefabInstance: {fileID: 912990848}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1276241212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276241195}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a565b4e62b079c428781a90fe631c25, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 622077645}
+  Boss: {fileID: 1289681281}
+  ChatCollider: {fileID: 0}
+  BossBar: {fileID: 531746582}
+  BossPanel: {fileID: 1884270841}
+  VictoryScreen: {fileID: 1984202309}
+--- !u!114 &1289681281 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6107630362012945905, guid: 12333afb052a5d44eb6a7bd09ccd4c07, type: 3}
+  m_PrefabInstance: {fileID: 787714881}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3162e48494bc64ab26370e7a299cde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1311969611
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9426,7 +9546,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 89
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9499,7 +9619,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 99
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9684,7 +9804,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9769,7 +9889,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 116
+      value: 117
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9920,7 +10040,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 129
+  m_RootOrder: 130
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1381816619
 GameObject:
@@ -10017,7 +10137,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 69
+      value: 70
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -10335,7 +10455,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2973149261809905399, guid: f5ba9e2973c6d8d4cad295b79e2a7f45, type: 3}
       propertyPath: m_RootOrder
-      value: 76
+      value: 77
       objectReference: {fileID: 0}
     - target: {fileID: 2973149261809905399, guid: f5ba9e2973c6d8d4cad295b79e2a7f45, type: 3}
       propertyPath: m_LocalScale.x
@@ -10412,7 +10532,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 55
+      value: 56
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10456,6 +10576,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
+--- !u!134 &1406379261
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ' (Instance)'
+  dynamicFriction: 0.6
+  staticFriction: 0.6
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 0
 --- !u!1001 &1429071591
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10465,7 +10597,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 23
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10526,7 +10658,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 34
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10615,7 +10747,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10672,7 +10804,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2546736939327218311, guid: 231991aabb568a143b480c4e6638d511, type: 3}
       propertyPath: m_RootOrder
-      value: 47
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 2546736939327218311, guid: 231991aabb568a143b480c4e6638d511, type: 3}
       propertyPath: m_LocalScale.x
@@ -10827,7 +10959,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1000002, guid: c3a41780c9b34a3da461643bd974cb26, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 1000002, guid: c3a41780c9b34a3da461643bd974cb26, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11001,6 +11133,18 @@ Transform:
   m_Father: {fileID: 834004125}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!134 &1461571723
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  dynamicFriction: 0.6
+  staticFriction: 0.6
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 0
 --- !u!1 &1464040392
 GameObject:
   m_ObjectHideFlags: 0
@@ -11030,7 +11174,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 134
+  m_RootOrder: 135
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1466635508
 PrefabInstance:
@@ -11049,7 +11193,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b0ea4d3f7274ce14ea02560e718eb6fb, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 63
+      value: 64
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -11196,7 +11340,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 61
+      value: 62
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11253,7 +11397,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 67
+      value: 68
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11310,7 +11454,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 59
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11450,7 +11594,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11507,7 +11651,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 82
+      value: 83
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11564,7 +11708,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 106
+      value: 107
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11838,7 +11982,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 86
+      value: 87
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12023,7 +12167,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 22
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12078,13 +12222,17 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3105038987031545733, guid: 3ca01142054c997498fd413b391cbfcc, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 1618395256}
     - target: {fileID: 6097588891569378077, guid: 3ca01142054c997498fd413b391cbfcc, type: 3}
       propertyPath: m_Name
       value: SM_Env_Rock_Cliff_02
       objectReference: {fileID: 0}
     - target: {fileID: 6905474423578167719, guid: 3ca01142054c997498fd413b391cbfcc, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6905474423578167719, guid: 3ca01142054c997498fd413b391cbfcc, type: 3}
       propertyPath: m_LocalScale.x
@@ -12165,6 +12313,18 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2391455183122611368, guid: f26a9274b8364d2eadcc13c8cb72a4fb, type: 3}
   m_PrefabInstance: {fileID: 880100000000002006}
   m_PrefabAsset: {fileID: 0}
+--- !u!134 &1618395256
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  dynamicFriction: 0.6
+  staticFriction: 0.6
+  bounciness: 0
+  frictionCombine: 0
+  bounceCombine: 0
 --- !u!1001 &1626259500
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12178,7 +12338,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12472,7 +12632,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12537,7 +12697,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 95
+      value: 96
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -12606,7 +12766,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 109
+      value: 110
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12663,7 +12823,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 65
+      value: 66
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12826,7 +12986,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 123
+      value: 124
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12992,7 +13152,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 124
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13045,7 +13205,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 60
+      value: 61
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13102,7 +13262,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1040850931279014532, guid: 11c80d5bf0fb6624eba4429b8c584d5d, type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1040850931279014532, guid: 11c80d5bf0fb6624eba4429b8c584d5d, type: 3}
       propertyPath: m_LocalScale.x
@@ -13184,7 +13344,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 40
+      value: 41
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13286,7 +13446,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 28
+  m_RootOrder: 29
   m_LocalEulerAnglesHint: {x: 0, y: -23.224, z: 0}
 --- !u!1001 &1783052359
 PrefabInstance:
@@ -13317,7 +13477,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7768601906473230819, guid: 0f2120e89197acc47bfde23175d19f26, type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 7768601906473230819, guid: 0f2120e89197acc47bfde23175d19f26, type: 3}
       propertyPath: m_LocalScale.x
@@ -13402,7 +13562,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13459,7 +13619,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: a9ab47e5edfc1d642aa3b203137260a5, type: 2}
     - target: {fileID: 8338378301107198266, guid: 5f65c00cc3a462845922182b4a0afbd9, type: 3}
       propertyPath: m_RootOrder
-      value: 25
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 8338378301107198266, guid: 5f65c00cc3a462845922182b4a0afbd9, type: 3}
       propertyPath: m_LocalScale.x
@@ -13548,7 +13708,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 53
+      value: 54
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13733,7 +13893,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 92
+      value: 93
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13790,7 +13950,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13872,7 +14032,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 127
+  m_RootOrder: 128
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1821628123
 GameObject:
@@ -13969,7 +14129,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 114
+  m_RootOrder: 116
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1834438920
 GameObject:
@@ -14066,7 +14226,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7303239927592868563, guid: 134f14d107514df4c910feac79050dfa, type: 3}
       propertyPath: m_RootOrder
-      value: 100
+      value: 101
       objectReference: {fileID: 0}
     - target: {fileID: 7303239927592868563, guid: 134f14d107514df4c910feac79050dfa, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14119,7 +14279,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 52
+      value: 53
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14176,7 +14336,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 46
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14224,6 +14384,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
+--- !u!1 &1884270841 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7611198330004951311, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
+  m_PrefabInstance: {fileID: 912990848}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1904467592
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14233,7 +14398,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 44
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14582,7 +14747,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3456968274152152882, guid: 71817b782d9840b4ca3c247d66955dac, type: 3}
       propertyPath: m_RootOrder
-      value: 85
+      value: 86
       objectReference: {fileID: 0}
     - target: {fileID: 3456968274152152882, guid: 71817b782d9840b4ca3c247d66955dac, type: 3}
       propertyPath: m_LocalPosition.x
@@ -15271,7 +15436,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -15328,7 +15493,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3744310324738383381, guid: 9a9a7159ff50ac546bee7767fa9538fb, type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 3744310324738383381, guid: 9a9a7159ff50ac546bee7767fa9538fb, type: 3}
       propertyPath: m_LocalPosition.x
@@ -15421,7 +15586,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 131
+  m_RootOrder: 132
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1945513441
 PrefabInstance:
@@ -15432,7 +15597,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 72
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -15744,7 +15909,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 94
+      value: 95
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -15925,6 +16090,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
   m_PrefabInstance: {fileID: 1107094084}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1984202309 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9155236690012679504, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
+  m_PrefabInstance: {fileID: 912990848}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1990091418
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15938,7 +16108,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: b585e19995ebf6849aef78956a833b15, type: 2}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_RootOrder
-      value: 112
+      value: 113
       objectReference: {fileID: 0}
     - target: {fileID: 8415304551286992157, guid: 1adbdd5ea9a76d247a3f262569b3e059, type: 3}
       propertyPath: m_LocalScale.x
@@ -16011,7 +16181,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1040850931279014532, guid: 11c80d5bf0fb6624eba4429b8c584d5d, type: 3}
       propertyPath: m_RootOrder
-      value: 57
+      value: 58
       objectReference: {fileID: 0}
     - target: {fileID: 1040850931279014532, guid: 11c80d5bf0fb6624eba4429b8c584d5d, type: 3}
       propertyPath: m_LocalScale.x
@@ -16093,7 +16263,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16166,7 +16336,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 75
+      value: 76
       objectReference: {fileID: 0}
     - target: {fileID: 1022977966684311796, guid: 973023a5853556b44b49f7bb95d38cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16379,7 +16549,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_RootOrder
-      value: 121
+      value: 122
       objectReference: {fileID: 0}
     - target: {fileID: 7634769701134653034, guid: 5506d011520fcd7418fcfce3cbaf494e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16432,7 +16602,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16489,7 +16659,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_RootOrder
-      value: 56
+      value: 57
       objectReference: {fileID: 0}
     - target: {fileID: 7679416759401954528, guid: 9f5cfb054d2b7174882402aae5da7193, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16578,7 +16748,7 @@ Transform:
   - {fileID: 619728386}
   - {fileID: 1515429428}
   m_Father: {fileID: 0}
-  m_RootOrder: 135
+  m_RootOrder: 136
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &880100000000001011
 GameObject:
@@ -16617,7 +16787,7 @@ Transform:
   - {fileID: 591025149}
   - {fileID: 1166240897}
   m_Father: {fileID: 0}
-  m_RootOrder: 136
+  m_RootOrder: 137
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &880100000000001021
 GameObject:
@@ -16649,7 +16819,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 137
+  m_RootOrder: 138
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &880100000000001023
 MonoBehaviour:

--- a/Assets/Scenes/Level 1 - Remastered - Steam.unity
+++ b/Assets/Scenes/Level 1 - Remastered - Steam.unity
@@ -6159,7 +6159,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3561575782887557094, guid: 12333afb052a5d44eb6a7bd09ccd4c07, type: 3}
       propertyPath: m_Material
-      value: 
+      value:
       objectReference: {fileID: 1461571723}
     - target: {fileID: 4047390275912104287, guid: 12333afb052a5d44eb6a7bd09ccd4c07, type: 3}
       propertyPath: m_AnchorMax.x
@@ -7213,7 +7213,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3635493143600522715, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Material
-      value: 
+      value:
       objectReference: {fileID: 1406379261}
     - target: {fileID: 3647759001035296367, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_RootOrder
@@ -7537,7 +7537,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6266455513764544185, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Material
-      value: 
+      value:
       objectReference: {fileID: 27838247}
     - target: {fileID: 6361804713551845010, guid: 2a15f0e1de9076d439fed905191529e4, type: 3}
       propertyPath: m_Intensity
@@ -9456,8 +9456,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7a565b4e62b079c428781a90fe631c25, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   player: {fileID: 622077645}
   Boss: {fileID: 1289681281}
   ChatCollider: {fileID: 0}
@@ -9473,8 +9473,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3d3162e48494bc64ab26370e7a299cde, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1001 &1311969611
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11139,7 +11139,7 @@ PhysicMaterial:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: 
+  m_Name:
   dynamicFriction: 0.6
   staticFriction: 0.6
   bounciness: 0
@@ -12224,7 +12224,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3105038987031545733, guid: 3ca01142054c997498fd413b391cbfcc, type: 3}
       propertyPath: m_Material
-      value: 
+      value:
       objectReference: {fileID: 1618395256}
     - target: {fileID: 6097588891569378077, guid: 3ca01142054c997498fd413b391cbfcc, type: 3}
       propertyPath: m_Name
@@ -12319,7 +12319,7 @@ PhysicMaterial:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: 
+  m_Name:
   dynamicFriction: 0.6
   staticFriction: 0.6
   bounciness: 0

--- a/Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs
+++ b/Assets/Scripts/Core/GameFlow/GameTimeScaleGate.cs
@@ -15,6 +15,7 @@ namespace Beavermania.Core.GameFlow
             None = 0,
             PauseMenu = 1 << 0,
             LooseScreen = 1 << 1,
+            VictoryScreen = 1 << 2,
         }
 
         const float FrozenScale = 0f;

--- a/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
+++ b/Assets/Scripts/NPC/Scorpion/ScorpionScript.cs
@@ -1,3 +1,4 @@
+using System;
 using Beavermania.Data.NPC;
 using Beavermania.Objects;
 using Beavermania.Player.Combat;
@@ -78,10 +79,12 @@ namespace Beavermania.NPC
         float minimumChargeTimeRemaining;
         float hitEffectTimer;
         bool deathHandled;
+        [SerializeField] float victoryDelay = 2f;
 
         public ScorpionState State => currentState;
         public ScorpionStatsData StatsData => ActiveStats;
         public int MaxHealth => ActiveStats.maxHealth;
+        public float VictoryDelay => Mathf.Max(0f, victoryDelay);
         public int comboLimit => ActiveStats.comboLimit;
         public float StunnedClock => currentState == ScorpionState.Stunned ? stateTimer : 0f;
         public float chargeSpeed => ActiveStats.chargeSpeed;
@@ -94,6 +97,7 @@ namespace Beavermania.NPC
         public int StingDamageAmount => ActiveStats.stingDamage;
         public float rotationSpeed => ActiveStats.rotationSpeed;
         public float recoveryDuration => ActiveStats.recoveryDuration;
+        public event Action<ScorpionScript> Defeated;
         bool IsAggressive => combo >= Mathf.Max(0, comboLimit - 5);
         float ReverseDistanceThreshold => Mathf.Max(0f, chargeDistance - 10f);
         ScorpionStatsData ActiveStats => statsData != null ? statsData : ResolveFallbackStats();
@@ -397,6 +401,7 @@ namespace Beavermania.NPC
                 }
             }
 
+            Defeated?.Invoke(this);
             gameObject.SetActive(false);
         }
 

--- a/Assets/Scripts/Player/BossHandler.cs
+++ b/Assets/Scripts/Player/BossHandler.cs
@@ -1,5 +1,5 @@
 using System.Collections;
-using System.Collections.Generic;
+using Beavermania.Core.GameFlow;
 using Beavermania.NPC;
 using Beavermania.Player;
 using BeaverPlayer = Beavermania.Player.BeaverPlayerBehaviour;
@@ -16,24 +16,47 @@ namespace Beavermania.Player.Combat
         public GameObject ChatCollider;
         public GameObject BossBar;
         public GameObject BossPanel;
+        public GameObject VictoryScreen;
         //public GameObject BossContinueButton;
         //public GameObject BossSkipButton;
         BossDialogueInteractionSource dialogueInteractionSource;
+        Coroutine victorySequenceCoroutine;
+        ScorpionScript subscribedBoss;
+        bool victorySequenceStarted;
 
+        void Awake()
+        {
+            ResolvePlayerReference();
+            EnsureDialogueSource();
+        }
+
+        void OnEnable()
+        {
+            RefreshBossSubscription();
+        }
 
         void Start()
         {
-            player = GetComponent<BeaverPlayer>();
-            var bossObject = GameObject.Find("ScorpionBoss");
-            if (bossObject != null)
-                Boss = bossObject.GetComponent<ScorpionScript>();
+            ResolvePlayerReference();
+            ResolveBossReference();
             EnsureDialogueSource();
+            RefreshBossSubscription();
             if (BossBar != null)
                 BossBar.SetActive(false);
         }
 
+        void OnDisable()
+        {
+            StopVictorySequence();
+            UnsubscribeFromBoss();
+        }
+
         void Update()
         {
+            ResolvePlayerReference();
+            ResolveBossReference();
+            RefreshBossSubscription();
+
             if (Boss == null)
             {
                 if (BossBar != null && BossBar.activeSelf)
@@ -137,6 +160,120 @@ namespace Beavermania.Player.Combat
                 dialogueInteractionSource = ChatCollider.AddComponent<BossDialogueInteractionSource>();
 
             dialogueInteractionSource.Configure(this);
+        }
+
+        void ResolvePlayerReference()
+        {
+            if (player == null)
+                player = GetComponent<BeaverPlayer>();
+        }
+
+        void ResolveBossReference()
+        {
+            if (Boss != null)
+                return;
+
+            var bossObject = GameObject.Find("ScorpionBoss");
+            if (bossObject != null)
+                Boss = bossObject.GetComponent<ScorpionScript>();
+        }
+
+        void RefreshBossSubscription()
+        {
+            if (subscribedBoss == Boss)
+                return;
+
+            UnsubscribeFromBoss();
+
+            if (Boss == null)
+                return;
+
+            Boss.Defeated += OnBossDefeated;
+            subscribedBoss = Boss;
+        }
+
+        void UnsubscribeFromBoss()
+        {
+            if (subscribedBoss == null)
+                return;
+
+            subscribedBoss.Defeated -= OnBossDefeated;
+            subscribedBoss = null;
+        }
+
+        void OnBossDefeated(ScorpionScript defeatedBoss)
+        {
+            if (victorySequenceStarted)
+                return;
+
+            victorySequenceStarted = true;
+            if (BossBar != null)
+                BossBar.SetActive(false);
+            if (BossPanel != null)
+                BossPanel.SetActive(false);
+            if (ChatCollider != null)
+                ChatCollider.SetActive(false);
+            if (dialogueInteractionSource != null)
+                dialogueInteractionSource.SetInteractionAvailable(false);
+
+            StopVictorySequence();
+            victorySequenceCoroutine = StartCoroutine(TriggerVictoryAfterDelay(defeatedBoss != null ? defeatedBoss.VictoryDelay : 0f));
+        }
+
+        IEnumerator TriggerVictoryAfterDelay(float delaySeconds)
+        {
+            if (delaySeconds > 0f)
+                yield return new WaitForSecondsRealtime(delaySeconds);
+
+            victorySequenceCoroutine = null;
+            if (IsLoseScreenActive())
+                yield break;
+
+            TriggerVictory();
+        }
+
+        void TriggerVictory()
+        {
+            GameTimeScaleGate.SetFreeze(GameTimeScaleGate.FreezeToken.VictoryScreen, true);
+
+            if (player != null)
+            {
+                if (player.Music != null)
+                    player.Music.StopMusic();
+
+                player.isAtTrader = false;
+                player.ShowCursor();
+
+                if (player.FreeLook != null)
+                    player.FreeLook.enabled = false;
+                if (player.CamForTraders != null)
+                    player.CamForTraders.enabled = false;
+
+                player.enabled = false;
+            }
+
+            if (BossBar != null)
+                BossBar.SetActive(false);
+            if (BossPanel != null)
+                BossPanel.SetActive(false);
+            if (VictoryScreen != null)
+                VictoryScreen.SetActive(true);
+        }
+
+        bool IsLoseScreenActive()
+        {
+            return player != null
+                && player.LooseScreen != null
+                && player.LooseScreen.activeSelf;
+        }
+
+        void StopVictorySequence()
+        {
+            if (victorySequenceCoroutine == null)
+                return;
+
+            StopCoroutine(victorySequenceCoroutine);
+            victorySequenceCoroutine = null;
         }
 
 

--- a/Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs
+++ b/Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Beavermania.Tests.PlayMode.Core.GameFlow
+{
+    public sealed class ScorpionBossVictoryFlowPlayModeTests
+    {
+        readonly Dictionary<string, Type> cachedRuntimeTypes = new(StringComparer.Ordinal);
+        readonly List<GameObject> spawnedObjects = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            InvokeStaticMethod("Beavermania.Core.GameFlow.GameTimeScaleGate", "ClearAll");
+
+            for (int index = 0; index < spawnedObjects.Count; index++)
+            {
+                if (spawnedObjects[index] != null)
+                    UnityEngine.Object.DestroyImmediate(spawnedObjects[index]);
+            }
+
+            spawnedObjects.Clear();
+        }
+
+        [UnityTest]
+        public IEnumerator BossDefeatedEvent_FiresOnce_WhenDeathIsTriggeredMultipleWays()
+        {
+            BossHarness harness = CreateHarness(victoryDelay: 0.1f);
+            int defeatEvents = 0;
+            EventInfo defeatedEvent = harness.Boss.GetType().GetEvent("Defeated");
+            Delegate defeatedHandler = CreateTypedActionDelegate(defeatedEvent.EventHandlerType, () => defeatEvents++);
+
+            defeatedEvent.AddEventHandler(harness.Boss, defeatedHandler);
+
+            yield return null;
+
+            Assert.That(GetPropertyValue<float>(harness.Boss, "VictoryDelay"), Is.EqualTo(0.1f).Within(0.0001f));
+
+            InvokeMethod(harness.Boss, "ReceiveDamage", GetFieldValue<int>(harness.Boss, "CurrentHealth"), CreateEnemyDamageType("Normal"), null);
+            InvokeMethod(harness.Boss, "TakeDamage", 1);
+            InvokeMethod(harness.Boss, "ReceiveDamage", 1, CreateEnemyDamageType("Normal"), null);
+
+            Assert.That(defeatEvents, Is.EqualTo(1));
+
+            defeatedEvent.RemoveEventHandler(harness.Boss, defeatedHandler);
+        }
+
+        [UnityTest]
+        public IEnumerator VictoryFlow_WaitsForDelay_ThenShowsVictoryExactlyOnce()
+        {
+            BossHarness harness = CreateHarness(victoryDelay: 0.15f);
+
+            yield return null;
+
+            harness.BossBar.SetActive(true);
+            KillBoss(harness.Boss);
+
+            Assert.That(harness.BossBar.activeSelf, Is.False);
+            Assert.That(harness.VictoryScreen.activeSelf, Is.False);
+            Assert.That(((Behaviour)harness.Player).enabled, Is.True);
+
+            yield return new WaitForSecondsRealtime(0.05f);
+
+            Assert.That(harness.VictoryScreen.activeSelf, Is.False);
+            Assert.That(((Behaviour)harness.Player).enabled, Is.True);
+
+            yield return new WaitForSecondsRealtime(0.2f);
+
+            Assert.That(harness.VictoryScreen.activeSelf, Is.True);
+            Assert.That(harness.BossBar.activeSelf, Is.False);
+            Assert.That(((Behaviour)harness.Player).enabled, Is.False);
+            Assert.That(GetStaticPropertyValue<bool>("Beavermania.Core.GameFlow.GameTimeScaleGate", "IsFrozen"), Is.True);
+            Assert.That(Time.timeScale, Is.EqualTo(0f));
+        }
+
+        [UnityTest]
+        public IEnumerator VictoryFlow_DoesNotActivate_WhenLoseScreenWinsDuringDelay()
+        {
+            BossHarness harness = CreateHarness(victoryDelay: 0.2f);
+
+            yield return null;
+
+            harness.BossBar.SetActive(true);
+            KillBoss(harness.Boss);
+            yield return new WaitForSecondsRealtime(0.05f);
+
+            InvokeMethod(harness.Player, "ActivateLooseMenu");
+            yield return new WaitForSecondsRealtime(0.25f);
+
+            Assert.That(harness.LoseScreen.activeSelf, Is.True);
+            Assert.That(harness.VictoryScreen.activeSelf, Is.False);
+            Assert.That(harness.BossBar.activeSelf, Is.False);
+            Assert.That(((Behaviour)harness.Player).enabled, Is.True);
+            Assert.That(GetStaticPropertyValue<bool>("Beavermania.Core.GameFlow.GameTimeScaleGate", "IsFrozen"), Is.True);
+            Assert.That(Time.timeScale, Is.EqualTo(0f));
+        }
+
+        BossHarness CreateHarness(float victoryDelay)
+        {
+            GameObject cameraObject = Spawn("Main Camera");
+            cameraObject.tag = "MainCamera";
+            cameraObject.AddComponent<Camera>();
+
+            GameObject playerObject = Spawn("Player");
+            playerObject.tag = "Player";
+            playerObject.AddComponent<Rigidbody>();
+
+            Animator playerAnimator = playerObject.AddComponent<Animator>();
+            playerAnimator.logWarnings = false;
+
+            Component player = playerObject.AddComponent(ResolveRuntimeType("Beavermania.Player.BeaverPlayerBehaviour"));
+            SetFieldValue(player, "Otter", playerAnimator);
+            SetFieldValue(player, "HoneyJar", Spawn("HoneyJar"));
+            SetFieldValue(player, "GoldBrick", Spawn("GoldBrick"));
+
+            GameObject loseScreen = Spawn("LoseScreen");
+            loseScreen.SetActive(false);
+            SetFieldValue(player, "LooseScreen", loseScreen);
+
+            GameObject bossBar = Spawn("BossBar");
+            bossBar.SetActive(false);
+
+            GameObject bossPanel = Spawn("BossPanel");
+            bossPanel.SetActive(false);
+
+            GameObject victoryScreen = Spawn("VictoryScreen");
+            victoryScreen.SetActive(false);
+
+            GameObject chatCollider = Spawn("ChatCollider");
+            chatCollider.SetActive(true);
+
+            Component handler = playerObject.AddComponent(ResolveRuntimeType("Beavermania.Player.Combat.BossHandler"));
+            SetFieldValue(handler, "ChatCollider", chatCollider);
+            SetFieldValue(handler, "BossBar", bossBar);
+            SetFieldValue(handler, "BossPanel", bossPanel);
+            SetFieldValue(handler, "VictoryScreen", victoryScreen);
+
+            GameObject bossObject = Spawn("ScorpionBoss");
+            bossObject.AddComponent<Rigidbody>();
+            Component boss = bossObject.AddComponent(ResolveRuntimeType("Beavermania.NPC.ScorpionScript"));
+            SetFieldValue(boss, "victoryDelay", victoryDelay);
+            SetFieldValue(handler, "Boss", boss);
+
+            return new BossHarness(player, handler, boss, bossBar, victoryScreen, loseScreen);
+        }
+
+        void KillBoss(Component boss)
+        {
+            InvokeMethod(boss, "ReceiveDamage", GetFieldValue<int>(boss, "CurrentHealth"), CreateEnemyDamageType("Normal"), null);
+        }
+
+        object CreateEnemyDamageType(string enumName)
+        {
+            return Enum.Parse(ResolveRuntimeType("Beavermania.NPC.EnemyDamageType"), enumName);
+        }
+
+        Type ResolveRuntimeType(string fullName)
+        {
+            if (cachedRuntimeTypes.TryGetValue(fullName, out Type cachedType))
+                return cachedType;
+
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type resolvedType = assembly.GetType(fullName, throwOnError: false);
+                if (resolvedType != null)
+                {
+                    cachedRuntimeTypes[fullName] = resolvedType;
+                    return resolvedType;
+                }
+            }
+
+            throw new InvalidOperationException($"Failed to resolve runtime type '{fullName}'.");
+        }
+
+        GameObject Spawn(string name)
+        {
+            var gameObject = new GameObject(name);
+            spawnedObjects.Add(gameObject);
+            return gameObject;
+        }
+
+        static Delegate CreateTypedActionDelegate(Type eventHandlerType, Action callback)
+        {
+            Type parameterType = eventHandlerType.GetGenericArguments()[0];
+            MethodInfo factoryMethod = typeof(ScorpionBossVictoryFlowPlayModeTests)
+                .GetMethod(nameof(CreateTypedActionDelegateInternal), BindingFlags.Static | BindingFlags.NonPublic)
+                .MakeGenericMethod(parameterType);
+
+            return (Delegate)factoryMethod.Invoke(null, new object[] { callback });
+        }
+
+        static Delegate CreateTypedActionDelegateInternal<T>(Action callback)
+        {
+            Action<T> handler = _ => callback();
+            return handler;
+        }
+
+        static T GetFieldValue<T>(object target, string fieldName)
+        {
+            FieldInfo fieldInfo = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (fieldInfo == null)
+                throw new MissingFieldException(target.GetType().FullName, fieldName);
+
+            return (T)fieldInfo.GetValue(target);
+        }
+
+        static void SetFieldValue(object target, string fieldName, object value)
+        {
+            FieldInfo fieldInfo = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (fieldInfo == null)
+                throw new MissingFieldException(target.GetType().FullName, fieldName);
+
+            fieldInfo.SetValue(target, value);
+        }
+
+        static T GetPropertyValue<T>(object target, string propertyName)
+        {
+            PropertyInfo propertyInfo = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (propertyInfo == null)
+                throw new MissingMemberException(target.GetType().FullName, propertyName);
+
+            return (T)propertyInfo.GetValue(target);
+        }
+
+        static T GetStaticPropertyValue<T>(string fullName, string propertyName)
+        {
+            Type type = ResolveLoadedType(fullName);
+            PropertyInfo propertyInfo = type.GetProperty(propertyName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            if (propertyInfo == null)
+                throw new MissingMemberException(fullName, propertyName);
+
+            return (T)propertyInfo.GetValue(null);
+        }
+
+        static object InvokeMethod(object target, string methodName, params object[] parameters)
+        {
+            MethodInfo methodInfo = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (methodInfo == null)
+                throw new MissingMethodException(target.GetType().FullName, methodName);
+
+            return methodInfo.Invoke(target, parameters);
+        }
+
+        static object InvokeStaticMethod(string fullName, string methodName, params object[] parameters)
+        {
+            Type type = ResolveLoadedType(fullName);
+            MethodInfo methodInfo = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            if (methodInfo == null)
+                throw new MissingMethodException(fullName, methodName);
+
+            return methodInfo.Invoke(null, parameters);
+        }
+
+        static Type ResolveLoadedType(string fullName)
+        {
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type resolvedType = assembly.GetType(fullName, throwOnError: false);
+                if (resolvedType != null)
+                    return resolvedType;
+            }
+
+            throw new InvalidOperationException($"Failed to resolve loaded type '{fullName}'.");
+        }
+
+        readonly struct BossHarness
+        {
+            public BossHarness(
+                Component player,
+                Component handler,
+                Component boss,
+                GameObject bossBar,
+                GameObject victoryScreen,
+                GameObject loseScreen)
+            {
+                Player = player;
+                Handler = handler;
+                Boss = boss;
+                BossBar = bossBar;
+                VictoryScreen = victoryScreen;
+                LoseScreen = loseScreen;
+            }
+
+            public Component Player { get; }
+
+            public Component Handler { get; }
+
+            public Component Boss { get; }
+
+            public GameObject BossBar { get; }
+
+            public GameObject VictoryScreen { get; }
+
+            public GameObject LoseScreen { get; }
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs
+++ b/Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs
@@ -117,6 +117,11 @@ namespace Beavermania.Tests.PlayMode.Core.GameFlow
             SetFieldValue(player, "Otter", playerAnimator);
             SetFieldValue(player, "HoneyJar", Spawn("HoneyJar"));
             SetFieldValue(player, "GoldBrick", Spawn("GoldBrick"));
+            SetFieldValue(player, "HologramedBridge", Spawn("HologramedBridge"));
+            SetFieldValue(player, "AttackPoint", Spawn("AttackPoint").transform);
+            SetFieldValue(player, "PlacedGold", Spawn("PlacedGold"));
+            SetFieldValue(player, "HealLight", Spawn("HealLight").AddComponent<Light>());
+            SetFieldValue(player, "HurtLight", Spawn("HurtLight").AddComponent<Light>());
 
             GameObject loseScreen = Spawn("LoseScreen");
             loseScreen.SetActive(false);
@@ -144,6 +149,7 @@ namespace Beavermania.Tests.PlayMode.Core.GameFlow
             bossObject.AddComponent<Rigidbody>();
             Component boss = bossObject.AddComponent(ResolveRuntimeType("Beavermania.NPC.ScorpionScript"));
             SetFieldValue(boss, "victoryDelay", victoryDelay);
+            ((Behaviour)boss).enabled = false;
             SetFieldValue(handler, "Boss", boss);
 
             return new BossHarness(player, handler, boss, bossBar, victoryScreen, loseScreen);

--- a/Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs.meta
+++ b/Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs.meta
+++ b/Assets/Tests/PlayMode/Core/GameFlow/ScorpionBossVictoryFlowPlayModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfbefd60c5a85ce41b39d57141c81272
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Stabilize the scorpion boss victory sequence so the win flow resolves cleanly after defeat.
- Tighten game-time gating and boss state handling to avoid lingering control or time-scale issues.
- Add Play Mode coverage for the scorpion boss victory path.
- Update workflow and Unity safety guidance for the related handoff and verification steps.

## Testing
- Added Play Mode test coverage for the scorpion boss victory flow.
- Not run (not requested).